### PR TITLE
[WEBRTC-711] Fix REGISTRATION issue from ld6/sy1 in Telnyx WebRTC SDK

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -500,7 +500,7 @@ class Call(
         //NOOP
     }
 
-    override fun onGatewayStateReceived(jsonObject: JsonObject) {
+    override fun onGatewayStateReceived(gatewayState: String, sessionId: String?) {
         //NOOP
     }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -607,8 +607,9 @@ class TelnyxClient(
                 socketResponseLiveData.postValue(SocketResponse.error("Gateway registration has failed"))
             }
             GatewayState.FAIL_WAIT.state -> {
-                if (autoRetryLogin && connectRetryCounter < RETRY_CONNECT_TIME){
+                if (autoRetryLogin && connectRetryCounter <= RETRY_CONNECT_TIME) {
                     connectRetryCounter++
+                    Timber.d("[%s] :: Attempting reconnection :: attempt $connectRetryCounter / $RETRY_CONNECT_TIME", this@TelnyxClient.javaClass.simpleName)
                     reconnectToSocket()
                 } else {
                     invalidateGatewayResponseTimer()

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -56,7 +56,7 @@ class TelnyxClient(
     private var connectRetryCounter = 0
     private var gatewayState = "idle"
 
-    internal lateinit var socket: TxSocket
+    internal var socket: TxSocket
     private var providedHostAddress: String? = null
     private var providedPort: Int? = null
     private var providedTurn: String? = null

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -49,7 +49,7 @@ class TelnyxClient(
     private var reconnecting = false
 
     //Gateway registration variables
-    private var autoRetryLogin: Boolean = true
+    private var autoReconnectLogin: Boolean = true
     private var gatewayResponseTimer: Timer? = null
     private var waitingForReg = true
     private var registrationRetryCounter = 0
@@ -298,7 +298,7 @@ class TelnyxClient(
         val password = config.sipPassword
         val fcmToken = config.fcmToken
         val logLevel = config.logLevel
-        autoRetryLogin = config.autoRetry
+        autoReconnectLogin = config.autoReconnect
 
         Config.USERNAME = config.sipUser
         Config.PASSWORD = config.sipPassword
@@ -349,7 +349,7 @@ class TelnyxClient(
         val token = config.sipToken
         val fcmToken = config.fcmToken
         val logLevel = config.logLevel
-        autoRetryLogin = config.autoRetry
+        autoReconnectLogin = config.autoReconnect
 
         tokenSessionConfig = config
 
@@ -615,7 +615,7 @@ class TelnyxClient(
                 socketResponseLiveData.postValue(SocketResponse.error("Gateway registration has failed"))
             }
             GatewayState.FAIL_WAIT.state -> {
-                if (autoRetryLogin && connectRetryCounter < RETRY_CONNECT_TIME) {
+                if (autoReconnectLogin && connectRetryCounter < RETRY_CONNECT_TIME) {
                     connectRetryCounter++
                     Timber.d("[%s] :: Attempting reconnection :: attempt $connectRetryCounter / $RETRY_CONNECT_TIME", this@TelnyxClient.javaClass.simpleName)
                     runBlocking { reconnectToSocket() }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -21,15 +21,12 @@ import com.telnyx.webrtc.sdk.verto.receive.*
 import com.telnyx.webrtc.sdk.verto.send.*
 import io.ktor.server.cio.backend.*
 import io.ktor.util.*
-import kotlinx.coroutines.cancel
 import org.webrtc.IceCandidate
 import timber.log.Timber
 import java.util.*
 import com.bugsnag.android.Bugsnag
 import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import kotlin.concurrent.timerTask
 
 /**
@@ -148,12 +145,16 @@ class TelnyxClient(
         socket.destroy()
         //Socket is now the reconnectionSocket
         socket = socketReconnection!!
-        //Connect to new socket
-        socket.connect(this@TelnyxClient, providedHostAddress, providedPort)
-        //Login with stored configuration
-        credentialSessionConfig?.let {
-            credentialLogin(it)
-        } ?: tokenLogin(tokenSessionConfig!!)
+
+        GlobalScope.launch {
+            //Connect to new socket
+            socket.connect(this@TelnyxClient, providedHostAddress, providedPort)
+            delay(1000)
+            //Login with stored configuration
+            credentialSessionConfig?.let {
+                credentialLogin(it)
+            } ?: tokenLogin(tokenSessionConfig!!)
+        }
 
         //Change an ongoing call's socket to the new socket.
         call?.let { call?.socket = socket }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -587,15 +587,19 @@ class TelnyxClient(
         sessionId = sessId
     }
 
-    override fun onGatewayStateReceived(gatewayState: String, sessionId: String?) {
+    override fun onGatewayStateReceived(gatewayState: String, receivedSessionId: String?) {
         when (gatewayState) {
             GatewayState.REGED.state -> {
                 invalidateGatewayResponseTimer()
                 waitingForReg = false
-                sessionId?.let { it
+                receivedSessionId?.let { it
                     onLoginSuccessful(it)
                 } ?: kotlin.run {
-                    socketResponseLiveData.postValue(SocketResponse.error("No session ID received. Please try again"))
+                    if (sessionId != null) {
+                        onLoginSuccessful(sessionId!!)
+                    } else {
+                        socketResponseLiveData.postValue(SocketResponse.error("No session ID received. Please try again"))
+                    }
                 }
             }
             GatewayState.NOREG.state -> {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -133,7 +133,7 @@ class TelnyxClient(
      * @see [TxSocket]
      * @see [TelnyxConfig]
      */
-    suspend private fun reconnectToSocket() = withContext(Dispatchers.Default) {
+    private suspend fun reconnectToSocket() = withContext(Dispatchers.Default) {
         //Create new socket connection
         socketReconnection = TxSocket(
             socket.host_address,

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxConfig.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxConfig.kt
@@ -29,8 +29,8 @@ sealed class TelnyxConfig
  * @property fcmToken The user's Firebase Cloud Messaging device ID
  * @property ringtone The integer raw value of the audio file to use as a ringtone
  * @property ringBackTone The integer raw value of the audio file to use as a ringback tone
- * @property autoRetry whether or not to reattempt (3 times) the login in the instance of a failure to connect and register to the gateway with valid credentials
  * @property logLevel The log level that the SDK should use - default value is none.
+ * @property autoRetry whether or not to reattempt (3 times) the login in the instance of a failure to connect and register to the gateway with valid credentials
  */
 data class CredentialConfig(
     val sipUser: String,
@@ -40,8 +40,8 @@ data class CredentialConfig(
     val fcmToken: String?,
     val ringtone: Int?,
     val ringBackTone: Int?,
-    val autoRetry : Boolean = true,
-    val logLevel: LogLevel = LogLevel.NONE
+    val logLevel: LogLevel = LogLevel.NONE,
+    val autoRetry : Boolean = true
     ) : TelnyxConfig()
 
 /**
@@ -53,8 +53,8 @@ data class CredentialConfig(
  * @property fcmToken The user's Firebase Cloud Messaging device ID
  * @property ringtone The integer raw value of the audio file to use as a ringtone
  * @property ringBackTone The integer raw value of the audio file to use as a ringback tone
- * @property autoRetry whether or not to reattempt (3 times) the login in the instance of a failure to connect and register to the gateway with a valid token
  * @property logLevel The log level that the SDK should use - default value is none.
+ * @property autoRetry whether or not to reattempt (3 times) the login in the instance of a failure to connect and register to the gateway with a valid token
  */
 data class TokenConfig(
     val sipToken: String,
@@ -63,7 +63,7 @@ data class TokenConfig(
     val fcmToken: String?,
     val ringtone: Int?,
     val ringBackTone: Int?,
+    val logLevel: LogLevel = LogLevel.NONE,
     val autoRetry : Boolean = true,
-    val logLevel: LogLevel = LogLevel.NONE
     ) : TelnyxConfig()
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxConfig.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxConfig.kt
@@ -30,7 +30,7 @@ sealed class TelnyxConfig
  * @property ringtone The integer raw value of the audio file to use as a ringtone
  * @property ringBackTone The integer raw value of the audio file to use as a ringback tone
  * @property logLevel The log level that the SDK should use - default value is none.
- * @property autoRetry whether or not to reattempt (3 times) the login in the instance of a failure to connect and register to the gateway with valid credentials
+ * @property autoReconnect whether or not to reattempt (3 times) the login in the instance of a failure to connect and register to the gateway with valid credentials
  */
 data class CredentialConfig(
     val sipUser: String,
@@ -41,7 +41,7 @@ data class CredentialConfig(
     val ringtone: Int?,
     val ringBackTone: Int?,
     val logLevel: LogLevel = LogLevel.NONE,
-    val autoRetry : Boolean = true
+    val autoReconnect : Boolean = true
     ) : TelnyxConfig()
 
 /**
@@ -54,7 +54,7 @@ data class CredentialConfig(
  * @property ringtone The integer raw value of the audio file to use as a ringtone
  * @property ringBackTone The integer raw value of the audio file to use as a ringback tone
  * @property logLevel The log level that the SDK should use - default value is none.
- * @property autoRetry whether or not to reattempt (3 times) the login in the instance of a failure to connect and register to the gateway with a valid token
+ * @property autoReconnect whether or not to reattempt (3 times) the login in the instance of a failure to connect and register to the gateway with a valid token
  */
 data class TokenConfig(
     val sipToken: String,
@@ -64,6 +64,6 @@ data class TokenConfig(
     val ringtone: Int?,
     val ringBackTone: Int?,
     val logLevel: LogLevel = LogLevel.NONE,
-    val autoRetry : Boolean = true,
+    val autoReconnect : Boolean = true,
     ) : TelnyxConfig()
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxConfig.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxConfig.kt
@@ -29,7 +29,7 @@ sealed class TelnyxConfig
  * @property fcmToken The user's Firebase Cloud Messaging device ID
  * @property ringtone The integer raw value of the audio file to use as a ringtone
  * @property ringBackTone The integer raw value of the audio file to use as a ringback tone
- * @property autoRetry whether or not to reattempt the login in the instance of a failure to connect and register to the gateway with valid credentials
+ * @property autoRetry whether or not to reattempt (3 times) the login in the instance of a failure to connect and register to the gateway with valid credentials
  * @property logLevel The log level that the SDK should use - default value is none.
  */
 data class CredentialConfig(
@@ -40,7 +40,7 @@ data class CredentialConfig(
     val fcmToken: String?,
     val ringtone: Int?,
     val ringBackTone: Int?,
-    val autoRetry : Boolean?,
+    val autoRetry : Boolean = true,
     val logLevel: LogLevel = LogLevel.NONE
     ) : TelnyxConfig()
 
@@ -53,7 +53,7 @@ data class CredentialConfig(
  * @property fcmToken The user's Firebase Cloud Messaging device ID
  * @property ringtone The integer raw value of the audio file to use as a ringtone
  * @property ringBackTone The integer raw value of the audio file to use as a ringback tone
- * @property autoRetry whether or not to reattempt the login in the instance of a failure to connect and register to the gateway with a valid token
+ * @property autoRetry whether or not to reattempt (3 times) the login in the instance of a failure to connect and register to the gateway with a valid token
  * @property logLevel The log level that the SDK should use - default value is none.
  */
 data class TokenConfig(
@@ -63,7 +63,7 @@ data class TokenConfig(
     val fcmToken: String?,
     val ringtone: Int?,
     val ringBackTone: Int?,
-    val autoRetry : Boolean?,
+    val autoRetry : Boolean = true,
     val logLevel: LogLevel = LogLevel.NONE
     ) : TelnyxConfig()
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxConfig.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxConfig.kt
@@ -26,9 +26,10 @@ sealed class TelnyxConfig
  * @property sipPassword The SIP password of the user logging in
  * @property sipCallerIDName The user's chosen Caller ID Name
  * @property sipCallerIDNumber The user's Caller ID Number
- * @property fcmDeviceId The user's Firebase Cloud Messaging device ID
+ * @property fcmToken The user's Firebase Cloud Messaging device ID
  * @property ringtone The integer raw value of the audio file to use as a ringtone
  * @property ringBackTone The integer raw value of the audio file to use as a ringback tone
+ * @property autoRetry whether or not to reattempt the login in the instance of a failure to connect and register to the gateway with valid credentials
  * @property logLevel The log level that the SDK should use - default value is none.
  */
 data class CredentialConfig(
@@ -39,6 +40,7 @@ data class CredentialConfig(
     val fcmToken: String?,
     val ringtone: Int?,
     val ringBackTone: Int?,
+    val autoRetry : Boolean?,
     val logLevel: LogLevel = LogLevel.NONE
     ) : TelnyxConfig()
 
@@ -48,9 +50,10 @@ data class CredentialConfig(
  * @property sipToken The JWT token for the SIP user.
  * @property sipCallerIDName The user's chosen Caller ID Name
  * @property sipCallerIDNumber The user's Caller ID Number
- * @property fcmDeviceId The user's Firebase Cloud Messaging device ID
+ * @property fcmToken The user's Firebase Cloud Messaging device ID
  * @property ringtone The integer raw value of the audio file to use as a ringtone
  * @property ringBackTone The integer raw value of the audio file to use as a ringback tone
+ * @property autoRetry whether or not to reattempt the login in the instance of a failure to connect and register to the gateway with a valid token
  * @property logLevel The log level that the SDK should use - default value is none.
  */
 data class TokenConfig(
@@ -60,6 +63,7 @@ data class TokenConfig(
     val fcmToken: String?,
     val ringtone: Int?,
     val ringBackTone: Int?,
+    val autoRetry : Boolean?,
     val logLevel: LogLevel = LogLevel.NONE
     ) : TelnyxConfig()
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
@@ -29,10 +29,11 @@ interface TxSocketListener {
 
     /**
      * Fires once a Gateway state has been received. These are used to find a verified registration
-     * @param jsonObject, the socket response in a jsonObject format
+     * @param gatewayState, the string representation of the gateway state received from the socket connection
+     * @param sessionId, the string representation of the session ID received from the socket connection
      * @see [TxSocket]
      */
-    fun onGatewayStateReceived(jsonObject: JsonObject)
+    fun onGatewayStateReceived(gatewayState: String, sessionId: String?)
 
     /**
      * Fires when a socket connection is established

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
@@ -33,7 +33,7 @@ interface TxSocketListener {
      * @param sessionId, the string representation of the session ID received from the socket connection
      * @see [TxSocket]
      */
-    fun onGatewayStateReceived(gatewayState: String, sessionId: String?)
+    fun onGatewayStateReceived(gatewayState: String, receivedSessionId: String?)
 
     /**
      * Fires when a socket connection is established

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -61,7 +61,6 @@ class TelnyxClientTest : BaseTest() {
 
     @MockK lateinit var capabilities: NetworkCapabilities
 
-
     @Spy
     private lateinit var socket: TxSocket
 
@@ -358,7 +357,6 @@ class TelnyxClientTest : BaseTest() {
         val params = StateParams(state = GatewayState.NOREG.state)
 
         val stateResult = StateResponse(sessid = sessid, params = params)
-
         val stateMessageBody = ReceivedMessageBody(
             method = SocketMethod.GATEWAY_STATE.methodName,
             result = stateResult

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -367,7 +367,8 @@ class TelnyxClientTest : BaseTest() {
         )
         client.credentialLogin(config)
         client.onGatewayStateReceived(GatewayState.FAIL_WAIT.state, null)
-        Mockito.verify(client, Mockito.atLeastOnce()).onGatewayStateReceived(anyString(), any())
+        Thread.sleep(5000)
+        Mockito.verify(client, Mockito.atLeast(2)).onGatewayStateReceived(anyString(), anyString())
     }
 
 


### PR DESCRIPTION
[WebRTC-711 - Fix REGISTRATION issue from ld6/sy1 in Telnyx WebRTC SDK.](https://telnyx.atlassian.net/browse/WEBRTC-711)
---

<!-- Describe your changed here -->
This PR implements a boolean value `autoRetry` to our login methods that will automatically try reconnect and log into our socket connection up to 3 times if set to true in the instance of receiving a FAIL_WAIT response from the gateway.

This is a temporary workaround to tackle the 480 SIP error we are receiving as a result of invalid gateway registrations

Tests are adjusted and added. 

## :older_man: :baby: Behaviors
### Before changes
FAIL_WAIT message would simply return an error. Often customers would then try login again without reconnecting to the socket, which would cause issues. (480 SIP error).

### After changes
If `autoRetry` is set to true, we will automatically disconnect and reconnect to the socket and attempt the login again in the instance of receiving a FAIL_WAIT gateway response.

## ✋ Manual testing
1. Attempt a login with an invalid username (forcing a FAIL_WAIT response)
2. See logs as connect -> login is attempted 3 times 
(will eventually fail because of invalid credentials. Customer scenario will eventually pass if credentials are valid, this is the only way we can test it because FAIL_WAIT happens with valid credentials very rarely but is still an issue)
