### PR TITLE
[WEBRTC-690][ENGDESK-11170] Push Notification investigation enhancements + IceCandidate Bug Fix

### DIFF
--- a/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
@@ -472,6 +472,7 @@ class MainActivity : AppCompatActivity() {
         mainViewModel.setCurrentCall(callId)
         when (notificationAcceptHandling) {
             true -> {
+                Thread.sleep(1000)
                 onAcceptCall(callId, callerIdNumber)
                 notificationAcceptHandling = null
             }
@@ -483,9 +484,6 @@ class MainActivity : AppCompatActivity() {
                 call_control_section_id.visibility = View.GONE
                 incoming_call_section_id.visibility = View.VISIBLE
                 incoming_call_section_id.bringToFront()
-
-                mainViewModel.setCurrentCall(callId)
-
 
                 answer_call_id.setOnClickListener {
                     onAcceptCall(callId, callerIdNumber)

--- a/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
@@ -64,6 +64,10 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
         setSupportActionBar(findViewById(R.id.toolbar_id))
 
+        // Add environment text
+        isDev = userManager.isDev
+        updateEnvText(isDev)
+
         FirebaseApp.initializeApp(this)
 
         mainViewModel = ViewModelProvider(this@MainActivity).get(MainViewModel::class.java)
@@ -214,10 +218,6 @@ class MainActivity : AppCompatActivity() {
         mockInputs()
         handleUserLoginState()
         getFCMToken()
-
-        // Add environment text
-        isDev = userManager.isDev
-        updateEnvText(isDev)
 
         connect_button_id.setOnClickListener {
             if (!hasLoginEmptyFields()) {
@@ -445,7 +445,8 @@ class MainActivity : AppCompatActivity() {
                 sip_password_id.text.toString(),
                 fcmToken,
                 caller_id_name_id.text.toString(),
-                caller_id_number_id.text.toString()
+                caller_id_number_id.text.toString(),
+                isDev
             )
         }
     }
@@ -468,6 +469,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun onReceiveCallView(callId: UUID, callerIdName: String, callerIdNumber: String) {
+        mainViewModel.setCurrentCall(callId)
         when (notificationAcceptHandling) {
             true -> {
                 onAcceptCall(callId, callerIdNumber)

--- a/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainViewModel.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainViewModel.kt
@@ -45,7 +45,8 @@ class MainViewModel @Inject constructor(
         password: String,
         fcmToken: String?,
         callerIdName: String,
-        callerIdNumber: String
+        callerIdNumber: String,
+        isDev: Boolean
     ) {
         if (!userManager.isUserLogin) {
             userManager.isUserLogin = true
@@ -54,6 +55,7 @@ class MainViewModel @Inject constructor(
             userManager.fcmToken = fcmToken
             userManager.callerIdName = callerIdName
             userManager.callerIdNumber = callerIdNumber
+            userManager.isDev = isDev
         }
     }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -493,6 +493,10 @@ class Call(
         //NOOP
     }
 
+    override fun onSessionIdReceived(jsonObject: JsonObject) {
+        //NOOP
+    }
+
     override fun onGatewayStateReceived(jsonObject: JsonObject) {
         //NOOP
     }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -423,6 +423,8 @@ class Call(
     }
 
     override fun onOfferReceived(jsonObject: JsonObject) {
+        Timber.d("[%s] :: onOfferReceived [%s]", this@Call.javaClass.simpleName, jsonObject)
+
         /* In case of receiving an invite
           local user should create an answer with both local and remote information :
           1. create a connection peer
@@ -475,6 +477,8 @@ class Call(
     }
 
     override fun onRingingReceived(jsonObject: JsonObject) {
+        Timber.d("[%s] :: onRingingReceived [%s]", this@Call.javaClass.simpleName, jsonObject)
+
         val params = jsonObject.getAsJsonObject("params")
         telnyxSessionId = UUID.fromString(params.get("telnyx_session_id").asString)
         telnyxLegId = UUID.fromString(params.get("telnyx_leg_id").asString)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -19,7 +19,6 @@ import com.telnyx.webrtc.sdk.verto.receive.*
 import com.telnyx.webrtc.sdk.verto.send.*
 import io.ktor.util.*
 import org.webrtc.IceCandidate
-import org.webrtc.PeerConnection
 import org.webrtc.SessionDescription
 import timber.log.Timber
 import java.util.*

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
@@ -143,7 +143,6 @@ internal class Peer(
     private fun PeerConnection.call(sdpObserver: SdpObserver) {
         val constraints = MediaConstraints().apply {
             mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveAudio", "true"))
-          //  mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveVideo", "true"))
             optional.add(MediaConstraints.KeyValuePair("DtlsSrtpKeyAgreement", "true"))
         }
 
@@ -181,7 +180,6 @@ internal class Peer(
     private fun PeerConnection.answer(sdpObserver: SdpObserver) {
         val constraints = MediaConstraints().apply {
             mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveAudio", "true"))
-       //     mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveVideo", "true"))
             optional.add(MediaConstraints.KeyValuePair("DtlsSrtpKeyAgreement", "true"))
         }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Peer.kt
@@ -143,7 +143,7 @@ internal class Peer(
     private fun PeerConnection.call(sdpObserver: SdpObserver) {
         val constraints = MediaConstraints().apply {
             mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveAudio", "true"))
-            mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveVideo", "true"))
+          //  mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveVideo", "true"))
             optional.add(MediaConstraints.KeyValuePair("DtlsSrtpKeyAgreement", "true"))
         }
 
@@ -181,7 +181,7 @@ internal class Peer(
     private fun PeerConnection.answer(sdpObserver: SdpObserver) {
         val constraints = MediaConstraints().apply {
             mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveAudio", "true"))
-            mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveVideo", "true"))
+       //     mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveVideo", "true"))
             optional.add(MediaConstraints.KeyValuePair("DtlsSrtpKeyAgreement", "true"))
         }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -573,6 +573,12 @@ class TelnyxClient(
         }
     }
 
+    override fun onSessionIdReceived(jsonObject: JsonObject) {
+        val result = jsonObject.get("result")
+        val sessId = result.asJsonObject.get("sessid").asString
+        sessionId = sessId
+    }
+
     override fun onGatewayStateReceived(jsonObject: JsonObject) {
         val result = jsonObject.get("result")
         val params = result.asJsonObject.get("params")

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
@@ -21,6 +21,13 @@ interface TxSocketListener {
     fun onClientReady(jsonObject: JsonObject)
 
     /**
+     * Fires once we have received a sessionID from the Telnyx web socket.
+     * @param jsonObject, the socket response in a jsonObject format
+     * @see [TxSocket]
+     */
+    fun onSessionIdReceived(jsonObject: JsonObject)
+
+    /**
      * Fires once a Gateway state has been received. These are used to find a verified registration
      * @param jsonObject, the socket response in a jsonObject format
      * @see [TxSocket]


### PR DESCRIPTION
[WebRTC-690 - Push Notification investigation.](https://telnyx.atlassian.net/browse/WEBRTC-690)
---
<!-- Describe your changed here -->
This PR fixes the autologin mechanism by storing the environment used after a successful login. 

There is also another socket listener method that is used to set our sessionID earlier, this makes it possible to build a call before the login is successful which is useful for the upcoming Push Notification release

We no longer send video media constraints on the WebRTC SDK

We now wait 300 ms before sending our invite, this means that we have time to gather more (most often all), ice candidates, before sending our invitation. This hopefully fixes a customer issue where IPv6 was the only candidate available, which is not supported

## :older_man: :baby: Behaviors
### Before changes
Environment not remembered for autologin
Session ID being set on successful login
Sending video media constraints with the invitation and answer SDPs
Sending invite as soon as first ice candidate obtained 

### After changes
Environment remembered via shared preferences 
The session ID is now set as soon as a login is attempted, rather than after it was successful
No video media constraints in SDPs
We now leave 300 ms to collect ice candidates before sending the invite 


