### PR TITLE
[WEBRTC-619] Add telnyx session ID and leg ID to Call object

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -45,6 +45,9 @@ class Call(
 
     lateinit var callId: UUID
 
+    private var telnyxSessionId: UUID? = null
+    private var telnyxLegId: UUID? = null
+
     private val callStateLiveData = MutableLiveData(CallState.NEW)
 
     // Ongoing call options
@@ -291,6 +294,24 @@ class Call(
     fun getIsOnLoudSpeakerStatus(): LiveData<Boolean> = loudSpeakerLiveData
 
     /**
+     * Returns the TelnyxSessionId set as a response
+     * from an invite or ringing socket call
+     * @return [UUID]
+     */
+    fun getTelnyxSessionId(): UUID? {
+        return telnyxSessionId
+    }
+
+    /**
+     * Returns the TelnyxSessionId set as a response
+     * from an invite or ringing socket call
+     * @return [UUID]
+     */
+    fun getTelnyxLegId(): UUID? {
+        return telnyxLegId
+    }
+
+    /**
      * Resets all call options, primarily hold, mute and loudspeaker state, as well as the earlySDP boolean value.
      * @return [LiveData]
      */
@@ -411,6 +432,8 @@ class Call(
         val remoteSdp = params.get("sdp").asString
         val callerName = params.get("caller_id_name").asString
         val callerNumber = params.get("caller_id_number").asString
+        telnyxSessionId = UUID.fromString(params.get("telnyx_session_id").asString)
+        telnyxLegId = UUID.fromString(params.get("telnyx_leg_id").asString)
 
         //Set global callID
         callId = offerCallId
@@ -446,6 +469,12 @@ class Call(
         )
         client.playRingtone()
         client.addToCalls(this)
+    }
+
+    override fun onRingingReceived(jsonObject: JsonObject) {
+        val params = jsonObject.getAsJsonObject("params")
+        telnyxSessionId = UUID.fromString(params.get("telnyx_session_id").asString)
+        telnyxLegId = UUID.fromString(params.get("telnyx_leg_id").asString)
     }
 
     override fun onIceCandidateReceived(iceCandidate: IceCandidate) {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -88,7 +88,6 @@ class TelnyxClient(
 
     private var socketReconnection: TxSocket? = null
 
-
     internal var isNetworkCallbackRegistered = false
     private val networkCallback = object : ConnectivityHelper.NetworkCallback() {
         override fun onNetworkAvailable() {
@@ -147,6 +146,7 @@ class TelnyxClient(
             host_address = Config.TELNYX_HOST_ADDRESS,
             port = Config.TELNYX_PORT
         )
+
         registerNetworkCallback()
     }
 
@@ -495,6 +495,11 @@ class TelnyxClient(
     override fun onOfferReceived(jsonObject: JsonObject) {
         Timber.d("[%s] :: onOfferReceived [%s]", this@TelnyxClient.javaClass.simpleName, jsonObject)
         call?.onOfferReceived(jsonObject)
+    }
+
+    override fun onRingingReceived(jsonObject: JsonObject) {
+        Timber.d("[%s] :: onRingingReceived [%s]", this@TelnyxClient.javaClass.simpleName, jsonObject)
+        call?.onRingingReceived(jsonObject)
     }
 
     override fun onIceCandidateReceived(iceCandidate: IceCandidate) {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SocketMethod.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SocketMethod.kt
@@ -26,5 +26,6 @@ enum class SocketMethod(var methodName: String) {
     MODIFY("telnyx_rtc.modify"),
     MEDIA("telnyx_rtc.media"),
     INFO("telnyx_rtc.info"),
+    RINGING("telnyx_rtc.ringing"),
     LOGIN("login")
 }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -137,6 +137,9 @@ class TxSocket(
                                                 INVITE.methodName -> {
                                                     listener.onOfferReceived(jsonObject)
                                                 }
+                                                RINGING.methodName -> {
+                                                    listener.onRingingReceived(jsonObject)
+                                                }
                                             }
                                         }
                                         jsonObject.has("error") -> {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
@@ -61,6 +61,13 @@ interface TxSocketListener {
     fun onOfferReceived(jsonObject: JsonObject)
 
     /**
+     * Fires once we receive a ringing socket response, containing Telnyx information
+     * @param jsonObject, the socket response in a jsonObject format
+     * @see [TxSocket]
+     */
+    fun onRingingReceived(jsonObject: JsonObject)
+
+    /**
      * Fires when a usable IceCandidate has been received
      * @param iceCandidate, the [IceCandidate] that was received
      * @see [IceCandidate]

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -201,7 +201,6 @@ class TelnyxClientTest : BaseTest() {
         Thread.sleep(3000)
         Mockito.verify(client.socket, Mockito.times(1)).send(any(SendingMessageBody::class.java))
         Mockito.verify(client, Mockito.times(0)).onLoginSuccessful(jsonMock)
-
     }
 
     @Test

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/socket/TxSocketTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/socket/TxSocketTest.kt
@@ -87,7 +87,7 @@ class TxSocketTest : BaseTest() {
         MockKAnnotations.init(this, true)
         Mockito.`when`(application.applicationContext).thenReturn(mockContext)
 
-        BuildConfig.IS_TESTING.set(true);
+        BuildConfig.IS_TESTING.set(true)
 
         every {socket.callOngoing()} just Runs
         every {socket.callNotOngoing()} just Runs
@@ -182,6 +182,7 @@ class TxSocketTest : BaseTest() {
 
     @Test
     fun `set call to ongoing`() {
+        BuildConfig.IS_TESTING.set(true)
         socket = Mockito.spy(TxSocket(
             host_address = "rtc.telnyx.com",
             port = 14938,


### PR DESCRIPTION
[WebRTC-619 - Add telnyx session ID and leg ID to Call object.](https://telnyx.atlassian.net/browse/WEBRTC-619)
---
<!-- Describe your changed here -->
The private variables telnyxSessionId and telnyxLegId are now set within the call object whenever a ringing or offer received listener method is fired. 

These are then accessible via getter methods. 

## :older_man: :baby: Behaviors
### Before changes
No access to telnyxSessionId or telnyxLegId. Neither variables were available or set.

### After changes
telnyxSessionId and telnyxLegId are set within the call object via listener methods, these are then accessible via getter methods. There is a possibility of these returning null if they are not yet set. 

## ✋ Manual testing
1. Create an invite or receive a call and monitor the telnyxSessionId or telnyxLegId variables within Call.kt. These are now set appropriately. 
