### PR TITLE
[WEBRTC-665] Provide a hidden way to switch to DEV ENV for testing.

### DIFF
--- a/app/src/androidTest/java/com/telnyx/webrtc/sdk/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/telnyx/webrtc/sdk/ui/MainActivityTest.kt
@@ -167,11 +167,11 @@ class MainActivityTest : BaseUITest() {
             onView(withId(R.id.sip_username_id)).perform(setTextInTextView(context.resources.getString(R.string.mock_username)))
             Thread.sleep(1500)
             onView(withId(R.id.sip_password_id)).perform(setTextInTextView(context.resources.getString(R.string.mock_password)))
-            Thread.sleep(1500)
+            Thread.sleep(6500)
             onView(withId(R.id.connect_button_id))
                 .perform(closeSoftKeyboard())
                 .perform(click())
-            Thread.sleep(6500)
+            Thread.sleep(2000)
 
             onView(withId(R.id.call_button_id))
                 .perform(closeSoftKeyboard())
@@ -183,6 +183,7 @@ class MainActivityTest : BaseUITest() {
             onView(withId(R.id.cancel_call_button_id))
                 .perform(closeSoftKeyboard())
                 .perform(click())
+            Thread.sleep(2000)
         }
     }
 

--- a/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
@@ -121,7 +121,11 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun connectToSocketAndObserve() {
-        mainViewModel.initConnection(applicationContext)
+        if (!isDev) {
+            mainViewModel.initConnection(applicationContext, null, null)
+        } else {
+            mainViewModel.initConnection(applicationContext, Config.TELNYX_DEV_HOST_ADDRESS, Config.TELNYX_PORT)
+        }
         observeSocketResponses()
     }
 
