### PR TITLE
[WEBRTC-1618] Generate random UUID when params are missing

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -504,10 +504,17 @@ class Call(
 
     override fun onRingingReceived(jsonObject: JsonObject) {
         Timber.d("[%s] :: onRingingReceived [%s]", this@Call.javaClass.simpleName, jsonObject)
-
         val params = jsonObject.getAsJsonObject("params")
-        telnyxSessionId = UUID.fromString(params.get("telnyx_session_id").asString)
-        telnyxLegId = UUID.fromString(params.get("telnyx_leg_id").asString)
+        telnyxSessionId = if (params.has("telnyx_session_id")) {
+            UUID.fromString(params.get("telnyx_session_id").asString)
+        } else {
+            UUID.randomUUID()
+        }
+        telnyxLegId = if (params.has("telnyx_leg_id")) {
+            UUID.fromString(params.get("telnyx_leg_id").asString)
+        } else {
+            UUID.randomUUID()
+        }
     }
 
     override fun onIceCandidateReceived(iceCandidate: IceCandidate) {


### PR DESCRIPTION
[WebRTC-1618 - onRingingReceived missing leg and session ID fix ](https://telnyx.atlassian.net/browse/WEBRTC-1618)
---
<!-- Describe your changed here -->
This PR adds random UUID for the onRingingReceived Call message when the telnyx_session_id and telnyx_leg_id are missing from the jsonObject. 

## :older_man: :baby: Behaviors
### Before changes
If these params are missing (rare, uncertain of cause. Backend related), the application would crash

### After changes
Instead of not handling the missing params, we now generate a random UUID. The call still works with these random values. 

## ✋ Manual testing
1. Do call flow as normal
