### PR TITLE
[WEBRTC-640] Change type and version to single user agent

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -140,8 +140,9 @@ class Call(
         val answerBodyMessage = SendingMessageBody(
             uuid, SocketMethod.ANSWER.methodName,
             CallParams(
-                sessionId, sessionDescriptionString,
-                CallDialogParams(
+                sessionId = sessionId,
+                sdp = sessionDescriptionString,
+                dialogParams = CallDialogParams(
                     callId = callId,
                     destinationNumber = destinationNumber
                 )

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/DialogParams.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/DialogParams.kt
@@ -19,10 +19,8 @@ data class CallDialogParams(val useStereo: Boolean = false,
                             val screenShare: Boolean = false,
                             val audio: Boolean = true,
                             val userVariables: ArrayList<Any> = arrayListOf(),
-                            @SerializedName("client_version")
-                            val clientVersion: String = BuildConfig.SDK_VERSION.toString(),
-                            @SerializedName("client_type")
-                            val clientType: String = "Android",
+                            @SerializedName("User-Agent")
+                            val userAgent: String = "Android-"+BuildConfig.SDK_VERSION.toString(),
                             @SerializedName("clientState")
                             val clientState: String = "",
                             @SerializedName("callID")

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/DialogParams.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/DialogParams.kt
@@ -19,8 +19,6 @@ data class CallDialogParams(val useStereo: Boolean = false,
                             val screenShare: Boolean = false,
                             val audio: Boolean = true,
                             val userVariables: ArrayList<Any> = arrayListOf(),
-                            @SerializedName("User-Agent")
-                            val userAgent: String = "Android-"+BuildConfig.SDK_VERSION.toString(),
                             @SerializedName("clientState")
                             val clientState: String = "",
                             @SerializedName("callID")

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/ParamRequest.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/ParamRequest.kt
@@ -4,6 +4,9 @@
 
 package com.telnyx.webrtc.sdk.verto.send
 
+import com.google.gson.annotations.SerializedName
+import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
+
 sealed class ParamRequest
 
 data class LoginParam(val login_token: String?, val login: String?,
@@ -14,7 +17,10 @@ data class LoginParam(val login_token: String?, val login: String?,
                       val loginParams: ArrayList<Any>?
                       ) : ParamRequest()
 
-data class CallParams(val sessionId: String, val sdp: String,
+data class CallParams(val sessionId: String,
+                      val sdp: String,
+                      @SerializedName("User-Agent")
+                      val userAgent: String = "Android-"+ BuildConfig.SDK_VERSION.toString(),
                       val dialogParams: CallDialogParams
                       ) : ParamRequest()
 


### PR DESCRIPTION
[WebRTC-640 -  Set an SDK property on INVITE (include client type and version in user-agent field).](https://telnyx.atlassian.net/browse/WEBRTC-640)

---
<!-- Describe your changed here -->
This PR adds the client type and client version to the call invitation in order to allow for SDK metric tracking by platform. These states are represented in a single User-Agent variable

## :older_man: :baby: Behaviors
### Before changes
No client type or version was included in the call invitation

### After changes
Now the call invitation includes an Android platform value that cannot be changed, as well as a version is taken from the BuildConfig of the Gradle Build version. These values are both available in User-Agent

## ✋ Manual testing
1. Launch sample application
2. Create call
3. monitor logcat and see new invitation JSON message. 
