### PR TITLE
[WEBRTC-623] Add connection check + Log, before sending message on socket

### DIFF
--- a/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
@@ -268,8 +268,6 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun connectButtonPressed() {
-        checkPermissions()
-
         //path to ringtone and ringBackTone
         val ringtone = R.raw.incoming_call
         val ringBackTone = R.raw.ringback_tone

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -44,6 +44,7 @@ class TxSocket(
 
     private var job: Job = SupervisorJob()
     private val gson = Gson()
+    private var isConnected = false
 
     override var coroutineContext = Dispatchers.IO + job
 
@@ -80,9 +81,10 @@ class TxSocket(
                     Timber.tag("VERTO").d("The outgoing channel was closed $message")
                     destroy()
                 }
-                listener.onConnectionEstablished()
                 Timber.tag("VERTO").d("Connection established")
                 val sendData = sendChannel.openSubscription()
+                listener.onConnectionEstablished()
+                isConnected = true
                 try {
                     while (true) {
                         sendData.poll()?.let {
@@ -215,13 +217,18 @@ class TxSocket(
      * @param dataObject, the data to be send to our subscriber
      */
     internal fun send(dataObject: Any?) = runBlocking {
-        sendChannel.send(gson.toJson(dataObject))
+        if(isConnected) {
+            sendChannel.send(gson.toJson(dataObject))
+        } else {
+            Timber.tag("VERTO").d("Message cannot be sent. There is no established WebSocket connection")
+        }
     }
 
     /**
      * Closes our websocket connection and cancels our coroutine job
      */
     internal fun destroy() {
+        isConnected = false
         client.close()
         job.cancel()
     }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -44,7 +44,7 @@ class TxSocket(
 
     private var job: Job = SupervisorJob()
     private val gson = Gson()
-    private var isConnected = false
+    internal var isConnected = false
 
     override var coroutineContext = Dispatchers.IO + job
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/ConnectivityHelper.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/ConnectivityHelper.kt
@@ -33,7 +33,9 @@ object ConnectivityHelper {
             manager.unregisterNetworkCallback(callback)
         } catch (e: Exception) {
             Timber.e(e,"unregisterNetworkCallback [%s]", this@ConnectivityHelper.javaClass.simpleName)
-            Bugsnag.notify(e)
+            if(!BuildConfig.IS_TESTING.get()) {
+                Bugsnag.notify(e)
+            }
         }
     }
 

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -10,6 +10,7 @@ import android.net.NetworkRequest
 import androidx.appcompat.app.AppCompatActivity
 import androidx.test.rule.GrantPermissionRule
 import com.google.gson.JsonObject
+import com.telnyx.webrtc.sdk.MockitoHelper.anyObject
 import com.telnyx.webrtc.sdk.model.LogLevel
 import com.telnyx.webrtc.sdk.socket.TxSocket
 import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
@@ -268,6 +269,32 @@ class TelnyxClientTest : BaseTest() {
         client.getRawRingbackTone()
     }
 
+    @Test
+    fun `try and send message when isConnected is false - do not connect before doing login`() {
+        client = Mockito.spy(TelnyxClient(mockContext))
+        client.socket = Mockito.spy(TxSocket(
+            host_address = "rtc.telnyx.com",
+            port = 14938,
+        ))
+
+        val config = CredentialConfig(
+            "asdfasass",
+            "asdlkfhjalsd",
+            "test",
+            "000000000",
+            null,
+            null,
+            null,
+            LogLevel.ALL
+        )
+
+        client.credentialLogin(config)
+
+        val jsonMock = Mockito.mock(JsonObject::class.java)
+
+        Thread.sleep(2000)
+        Mockito.verify(client, Mockito.times(0)).onLoginSuccessful(jsonMock)
+    }
 }
 
 object MockitoHelper {
@@ -278,5 +305,7 @@ object MockitoHelper {
     @Suppress("UNCHECKED_CAST")
     fun <T> uninitialized(): T =  null as T
 }
+
+
 
 

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/socket/TxSocketTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/socket/TxSocketTest.kt
@@ -27,11 +27,10 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito
 import org.mockito.Mockito.*
 import org.mockito.Spy
 import org.robolectric.RuntimeEnvironment.application
-
+import kotlin.test.assertEquals
 
 class TxSocketTest : BaseTest() {
     @Test
@@ -190,9 +189,6 @@ class TxSocketTest : BaseTest() {
             host_address = "rtc.telnyx.com",
             port = 14938,
         ))
-
-        client = spy(TelnyxClient(mockContext))
-
         socket.callOngoing()
         socket.ongoingCall shouldBe true
     }
@@ -204,10 +200,34 @@ class TxSocketTest : BaseTest() {
             host_address = "rtc.telnyx.com",
             port = 14938,
         ))
-
-        client = spy(TelnyxClient(mockContext))
-
         socket.callNotOngoing()
         socket.ongoingCall shouldBe false
+    }
+
+    @Test
+    fun `ensure connect changes isConnected appropriately`() {
+        BuildConfig.IS_TESTING.set(true)
+        socket = spy(TxSocket(
+            host_address = "rtc.telnyx.com",
+            port = 14938,
+        ))
+        client = spy(TelnyxClient(mockContext))
+        socket.connect(client)
+        Thread.sleep(2000)
+        assertEquals(socket.isConnected, true)
+    }
+
+    @Test
+    fun `make sure isConnected is false before connect is called`() {
+        BuildConfig.IS_TESTING.set(true)
+        client = spy(TelnyxClient(mockContext))
+        client.socket = spy(
+            TxSocket(
+                host_address = "rtc.telnyx.com",
+                port = 14938,
+            )
+        )
+        assertEquals(client.socket.isConnected, false)
+
     }
 }

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/socket/TxSocketTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/socket/TxSocketTest.kt
@@ -85,7 +85,7 @@ class TxSocketTest : BaseTest() {
     @Before
     fun setup() {
         MockKAnnotations.init(this, true)
-        Mockito.`when`(application.applicationContext).thenReturn(mockContext)
+        `when`(application.applicationContext).thenReturn(mockContext)
 
         BuildConfig.IS_TESTING.set(true)
 
@@ -135,60 +135,63 @@ class TxSocketTest : BaseTest() {
 
     @Test
     fun `connect with valid host and port`() {
-        socket = Mockito.spy(TxSocket(
+        BuildConfig.IS_TESTING.set(true)
+        socket = spy(TxSocket(
             host_address = "rtc.telnyx.com",
             port = 14938,
         ))
 
-        client = Mockito.spy(TelnyxClient(mockContext))
+        client = spy(TelnyxClient(mockContext))
 
         socket.connect(client)
 
         //Sleep to give time to connect
         Thread.sleep(3000)
-        Mockito.verify(client, times(1)).onConnectionEstablished()
+        verify(client, times(1)).onConnectionEstablished()
     }
 
     @Test
     fun `disconnect from socket`() {
-        client = Mockito.spy(TelnyxClient(mockContext))
+        BuildConfig.IS_TESTING.set(true)
+        client = spy(TelnyxClient(mockContext))
 
-        client.socket = Mockito.spy(TxSocket(
+        client.socket = spy(TxSocket(
             host_address = "rtc.telnyx.com",
             port = 14938,
         ))
 
         client.disconnect()
         Thread.sleep(3000)
-        Mockito.verify(client.socket, atLeastOnce()).destroy()
+        verify(client.socket, atLeastOnce()).destroy()
     }
 
 
     @Test
     fun `connect with empty host or port`() {
-        socket = Mockito.spy(TxSocket(
+        BuildConfig.IS_TESTING.set(true)
+        socket = spy(TxSocket(
             host_address = "",
             port = 0,
         ))
 
-        client = Mockito.spy(TelnyxClient(mockContext))
+        client = spy(TelnyxClient(mockContext))
         socket.connect(client)
 
         //Sleep to give time to connect
         Thread.sleep(3000)
-        Mockito.verify(client, times(0)).onConnectionEstablished()
+        verify(client, times(0)).onConnectionEstablished()
 
     }
 
     @Test
     fun `set call to ongoing`() {
         BuildConfig.IS_TESTING.set(true)
-        socket = Mockito.spy(TxSocket(
+        socket = spy(TxSocket(
             host_address = "rtc.telnyx.com",
             port = 14938,
         ))
 
-        client = Mockito.spy(TelnyxClient(mockContext))
+        client = spy(TelnyxClient(mockContext))
 
         socket.callOngoing()
         socket.ongoingCall shouldBe true
@@ -196,12 +199,13 @@ class TxSocketTest : BaseTest() {
 
     @Test
     fun `set call to not ongoing`() {
-        socket = Mockito.spy(TxSocket(
+        BuildConfig.IS_TESTING.set(true)
+        socket = spy(TxSocket(
             host_address = "rtc.telnyx.com",
             port = 14938,
         ))
 
-        client = Mockito.spy(TelnyxClient(mockContext))
+        client = spy(TelnyxClient(mockContext))
 
         socket.callNotOngoing()
         socket.ongoingCall shouldBe false


### PR DESCRIPTION
[WebRTC-623 - Improve logging.](https://telnyx.atlassian.net/browse/WEBRTC-623)

---
<!-- Describe your changed here -->
This PR adds a boolean value isConnected, which switches to true once a connection is established in the TxSocket class. If this is set to false, no message will be sent on the socket and a log is provided

This PR also adds required changes to TxSocket tests that should have been done earlier in relation to BugSnag. 

## :older_man: :baby: Behaviors
### Before changes
No check, users had to rely on the onConnectionEstablished callback. 

### After changes
Now, in addition to the onConnectionEstablished callback, there is also a log that fires whenever somebody attempts to send a message on TxSocket that has no connection. 

## ✋ Manual testing
1. Launch the application and attempt an action before a connection is established
2. Monitor logs for a message
3. Launch the application, connect, and then attempt an action. It will succeed. 
