### PR TITLE
[WEBRTC-640] Set an SDK property on INVITE (include client type and version in user-agent field)

### DIFF
--- a/telnyx_rtc/build.gradle
+++ b/telnyx_rtc/build.gradle
@@ -94,6 +94,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'proguard-rules.txt'
 
+        buildConfigField ("double", "SDK_VERSION", versionName)
         buildConfigField "java.util.concurrent.atomic.AtomicBoolean", "IS_TESTING", "new java.util.concurrent.atomic.AtomicBoolean(false)"
     }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/DialogParams.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/DialogParams.kt
@@ -5,6 +5,7 @@
 package com.telnyx.webrtc.sdk.verto.send
 
 import com.google.gson.annotations.SerializedName
+import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
 import java.util.*
 import kotlin.collections.ArrayList
 
@@ -18,6 +19,10 @@ data class CallDialogParams(val useStereo: Boolean = false,
                             val screenShare: Boolean = false,
                             val audio: Boolean = true,
                             val userVariables: ArrayList<Any> = arrayListOf(),
+                            @SerializedName("client_version")
+                            val clientVersion: String = BuildConfig.SDK_VERSION.toString(),
+                            @SerializedName("client_type")
+                            val clientType: String = "Android",
                             @SerializedName("clientState")
                             val clientState: String = "",
                             @SerializedName("callID")


### PR DESCRIPTION
[WebRTC-640 -  Set an SDK property on INVITE (include client type and version in user-agent field).](https://telnyx.atlassian.net/browse/WEBRTC-640)

---
<!-- Describe your changed here -->
This PR adds the client type and client version to the call invitation in order to allow for SDK metric tracking by platform. 

## :older_man: :baby: Behaviors
### Before changes
No client type or version was included in the call invitation

### After changes
Now the call invitation includes an Android platform value that cannot be changed, as well as a version taken from the BuildConfig of the Gradle Build version. 

## ✋ Manual testing
1. Launch sample application
2. Create call
3. monitor logcat and see new invitation JSON message. 
