### PR TITLE
[WEBRTC-548] Added dtmf support

### DIFF
--- a/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainViewModel.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainViewModel.kt
@@ -101,7 +101,8 @@ class MainViewModel @Inject constructor(
     }
 
     fun onHoldUnholdPressed(callId: UUID) {
-        currentCall?.onHoldUnholdPressed(callId)
+        currentCall?.dtmf(callId, "2")
+        //currentCall?.onHoldUnholdPressed(callId)
     }
 
     fun onMuteUnmutePressed() {

--- a/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainViewModel.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainViewModel.kt
@@ -101,8 +101,7 @@ class MainViewModel @Inject constructor(
     }
 
     fun onHoldUnholdPressed(callId: UUID) {
-        currentCall?.dtmf(callId, "2")
-        //currentCall?.onHoldUnholdPressed(callId)
+        currentCall?.onHoldUnholdPressed(callId)
     }
 
     fun onMuteUnmutePressed() {
@@ -111,6 +110,10 @@ class MainViewModel @Inject constructor(
 
     fun onLoudSpeakerPressed() {
         currentCall?.onLoudSpeakerPressed()
+    }
+
+    fun dtmfPressed(callId: UUID, tone: String){
+        currentCall?.dtmf(callId, tone)
     }
 
     fun disconnect() {

--- a/telnyx_rtc/build.gradle
+++ b/telnyx_rtc/build.gradle
@@ -102,6 +102,8 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'proguard-rules.txt'
+
+        buildConfigField "java.util.concurrent.atomic.AtomicBoolean", "IS_TESTING", "new java.util.concurrent.atomic.AtomicBoolean(false)"
     }
 
     buildTypes {
@@ -127,6 +129,9 @@ android {
     }
     testOptions {
         unitTests.returnDefaultValues = true
+    }
+    sourceSets {
+        test.manifest.srcFile "src/main/AndroidManifest.xml"
     }
 }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -138,26 +138,28 @@ class Call(
      * @param interToneGap Indicates the gap between tones in ms. Must be at least 50 ms but should be
      *                     as short as possible.
      */
-    fun sendDTMF(tones: String, duration: Int, interToneGap: Int){
+    fun sendDTMF(tones: String, duration: Int, interToneGap: Int): Boolean {
         peerConnection?.let {
             for (sender in it.getRTPSenders()!!) {
                 if (sender.track()?.kind().equals("audio")) {
                     it.audioSender = sender
                 }
             }
-            if (it.audioSender != null) {
+            return if (it.audioSender != null) {
                 val dtmfSender: DtmfSender? = it.audioSender?.dtmf()!!
                 if (dtmfSender!!.canInsertDtmf()) {
                     dtmfSender.insertDtmf(tones, duration, interToneGap)
-                 }
-                else {
+                } else {
                     Timber.d("[%s] :: sendDTMF :: AudioSender not capable of inserting DTMF", this@Call.javaClass.simpleName)
+                    false
                 }
             } else {
                 Timber.d("[%s] :: sendDTMF :: no AudioSender found", this@Call.javaClass.simpleName)
+                false
             }
         } ?: run {
             Timber.d("[%s] :: sendDTMF :: no PeerConnection established", this@Call.javaClass.simpleName)
+            return false
         }
     }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -127,7 +127,7 @@ class Call(
     }
 
     /**
-     * Sends a dial tone multi frequency tone down the current peer connection.
+     * Sends Dual-Tone Multi-Frequency tones down the current peer connection.
      * @param tones This parameter is treated as a series of characters. The characters 0
      *              through 9, A through D, #, and * generate the associated DTMF tones. The
      *              characters a to d are equivalent to A to D. The character ',' indicates a
@@ -233,7 +233,6 @@ class Call(
      * @see [AudioManager]
      */
     fun onLoudSpeakerPressed() {
-        sendDTMF("1")
         if (!loudSpeakerLiveData.value!!) {
             loudSpeakerLiveData.postValue(true)
             audioManager.isSpeakerphoneOn = true

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
@@ -7,12 +7,13 @@ package com.telnyx.webrtc.sdk
 import android.content.Context
 import com.telnyx.webrtc.sdk.Config.Companion.DEFAULT_STUN
 import com.telnyx.webrtc.sdk.Config.Companion.DEFAULT_TURN
-import com.telnyx.webrtc.sdk.Config.Companion.USERNAME
 import com.telnyx.webrtc.sdk.Config.Companion.PASSWORD
+import com.telnyx.webrtc.sdk.Config.Companion.USERNAME
 import com.telnyx.webrtc.sdk.socket.TxSocket
 import org.webrtc.*
 import timber.log.Timber
 import java.util.*
+
 
 /**
  * Peer class that represents a peer connection which is required to initiate a call.
@@ -26,6 +27,8 @@ internal class Peer(
     val client: TelnyxClient,
     observer: PeerConnection.Observer
 ) {
+
+    internal var audioSender: RtpSender? = null
 
     companion object {
         private const val AUDIO_LOCAL_TRACK_ID = "audio_local_track"
@@ -204,6 +207,10 @@ internal class Peer(
                 sdpObserver.onCreateSuccess(desc)
             }
         }, constraints)
+    }
+
+    fun getRTPSenders(): MutableList<RtpSender>? {
+            return peerConnection?.senders
     }
 
     /**

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
@@ -28,8 +28,6 @@ internal class Peer(
     observer: PeerConnection.Observer
 ) {
 
-    internal var audioSender: RtpSender? = null
-
     companion object {
         private const val AUDIO_LOCAL_TRACK_ID = "audio_local_track"
         private const val AUDIO_LOCAL_STREAM_ID = "audio_local_stream"
@@ -208,11 +206,7 @@ internal class Peer(
             }
         }, constraints)
     }
-
-    fun getRTPSenders(): MutableList<RtpSender>? {
-            return peerConnection?.senders
-    }
-
+    
     /**
      * Initiates an offer by setting a local SDP
      * @param sdpObserver, the provided [SdpObserver] that listens for SDP set events

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
@@ -206,7 +206,7 @@ internal class Peer(
             }
         }, constraints)
     }
-    
+
     /**
      * Initiates an offer by setting a local SDP
      * @param sdpObserver, the provided [SdpObserver] that listens for SDP set events

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -27,8 +27,6 @@ import org.webrtc.IceCandidate
 import timber.log.Timber
 import java.util.*
 import com.bugsnag.android.Bugsnag
-import com.bugsnag.android.Configuration
-import com.bugsnag.android.ThreadSendPolicy
 
 /**
  * The TelnyxClient class that can be used to control the SDK. Create / Answer calls, change audio device, etc.
@@ -141,14 +139,9 @@ class TelnyxClient(
     }
 
     init {
-
-        //Initialize BugSnag
-        val config = Configuration.load(context)
-        config.projectPackages = setOf("com.telnyx.webrtc.sdk.telnyx_rtc")
-        config.sendThreads = ThreadSendPolicy.ALWAYS
-        config.enabledErrorTypes.anrs = false
-        config.appType = "telnyx_rtc"
-        Bugsnag.start(context)
+        if(!BuildConfig.IS_TESTING.get()) {
+            Bugsnag.start(context)
+        }
 
         socket = TxSocket(
             host_address = Config.TELNYX_HOST_ADDRESS,

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SocketMethod.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SocketMethod.kt
@@ -16,6 +16,7 @@ package com.telnyx.webrtc.sdk.model
  * @property BYE a user has ended the call
  * @property MODIFY a modifier that allows the user to hold the call, etc
  * @property MEDIA received media from destination, such as a dialtone
+ * @property MEDIA send information to the destination such as DTMF
  * @property LOGIN the response to a login request.
  */
 enum class SocketMethod(var methodName: String) {
@@ -24,5 +25,6 @@ enum class SocketMethod(var methodName: String) {
     BYE("telnyx_rtc.bye"),
     MODIFY("telnyx_rtc.modify"),
     MEDIA("telnyx_rtc.media"),
+    INFO("telnyx_rtc.info"),
     LOGIN("login")
 }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -11,6 +11,7 @@ import com.google.gson.JsonObject
 import com.telnyx.webrtc.sdk.TelnyxClient
 import com.telnyx.webrtc.sdk.model.SocketError.*
 import com.telnyx.webrtc.sdk.model.SocketMethod.*
+import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
 import io.ktor.client.*
 import io.ktor.client.engine.android.*
 import io.ktor.client.features.json.*
@@ -163,25 +164,32 @@ class TxSocket(
                     }
                 } catch (exception: Throwable) {
                     Timber.d(exception)
-                    Bugsnag.notify(exception) { event ->
-                        // Add extra information
-                        event.addMetadata("availableMemory", "", Runtime.getRuntime().freeMemory())
-                        //This is not an issue, the coroutine has just been cancelled
-                        event.severity = Severity.INFO
-                        false
+                    if(!BuildConfig.IS_TESTING.get()) {
+                        Bugsnag.notify(exception) { event ->
+                            // Add extra information
+                            event.addMetadata(
+                                "availableMemory",
+                                "",
+                                Runtime.getRuntime().freeMemory()
+                            )
+                            //This is not an issue, the coroutine has just been cancelled
+                            event.severity = Severity.INFO
+                            false
+                        }
                     }
                 }
             }
         } catch (cause: Throwable) {
             Timber.d(cause)
-            Bugsnag.notify(cause) { event ->
-                // Add extra information
-                event.addMetadata("availableMemory", "", Runtime.getRuntime().freeMemory())
-                //This is not an issue, the coroutine has just been cancelled
-                event.severity = Severity.INFO
-                false
+            if(!BuildConfig.IS_TESTING.get()) {
+                Bugsnag.notify(cause) { event ->
+                    // Add extra information
+                    event.addMetadata("availableMemory", "", Runtime.getRuntime().freeMemory())
+                    //This is not an issue, the coroutine has just been cancelled
+                    event.severity = Severity.INFO
+                    false
+                }
             }
-
         }
     }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/ConnectivityHelper.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/ConnectivityHelper.kt
@@ -10,6 +10,7 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import com.bugsnag.android.Bugsnag
+import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
 import timber.log.Timber
 
 /**
@@ -57,7 +58,9 @@ object ConnectivityHelper {
             manager.registerNetworkCallback(request, callback)
         } catch (e: Exception) {
             Timber.e(e,"registerNetworkStatusCallback [%s]", this@ConnectivityHelper.javaClass.simpleName)
-            Bugsnag.notify(e)
+            if(!BuildConfig.IS_TESTING.get()) {
+                Bugsnag.notify(e)
+            }
         }
     }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/ParamRequest.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/ParamRequest.kt
@@ -18,10 +18,14 @@ data class CallParams(val sessionId: String, val sdp: String,
                       val dialogParams: CallDialogParams
                       ) : ParamRequest()
 
-data class ByeParams(val sessid: String, val causeCode: Int,
+data class ByeParams(val sessionId: String, val causeCode: Int,
                      val cause: String, val dialogParams: ByeDialogParams
                      ) : ParamRequest()
 
-data class ModifyParams(val sessid: String, val action: String,
+data class ModifyParams(val sessionId: String, val action: String,
                         val dialogParams: CallDialogParams
                         ) : ParamRequest()
+
+data class InfoParams(val sessionId: String, val dtmf: String,
+                      val dialogParams: CallDialogParams) : ParamRequest()
+

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito
+import org.mockito.Spy
 import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -127,20 +128,6 @@ class CallTest: BaseTest() {
 
         client.removeFromCalls(newCall.callId)
         assert(!client.calls.containsValue(newCall))
-    }
-
-    @Test
-    fun `test send valid tones via DTMF`() {
-        socket = Mockito.spy(
-            TxSocket(
-                host_address = "rtc.telnyx.com",
-                port = 14938,
-            )
-        )
-
-        val newCall = Mockito.spy(Call(mockContext, client, socket, "123", audioManager))
-        newCall.callId = UUID.randomUUID()
-        assertEquals(newCall.sendDTMF("123,123,*", 1000, 500), true)
     }
 }
 

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
@@ -129,6 +129,20 @@ class CallTest: BaseTest() {
         client.removeFromCalls(newCall.callId)
         assert(!client.calls.containsValue(newCall))
     }
+
+    @Test
+    fun `test send DTMF without a peerConnection established`() {
+        socket = Mockito.spy(
+            TxSocket(
+                host_address = "rtc.telnyx.com",
+                port = 14938,
+            )
+        )
+
+        val newCall = Mockito.spy(Call(mockContext, client, socket, "123", audioManager))
+        newCall.callId = UUID.randomUUID()
+        assertEquals(newCall.sendDTMF("123,123,*", 1000, 500), false)
+    }
 }
 
 //Extension function for getOrAwaitValue for unit tests

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
@@ -4,17 +4,22 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.media.AudioManager
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Client
 import com.bugsnag.android.Configuration
+import com.google.gson.JsonObject
 import com.telnyx.webrtc.sdk.socket.TxSocket
 import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
 import com.telnyx.webrtc.sdk.testhelpers.BaseTest
 import com.telnyx.webrtc.sdk.testhelpers.extensions.CoroutinesTestExtension
 import com.telnyx.webrtc.sdk.testhelpers.extensions.InstantExecutorExtension
+import com.telnyx.webrtc.sdk.verto.send.SendingMessageBody
 import io.ktor.client.features.websocket.*
 import io.mockk.MockKAnnotations
 import io.mockk.Runs
@@ -25,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 import org.mockito.Spy
 import java.util.*
@@ -39,10 +45,12 @@ class CallTest: BaseTest() {
 
     @MockK
     private lateinit var mockContext: Context
-    @MockK
+    @Spy
     lateinit var client: TelnyxClient
-    @MockK
+    @Spy
     lateinit var socket: TxSocket
+    @Spy
+    lateinit var call: Call
     @MockK
     lateinit var audioManager: AudioManager
 
@@ -111,7 +119,6 @@ class CallTest: BaseTest() {
         assertEquals(newCall.getIsOnLoudSpeakerStatus().getOrAwaitValue(), true)
     }
 
-
     @Test
     fun `test new call is added to calls map - then assert that remove`() {
         socket = Mockito.spy(
@@ -130,7 +137,22 @@ class CallTest: BaseTest() {
         assert(!client.calls.containsValue(newCall))
     }
 
-   
+    @Test
+    fun `test dtmf pressed during call with value 2`() {
+        client = Mockito.spy(TelnyxClient(mockContext))
+        client.socket = Mockito.spy(TxSocket(
+            host_address = "rtc.telnyx.com",
+            port = 14938,
+        ))
+
+        call = Mockito.spy(
+            Call(mockContext, client, client.socket, "123", audioManager)
+        )
+        call.dtmf(UUID.randomUUID(), "2")
+        Thread.sleep(1000)
+        Mockito.verify(client.socket, Mockito.times(1)).send(ArgumentMatchers.any(SendingMessageBody::class.java))
+    }
+
 }
 
 //Extension function for getOrAwaitValue for unit tests

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
@@ -118,6 +118,21 @@ class CallTest: BaseTest() {
         client.removeFromCalls(newCall.callId)
         assert(!client.calls.containsValue(newCall))
     }
+
+    @Test
+    fun `test send tone via DTMF`() {
+        socket = Mockito.spy(
+            TxSocket(
+                host_address = "rtc.telnyx.com",
+                port = 14938,
+            )
+        )
+
+        client = Mockito.spy(TelnyxClient(mockContext))
+        val newCall = Mockito.spy(Call(mockContext, client, socket, "123", audioManager))
+        newCall.callId = UUID.randomUUID()
+        newCall.sendDTMF("123,123,*", 1000, 500)
+    }
 }
 
 //Extension function for getOrAwaitValue for unit tests

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
@@ -1,11 +1,17 @@
 package com.telnyx.webrtc.sdk
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
 import android.media.AudioManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Client
+import com.bugsnag.android.Configuration
 import com.telnyx.webrtc.sdk.socket.TxSocket
+import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
 import com.telnyx.webrtc.sdk.testhelpers.BaseTest
 import com.telnyx.webrtc.sdk.testhelpers.extensions.CoroutinesTestExtension
 import com.telnyx.webrtc.sdk.testhelpers.extensions.InstantExecutorExtension
@@ -26,11 +32,12 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import kotlin.test.assertEquals
 
+
 @ExtendWith(InstantExecutorExtension::class, CoroutinesTestExtension::class)
 class CallTest: BaseTest() {
 
-
-    @MockK private lateinit var mockContext: Context
+    @MockK
+    private lateinit var mockContext: Context
     @MockK
     lateinit var client: TelnyxClient
     @MockK
@@ -41,20 +48,24 @@ class CallTest: BaseTest() {
     @BeforeEach
     fun setup() {
         MockKAnnotations.init(this, true, true, true)
-
         socket = TxSocket(
             host_address = "rtc.telnyx.com",
             port = 14938,
         )
 
+        BuildConfig.IS_TESTING.set(true);
+
         every { mockContext.getSystemService(AppCompatActivity.AUDIO_SERVICE) } returns audioManager
         every { audioManager.isMicrophoneMute = true } just Runs
         every { audioManager.isSpeakerphoneOn = true } just Runs
+        every { audioManager.isSpeakerphoneOn} returns false
+        every { audioManager.isMicrophoneMute} returns false
 
-        every { audioManager.isSpeakerphoneOn}  returns false
-        every { audioManager.isMicrophoneMute}  returns false
-
-        client = TelnyxClient(mockContext)
+        client = Mockito.spy(
+            TelnyxClient(
+                mockContext
+            )
+        )
     }
 
     @Test
@@ -109,7 +120,6 @@ class CallTest: BaseTest() {
             )
         )
 
-        client = Mockito.spy(TelnyxClient(mockContext))
         val newCall = Mockito.spy(Call(mockContext, client, socket, "123", audioManager))
         newCall.callId = UUID.randomUUID()
         client.addToCalls(newCall)
@@ -120,7 +130,7 @@ class CallTest: BaseTest() {
     }
 
     @Test
-    fun `test send tone via DTMF`() {
+    fun `test send valid tones via DTMF`() {
         socket = Mockito.spy(
             TxSocket(
                 host_address = "rtc.telnyx.com",
@@ -128,10 +138,9 @@ class CallTest: BaseTest() {
             )
         )
 
-        client = Mockito.spy(TelnyxClient(mockContext))
         val newCall = Mockito.spy(Call(mockContext, client, socket, "123", audioManager))
         newCall.callId = UUID.randomUUID()
-        newCall.sendDTMF("123,123,*", 1000, 500)
+        assertEquals(newCall.sendDTMF("123,123,*", 1000, 500), true)
     }
 }
 

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
@@ -130,19 +130,7 @@ class CallTest: BaseTest() {
         assert(!client.calls.containsValue(newCall))
     }
 
-    @Test
-    fun `test send DTMF without a peerConnection established`() {
-        socket = Mockito.spy(
-            TxSocket(
-                host_address = "rtc.telnyx.com",
-                port = 14938,
-            )
-        )
-
-        val newCall = Mockito.spy(Call(mockContext, client, socket, "123", audioManager))
-        newCall.callId = UUID.randomUUID()
-        assertEquals(newCall.sendDTMF("123,123,*", 1000, 500), false)
-    }
+   
 }
 
 //Extension function for getOrAwaitValue for unit tests

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/PeerTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/PeerTest.kt
@@ -1,22 +1,13 @@
 package com.telnyx.webrtc.sdk
 
-import android.content.Context
-import android.media.AudioManager
-import androidx.appcompat.app.AppCompatActivity
-import com.telnyx.webrtc.sdk.socket.TxSocket
+
+import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
 import com.telnyx.webrtc.sdk.testhelpers.BaseTest
-import com.telnyx.webrtc.sdk.testhelpers.extensions.CoroutinesTestExtension
-import com.telnyx.webrtc.sdk.testhelpers.extensions.InstantExecutorExtension
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import org.junit.Before
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
-import org.mockito.Spy
-import org.robolectric.RuntimeEnvironment.application
 import org.webrtc.PeerConnection
 import org.webrtc.PeerConnectionFactory
 
@@ -28,6 +19,8 @@ class PeerTest : BaseTest() {
 
     @BeforeEach
     fun setup() {
+        BuildConfig.IS_TESTING.set(true);
+
         MockitoAnnotations.openMocks(this)
         mockkStatic(PeerConnectionFactory::class)
         mockkStatic(PeerConnection::class)

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -12,6 +12,7 @@ import androidx.test.rule.GrantPermissionRule
 import com.google.gson.JsonObject
 import com.telnyx.webrtc.sdk.model.LogLevel
 import com.telnyx.webrtc.sdk.socket.TxSocket
+import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
 import com.telnyx.webrtc.sdk.testhelpers.BaseTest
 import com.telnyx.webrtc.sdk.testhelpers.extensions.CoroutinesTestExtension
 import com.telnyx.webrtc.sdk.testhelpers.extensions.InstantExecutorExtension
@@ -70,6 +71,8 @@ class TelnyxClientTest : BaseTest() {
     fun setUp() {
         MockKAnnotations.init(this, true, true, true)
         networkCallbackSetup()
+
+        BuildConfig.IS_TESTING.set(true);
 
         every { mockContext.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
         every { mockContext.getSystemService(AppCompatActivity.AUDIO_SERVICE) } returns audioManager

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/socket/TxSocketTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/socket/TxSocketTest.kt
@@ -11,6 +11,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.test.rule.GrantPermissionRule
 import com.google.gson.JsonObject
 import com.telnyx.webrtc.sdk.TelnyxClient
+import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
 import com.telnyx.webrtc.sdk.testhelpers.BaseTest
 import com.telnyx.webrtc.sdk.utilities.ConnectivityHelper
 import io.kotest.matchers.shouldBe
@@ -85,6 +86,8 @@ class TxSocketTest : BaseTest() {
     fun setup() {
         MockKAnnotations.init(this, true)
         Mockito.`when`(application.applicationContext).thenReturn(mockContext)
+
+        BuildConfig.IS_TESTING.set(true);
 
         every {socket.callOngoing()} just Runs
         every {socket.callNotOngoing()} just Runs

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/utilities/ConnectivityHelperTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/utilities/ConnectivityHelperTest.kt
@@ -3,6 +3,7 @@ package com.telnyx.webrtc.sdk.utilities
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkRequest
+import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
 import com.telnyx.webrtc.sdk.testhelpers.BaseTest
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
@@ -18,6 +19,8 @@ class ConnectivityHelperTest : BaseTest() {
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
+
+        BuildConfig.IS_TESTING.set(true);
     }
 
     /**


### PR DESCRIPTION
[WebRTC-548- Added dtmf support.](https://telnyx.atlassian.net/browse/WEBRTC-548)
---

<!-- Describe your changed here -->
Added a dtmf() method that will send DTMF tone to an ongoing call. 

Also created IS_TESTING build configuration which we use during tests. This temporarily disables BugSnag so that we don't get false bugs reported when we are intentionally testing failures. 

## :older_man: :baby: Behaviors
### Before changes
No way of sending DTMF

### After changes
DTMF can now be sent via the dtmf() method

## ✋ Manual testing
1. Create an ongoing call to +13129457420
2. Use the dtmfPressed() method durinc call with an alphanumeric character ("2") - I temporarily fired this method when onHold is pressed to test. 
3. See response in logs. 
