### PR TITLE
fix(WEBRTC-2081): Release MediaPlayer when stopped

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -441,7 +441,7 @@ class TelnyxClient(
             stopMediaPlayer()
             mediaPlayer = MediaPlayer.create(context, it)
             mediaPlayer!!.setWakeMode(context, PowerManager.PARTIAL_WAKE_LOCK)
-            if (!mediaPlayer!!.isPlaying) {
+            if (mediaPlayer?.isPlaying == false) {
                 mediaPlayer!!.start()
                 mediaPlayer!!.isLooping = true
             }
@@ -461,7 +461,7 @@ class TelnyxClient(
             stopMediaPlayer()
             mediaPlayer = MediaPlayer.create(context, it)
             mediaPlayer!!.setWakeMode(context, PowerManager.PARTIAL_WAKE_LOCK)
-            if (!mediaPlayer!!.isPlaying) {
+            if (mediaPlayer?.isPlaying == false) {
                 mediaPlayer!!.start()
                 mediaPlayer!!.isLooping = true
             }
@@ -475,9 +475,11 @@ class TelnyxClient(
      * @see [MediaPlayer]
      */
     internal fun stopMediaPlayer() {
-        if (mediaPlayer != null && mediaPlayer!!.isPlaying) {
+        if (mediaPlayer != null) {
             mediaPlayer!!.stop()
             mediaPlayer!!.reset()
+            mediaPlayer!!.release()
+            mediaPlayer = null
         }
         Timber.d("ringtone/ringback media player stopped and released")
     }


### PR DESCRIPTION
[WebRTC-2081 - Release MediaPlayer when stopped.](https://telnyx.atlassian.net/browse/WEBRTC-2081)

---
<!-- Describe your changed here -->
This PR includes some code changes to release MediaPlayer when stopped, then recreated when required again. 

This comes as a result of a customer reported issue, stating:

"app acquires a partial wake lock by calling acquire() with the PARTIAL_WAKE_LOCK flag. A partial wake lock becomes stuck if it is held for a long time while your app is running in the background (no part of your app is visible to the user). This information is the suggestion that Google returned to our APP. After I checked the corresponding code, I found this situation, so I asked your opinion on this. This is the document address given by Google : https://developer.android/. com/topic/performance/vitals/wakelock"

We now get around this by creating a Mediaplayer with setWakeMode set to partial WakeLock only when used. When we stop the MediaPlayer, we now release and null it to avoid this issue. 

## :older_man: :baby: Behaviors
### Before changes
Not releasing MediaPlayer, only stopping and reusing. Maintaining WakeLock

### After changes
Release and null MediaPlayer when stopped.
Create a new instance of MediaPlayer with WakeLock _ONLY_ when required.

## ✋ Manual testing
1. Run application, receive call and accept/deny and ensure audio works as required
2. Call someone to hear ringback tone and make sure it stops when accepted/declined
3. Audio should work the same as before, but now MediaPlayer is being released
