### PR TITLE
[WEBRTC-579] Add ProGuard workarround to README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,36 @@ When we receive a call we will receive an InviteResponse data class that contain
  telnyxClient.call.acceptCall(callId, destinationNumber)
 ```
 
+ ## ProGuard changes
+ NOTE:
+       In case that you need to modify proguard default settings in order to obfuscate your code:
+    
+#### **`app/build.gradle`**
+```gradle
+buildTypes {
+        release {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            debuggable true
+            jniDebuggable true
+        }
+        debug {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            debuggable true
+            jniDebuggable true
+        }
+    }
+```
+please have also in mind to add the following rules to proguard-rules.pro file in your app
+
+#### **`app/proguard-rules.pro`**
+```gradle
+-keep class org.webrtc.** { *; }
+-keep class com.telnyx.webrtc.sdk.** { *; }
+```
 
 -----
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ When we receive a call we will receive an InviteResponse data class that contain
 
  ## ProGuard changes
  NOTE:
-       In case that you need to modify proguard default settings in order to obfuscate your code:
+       In the case that you need to modify your application's proguard settings in order to obfuscate your code, such as we have done below:
     
 #### **`app/build.gradle`**
 ```gradle
@@ -157,7 +157,6 @@ buildTypes {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            debuggable true
             jniDebuggable true
         }
         debug {
@@ -169,7 +168,7 @@ buildTypes {
         }
     }
 ```
-please have also in mind to add the following rules to proguard-rules.pro file in your app
+please keep in mind that you will need to add the following rules to the proguard-rules.pro file in your app in order for the SDK to continue functioning
 
 #### **`app/proguard-rules.pro`**
 ```gradle


### PR DESCRIPTION
Signed-off-by: Lucas Pais <lucasp@7g804d3.office.telnyx.com>

[WEBRTC-579 - [Android] App does not work when enabling obfuscation flags on build.gradle file.](https://telnyx.atlassian.net/browse/WEBRTC-579)

---
We found an issue with connecting to websocket and placing call, whenever proguard rules are modified by adding

#### **`app/build.gradle`**
```gradle
buildTypes {
        release {
            minifyEnabled true
            shrinkResources true
            ...
        }
        debug {
            minifyEnabled true
            shrinkResources true
            ...
        }
    }
```
causing the following error:

```logs
2021-06-08 10:48:12.102 13951-14084/com.telnyx.webrtc.sdk D/VERTO: Connection established
2021-06-08 10:48:12.102 13951-14084/com.telnyx.webrtc.sdk D/VERTO: [a] Sending [{}]
2021-06-08 10:48:12.404 13951-14084/com.telnyx.webrtc.sdk D/VERTO: [a] Receiving [{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid message"},"id":null}]
2021-06-08 10:48:12.405 13951-13951/com.telnyx.webrtc.sdk D/VERTO: [a] Received Error From Telnyx ["Invalid message"]
```
When this happens, is due to ProGuard obfuscating code we need coming from the org.webrtc.** and com.telnyx.webrtc.sdk.** packages, and we have to add exclusions to those packages on the proguard-rules.pro file

#### **`app/proguard-rules.pro`**
```gradle
-keep class org.webrtc.** { *; }
-keep class com.telnyx.webrtc.sdk.** { *; }
```

## :older_man: :baby: Behaviors
### Before changes
We didn't have instructions in case ProGuard rules have to be modified

### After changes
We have instructions to modify proguard-rules.pro file in order to allow obfuscation, excluding important classes

## ✋ Manual testing
1. Open repo
2. Read README.md file
