### PR TITLE
[WEBRTC-680] Run client ready method in coroutine scope 

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -27,6 +27,9 @@ import org.webrtc.IceCandidate
 import timber.log.Timber
 import java.util.*
 import com.bugsnag.android.Bugsnag
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlin.concurrent.timerTask
 
 /**
@@ -498,6 +501,17 @@ class TelnyxClient(
                 )
             )
         )
+
+        CoroutineScope(Dispatchers.Main).launch {
+            socketResponseLiveData.postValue(
+                SocketResponse.messageReceived(
+                    ReceivedMessageBody(
+                        SocketMethod.CLIENT_READY.methodName,
+                        null
+                    )
+                )
+            )
+        }
     }
 
     // TxSocketListener Overrides


### PR DESCRIPTION

[WebRTC-680 - Run client-ready method in coroutine scope .](https://telnyx.atlassian.net/browse/WEBRTC-680)
---
<!-- Describe your changed here -->
We will now receive client-ready after a successful login too. 