@@ -210,7 +214,6 @@ class MainActivity : AppCompatActivity() {
             environmentSwitchCounter++
             if (environmentSwitchCounter == 3) {
                 environmentSwitchCounter = 0
-                mainViewModel.switchEnvironment(!isDev)
                 if (isDev){
                     Toast.makeText(this, "Switched to PROD environment", Toast.LENGTH_LONG).show()
                 } else {

--- a/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
@@ -42,14 +42,13 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
 
-    private var invitationSent: Boolean = false
-
     @Inject
     lateinit var userManager: UserManager
-
+    private var invitationSent: Boolean = false
     lateinit var mainViewModel: MainViewModel
-
     private var fcmToken: String? = null
+    private var environmentSwitchCounter = 0
+    private var isDev = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -207,26 +206,39 @@ class MainActivity : AppCompatActivity() {
             call_button_id.visibility = View.VISIBLE
             cancel_call_button_id.visibility = View.GONE
         }
+        telnyx_image_id.setOnClickListener {
+            environmentSwitchCounter++
+            if (environmentSwitchCounter == 3) {
+                environmentSwitchCounter = 0
+                mainViewModel.switchEnvironment(!isDev)
+                if (isDev){
+                    Toast.makeText(this, "Switched to PROD environment", Toast.LENGTH_LONG).show()
+                } else {
+                    Toast.makeText(this, "Switched to DEV environment", Toast.LENGTH_LONG).show()
+                }
+                isDev = !isDev
+            }
+        }
     }
 
     private fun hasLoginEmptyFields(): Boolean {
-        var hasEmptyFileds = false
+        var hasEmptyFields = false
         if (token_login_switch.isChecked) {
             if (sip_token_id.text.isEmpty()) {
                 showEmptyFieldsToast()
-                hasEmptyFileds = true
+                hasEmptyFields = true
             }
         } else {
             if (sip_username_id.text.isEmpty() || sip_password_id.text.isEmpty()) {
                 showEmptyFieldsToast()
-                hasEmptyFileds = true
+                hasEmptyFields = true
             }
         }
-        return hasEmptyFileds
+        return hasEmptyFields
     }
 
     private fun showEmptyFieldsToast() {
-        Toast.makeText(this, getString(R.string.empty_msj_toast), Toast.LENGTH_LONG).show()
+        Toast.makeText(this, getString(R.string.empty_msg_toast), Toast.LENGTH_LONG).show()
     }
 
     private fun mockInputs() {

--- a/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainViewModel.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainViewModel.kt
@@ -124,4 +124,12 @@ class MainViewModel @Inject constructor(
     fun changeAudioOutput(audioDevice: AudioDevice) {
         telnyxClient?.setAudioOutputDevice(audioDevice)
     }
+
+    fun switchEnvironment(isDev: Boolean) {
+        if (isDev) {
+            Config.TELNYX_HOST_ADDRESS = Config.TELNYX_DEV_ENV
+        } else {
+            Config.TELNYX_HOST_ADDRESS = Config.TELNYX_PROD_ENV
+        }
+    }
 }

--- a/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainViewModel.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainViewModel.kt
@@ -11,6 +11,7 @@ import com.telnyx.webrtc.sdk.*
 import com.telnyx.webrtc.sdk.manager.UserManager
 import com.telnyx.webrtc.sdk.model.AudioDevice
 import com.telnyx.webrtc.sdk.model.CallState
+import com.telnyx.webrtc.sdk.model.TxServerConfiguration
 import com.telnyx.webrtc.sdk.verto.receive.ReceivedMessageBody
 import com.telnyx.webrtc.sdk.verto.receive.SocketResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -29,14 +30,10 @@ class MainViewModel @Inject constructor(
 
     private var calls: Map<UUID, Call> = mapOf()
 
-    fun initConnection(context: Context, providedHostname: String?, providedPort: Int?) {
+    fun initConnection(context: Context, providedServerConfig: TxServerConfiguration?) {
         telnyxClient = TelnyxClient(context)
-        providedHostname?.let {
-            if (providedPort == null) {
+        providedServerConfig?.let {
                 telnyxClient?.connect(it)
-            } else {
-                telnyxClient?.connect(it, providedPort)
-            }
         } ?: run {
             telnyxClient?.connect()
         }

--- a/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainViewModel.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainViewModel.kt
@@ -29,9 +29,18 @@ class MainViewModel @Inject constructor(
 
     private var calls: Map<UUID, Call> = mapOf()
 
-    fun initConnection(context: Context) {
+    fun initConnection(context: Context, providedHostname: String?, providedPort: Int?) {
         telnyxClient = TelnyxClient(context)
-        telnyxClient?.connect()
+        providedHostname?.let {
+            if (providedPort == null) {
+                telnyxClient?.connect(it)
+            } else {
+                telnyxClient?.connect(it, providedPort)
+            }
+        } ?: run {
+            telnyxClient?.connect()
+        }
+
     }
 
     fun saveUserData(
@@ -123,13 +132,5 @@ class MainViewModel @Inject constructor(
 
     fun changeAudioOutput(audioDevice: AudioDevice) {
         telnyxClient?.setAudioOutputDevice(audioDevice)
-    }
-
-    fun switchEnvironment(isDev: Boolean) {
-        if (isDev) {
-            Config.TELNYX_HOST_ADDRESS = Config.TELNYX_DEV_ENV
-        } else {
-            Config.TELNYX_HOST_ADDRESS = Config.TELNYX_PROD_ENV
-        }
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -35,6 +35,8 @@
         android:layout_height="36dp"
         android:layout_marginTop="@dimen/spacing_large"
         android:src="@drawable/ic_telnyx_logo"
+        android:focusable="true"
+        android:clickable="true"
         app:layout_constraintEnd_toStartOf="@id/guideline_end"
         app:layout_constraintStart_toEndOf="@id/guideline_start"
         app:layout_constraintTop_toBottomOf="@+id/toolbar_id" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,6 @@
     <string name="call_state">Call State:</string>
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
-    <string name="empty_msj_toast"><![CDATA[You must provide User&Password, or TokenID to proceed]]></string>
+    <string name="empty_msg_toast"><![CDATA[You must provide User&Password, or TokenID to proceed]]></string>
 
 </resources>

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -33,11 +33,13 @@ import java.util.*
  * @param audioManager the [AudioManager] instance in use, used to change audio related settings.
  */
 class Call(
-    var context: Context,
-    var client: TelnyxClient,
+    val context: Context,
+    val client: TelnyxClient,
     var socket: TxSocket,
-    var sessionId: String,
-    var audioManager: AudioManager
+    val sessionId: String,
+    private val audioManager: AudioManager,
+    private val providedTurn: String,
+    private val providedStun: String
 ) : TxSocketListener {
     private var peerConnection: Peer? = null
 
@@ -89,7 +91,7 @@ class Call(
         var sentFlag = false
 
         //Create new peer
-        peerConnection = Peer(context, client,
+        peerConnection = Peer(context, client, providedTurn, providedStun,
             object : PeerConnectionObserver() {
                 override fun onIceCandidate(p0: IceCandidate?) {
                     super.onIceCandidate(p0)
@@ -440,7 +442,7 @@ class Call(
         callId = offerCallId
 
         peerConnection = Peer(
-            context, client,
+            context, client, providedTurn, providedStun,
             object : PeerConnectionObserver() {
                 override fun onIceCandidate(p0: IceCandidate?) {
                     super.onIceCandidate(p0)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -38,8 +38,8 @@ class Call(
     var socket: TxSocket,
     val sessionId: String,
     private val audioManager: AudioManager,
-    private val providedTurn: String,
-    private val providedStun: String
+    private val providedTurn: String = Config.DEFAULT_TURN,
+    private val providedStun: String = Config.DEFAULT_STUN
 ) : TxSocketListener {
     private var peerConnection: Peer? = null
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Config.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Config.kt
@@ -4,7 +4,7 @@
 
 package com.telnyx.webrtc.sdk
 
-object Config {
+internal object Config {
         const val TELNYX_PROD_HOST_ADDRESS = "rtc.telnyx.com"
         const val TELNYX_DEV_HOST_ADDRESS = "rtcdev.telnyx.com"
         const val TELNYX_PORT = 14938

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Config.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Config.kt
@@ -5,9 +5,8 @@
 package com.telnyx.webrtc.sdk
 
 object Config {
-        var TELNYX_HOST_ADDRESS = "rtc.telnyx.com"
-        const val TELNYX_DEV_ENV = "rtcdev.telnyx.com"
-        const val TELNYX_PROD_ENV = "rtc.telnyx.com"
+        const val TELNYX_PROD_HOST_ADDRESS = "rtc.telnyx.com"
+        const val TELNYX_DEV_HOST_ADDRESS = "rtcdev.telnyx.com"
         const val TELNYX_PORT = 14938
         const val DEFAULT_TURN = "turn:turn.telnyx.com:3478?transport=tcp"
         const val DEFAULT_STUN = "stun:stun.telnyx.com:3843"

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Config.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Config.kt
@@ -4,13 +4,13 @@
 
 package com.telnyx.webrtc.sdk
 
-internal class Config {
-    companion object {
-        const val TELNYX_HOST_ADDRESS = "rtc.telnyx.com"
+object Config {
+        var TELNYX_HOST_ADDRESS = "rtc.telnyx.com"
+        const val TELNYX_DEV_ENV = "rtcdev.telnyx.com"
+        const val TELNYX_PROD_ENV = "rtc.telnyx.com"
         const val TELNYX_PORT = 14938
         const val DEFAULT_TURN = "turn:turn.telnyx.com:3478?transport=tcp"
         const val DEFAULT_STUN = "stun:stun.telnyx.com:3843"
         var USERNAME = "testuser"
         var PASSWORD = "testpassword"
-    }
 }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
@@ -25,8 +25,8 @@ import java.util.*
 internal class Peer(
     context: Context,
     val client: TelnyxClient,
-    private val providedTurn: String,
-    private val providedStun: String,
+    private val providedTurn: String = DEFAULT_TURN,
+    private val providedStun: String = DEFAULT_STUN,
     observer: PeerConnection.Observer
 ) {
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
@@ -5,10 +5,10 @@
 package com.telnyx.webrtc.sdk
 
 import android.content.Context
-import com.telnyx.webrtc.sdk.Config.Companion.DEFAULT_STUN
-import com.telnyx.webrtc.sdk.Config.Companion.DEFAULT_TURN
-import com.telnyx.webrtc.sdk.Config.Companion.PASSWORD
-import com.telnyx.webrtc.sdk.Config.Companion.USERNAME
+import com.telnyx.webrtc.sdk.Config.DEFAULT_STUN
+import com.telnyx.webrtc.sdk.Config.DEFAULT_TURN
+import com.telnyx.webrtc.sdk.Config.PASSWORD
+import com.telnyx.webrtc.sdk.Config.USERNAME
 import com.telnyx.webrtc.sdk.socket.TxSocket
 import org.webrtc.*
 import timber.log.Timber

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
@@ -25,6 +25,8 @@ import java.util.*
 internal class Peer(
     context: Context,
     val client: TelnyxClient,
+    private val providedTurn: String,
+    private val providedStun: String,
     observer: PeerConnection.Observer
 ) {
 
@@ -52,12 +54,12 @@ internal class Peer(
     private fun getIceServers(): List<PeerConnection.IceServer> {
         val iceServers: MutableList<PeerConnection.IceServer> = ArrayList()
         iceServers.add(
-            PeerConnection.IceServer.builder(DEFAULT_STUN).setUsername(USERNAME).setPassword(
+            PeerConnection.IceServer.builder(providedStun).setUsername(USERNAME).setPassword(
                 PASSWORD
             ).createIceServer()
         )
         iceServers.add(
-            PeerConnection.IceServer.builder(DEFAULT_TURN).setUsername(USERNAME).setPassword(
+            PeerConnection.IceServer.builder(providedTurn).setUsername(USERNAME).setPassword(
                 PASSWORD
             ).createIceServer()
         )

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -456,7 +456,7 @@ class TelnyxClient(
         }
         Timber.d("ringtone/ringback media player stopped and released")
     }
-
+    
     private fun requestGatewayStatus() {
         if (waitingForReg) {
             socket.send(
@@ -491,7 +491,6 @@ class TelnyxClient(
             )
         )
     }
-
 
     // TxSocketListener Overrides
     override fun onClientReady(jsonObject: JsonObject) {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/TxServerConfiguration.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/TxServerConfiguration.kt
@@ -1,0 +1,10 @@
+package com.telnyx.webrtc.sdk.model
+
+import com.telnyx.webrtc.sdk.Config
+
+data class TxServerConfiguration(
+    val host: String = Config.TELNYX_PROD_HOST_ADDRESS,
+    val port: Int = Config.TELNYX_PORT,
+    val turn: String = Config.DEFAULT_TURN,
+    val stun: String = Config.DEFAULT_STUN
+)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -8,6 +8,7 @@ import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Severity
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import com.telnyx.webrtc.sdk.Config
 import com.telnyx.webrtc.sdk.TelnyxClient
 import com.telnyx.webrtc.sdk.model.SocketError.*
 import com.telnyx.webrtc.sdk.model.SocketMethod.*
@@ -70,7 +71,7 @@ class TxSocket(
      * @param listener, the [TelnyxClient] used to create an instance of TxSocket that contains our relevant listener methods via the [TxSocketListener] interface
      * @see [TxSocketListener]
      */
-    fun connect(listener: TelnyxClient, providedHostAddress: String?, providedPort: Int?) = launch {
+    fun connect(listener: TelnyxClient, providedHostAddress: String? = Config.TELNYX_PROD_HOST_ADDRESS, providedPort: Int? = Config.TELNYX_PORT) = launch {
         try {
             providedHostAddress?.let {
                 host_address = it

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -38,8 +38,8 @@ import java.util.*
  * @param port the port that the websocket connection should use
  */
 class TxSocket(
-    internal val host_address: String,
-    internal val port: Int
+    internal var host_address: String,
+    internal var port: Int
 ) : CoroutineScope {
 
     private var job: Job = SupervisorJob()
@@ -70,8 +70,14 @@ class TxSocket(
      * @param listener, the [TelnyxClient] used to create an instance of TxSocket that contains our relevant listener methods via the [TxSocketListener] interface
      * @see [TxSocketListener]
      */
-    fun connect(listener: TelnyxClient) = launch {
+    fun connect(listener: TelnyxClient, providedHostAddress: String?, providedPort: Int?) = launch {
         try {
+            providedHostAddress?.let {
+                host_address = it
+            }
+            providedPort?.let {
+                port = it
+            }
             client.wss(
                 host = host_address,
                 port = port

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/socket/TxSocketTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/socket/TxSocketTest.kt
@@ -149,7 +149,7 @@ class TxSocketTest : BaseTest() {
 
 
     @Test
-    fun `connect with empty host or port`() {
+    fun `connect with empty host or port - still connects with default`() {
         BuildConfig.IS_TESTING.set(true)
         socket = spy(TxSocket(
             host_address = "",
@@ -161,7 +161,7 @@ class TxSocketTest : BaseTest() {
 
         //Sleep to give time to connect
         Thread.sleep(3000)
-        verify(client, times(0)).onConnectionEstablished()
+        verify(client, times(1)).onConnectionEstablished()
 
     }
 


### PR DESCRIPTION
[WebRTC-665 - Provide a hidden way to switch to DEV ENV for testing.](https://telnyx.atlassian.net/browse/WEBRTC-665)
---
<!-- Describe your changed here -->
This PR implements a method of switching to DEV and PROD environments within the application. DEV environment requires a VPN so exposing these details is not an issue. 

The environment is changed via long pressing the Telnyx logo. An alert dialog will appear providing options to switch to Dev, Prod and copy the firebase token instance

A few minor changes were required to enable this, but nothing will break current customer implementations. There is now a TxServerConfiguration class that has default values that can be included in connect(), however, there is a default configuration provided so it is not an issue if the customer does not include one. 

Other changes include minor typo and test changes. 

## :older_man: :baby: Behaviors
### Before changes
App was always set to PROD environment

### After changes
The app can be switched to DEV and back via long pressing Telnyx Logo 
We can copy the firebase instance from the same hidden menu dialog. 

## ✋ Manual testing
1. Open the application, long press the Telnyx logo, select DEV environment
2. Try login with prod credentials, it will fail
3. Long press logo again, select PROD environment
4. Try log in with prod credentials, it will work. 
5. Long press logo again, copy Firebase instance. Paste it anywhere (Slack, etc)
