### PR TITLE
[Android] WEBRTC-428 Crash when stopping dialtone

### DIFF
--- a/sdk/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/sdk/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -51,7 +51,7 @@ class TelnyxClient(
     }
 
     //MediaPlayer for ringtone / ringbacktone
-    private var mediaPlayer = MediaPlayer()
+    private lateinit var mediaPlayer: MediaPlayer
     private var rawRingtone: Int? = null
     private var rawRingBackTone: Int? = null
 
@@ -268,31 +268,36 @@ class TelnyxClient(
 
 
     private fun playRingtone() {
-        rawRingtone?.let {
-            mediaPlayer = MediaPlayer.create(context, it)
-            mediaPlayer.setWakeMode(context, PowerManager.PARTIAL_WAKE_LOCK)
-            mediaPlayer.isLooping = true
-            mediaPlayer.start()
-        } ?: run {
-            Timber.d("No ringtone specified :: No ringtone will be played")
+        if (!mediaPlayer.isPlaying) {
+            rawRingtone?.let {
+                mediaPlayer = MediaPlayer.create(context, it)
+                mediaPlayer.setWakeMode(context, PowerManager.PARTIAL_WAKE_LOCK)
+                mediaPlayer.isLooping = true
+                if (!mediaPlayer.isPlaying) {
+                    mediaPlayer.start()
+                }
+            } ?: run {
+                Timber.d("No ringtone specified :: No ringtone will be played")
+            }
         }
     }
 
     private fun playRingBackTone() {
-        rawRingBackTone?.let {
-            mediaPlayer = MediaPlayer.create(context, it)
-            mediaPlayer.setWakeMode(context, PowerManager.PARTIAL_WAKE_LOCK)
-            mediaPlayer.isLooping = true
-            mediaPlayer.start()
-        } ?: run {
-            Timber.d("No ringtone specified :: No ringtone will be played")
-        }
+            rawRingBackTone?.let {
+                mediaPlayer = MediaPlayer.create(context, it)
+                mediaPlayer.setWakeMode(context, PowerManager.PARTIAL_WAKE_LOCK)
+                mediaPlayer.isLooping = true
+                if (!mediaPlayer.isPlaying) {
+                    mediaPlayer.start()
+                }
+            } ?: run {
+                Timber.d("No ringtone specified :: No ringtone will be played")
+            }
     }
 
     private fun stopMediaPlayer() {
-        if (mediaPlayer.isPlaying) {
+        if (this::mediaPlayer.isInitialized && mediaPlayer.isPlaying) {
             mediaPlayer.stop()
-            mediaPlayer.release()
             Timber.d("ringtone/ringback media player stopped and released")
         }
     }
@@ -343,6 +348,7 @@ class TelnyxClient(
         )
 
         resetCallOptions()
+        stopMediaPlayer()
     }
 
     override fun onConnectionEstablished() {

--- a/sdk/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/sdk/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -91,7 +91,7 @@ class TxSocket(
                         }
                     }
                 } catch (exception: Throwable) {
-                    Timber.d("Disconnected :: $exception")
+                    Timber.e( exception)
                 }
             }
         } catch (cause: Throwable) {


### PR DESCRIPTION
[WebRTC-428 - Crash when stopping dial tone.](https://telnyx.atlassian.net/browse/WEBRTC-428)

---
<!-- Describe your changed here -->
Change MediaPlayer to a leteinit which can then be checked to see if it is initialized before running .stop(). The app was crashing because it was trying to stop something that was released and no longer initialized. 

## :older_man: :baby: Behaviors
### Before changes
Crash when stopping dialtone after it had already been stopped previously 

### After changes
Dial tone stops and app works accordingly. 

## ✋ Manual testing
1. Call web dialer
2. answer and then put down on web dialer (sending a bye, which triggers media to stop)
3. there should be no crash
