### PR TITLE
[WEBRTC-636] Remove BuildConfig check when setting log level

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -341,9 +341,7 @@ class TelnyxClient(
      */
     private fun setSDKLogLevel(logLevel: LogLevel) {
         Timber.uprootAll()
-        if (BuildConfig.DEBUG) {
-            Timber.plant(TelnyxLoggingTree(logLevel))
-        }
+        Timber.plant(TelnyxLoggingTree(logLevel))
     }
 
     /**


### PR DESCRIPTION
[WebRTC-636 - per call token authentication investigation.](https://telnyx.atlassian.net/browse/WEBRTC-636)

---
<!-- Describe your changed here -->
Remove build config check before planting timber logging tree.

## :older_man: :baby: Behaviors
### Before changes
Build check before planting tree

### After changes
plant tree regardless of build config 

