### PR TITLE
feat(WEBRTC-2102): implement reconnect functionality with attach flow

### DIFF
--- a/app/src/main/java/com/telnyx/webrtc/sdk/manager/UserManager.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/manager/UserManager.kt
@@ -64,7 +64,7 @@ class UserManager @Inject constructor(private val sharedPreferences: SharedPrefe
         }
         set(callerNumber) = sharedPreferences.edit().putString(KEY_USER_CALLER_ID_NUMBER, callerNumber).apply()
 
-    var sessionId: String
+    var sessid: String
         get() {
             val temp = sharedPreferences.getString(KEY_USER_SESSION_ID, "")
             return temp ?: ""

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -601,11 +601,7 @@ class Call(
         // NOOP
     }
 
-    override fun onSessionIdReceived(jsonObject: JsonObject) {
-        // NOOP
-    }
-
-    override fun onGatewayStateReceived(gatewayState: String, sessionId: String?) {
+    override fun onGatewayStateReceived(gatewayState: String, receivedSessionId: String?) {
         // NOOP
     }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -19,7 +19,6 @@ import com.telnyx.webrtc.sdk.socket.TxSocketListener
 import com.telnyx.webrtc.sdk.utilities.encodeBase64
 import com.telnyx.webrtc.sdk.verto.receive.*
 import com.telnyx.webrtc.sdk.verto.send.*
-import io.ktor.util.*
 import org.webrtc.IceCandidate
 import org.webrtc.SessionDescription
 import timber.log.Timber
@@ -120,7 +119,7 @@ class Call(
                     id = uuid,
                     method = SocketMethod.INVITE.methodName,
                     params = CallParams(
-                        sessionId = sessionId,
+                        sessid = sessionId,
                         sdp = peerConnection?.getLocalDescription()?.description.toString(),
                         dialogParams = CallDialogParams(
                             callerIdName = callerName,
@@ -158,7 +157,7 @@ class Call(
             val answerBodyMessage = SendingMessageBody(
                 uuid, SocketMethod.ANSWER.methodName,
                 CallParams(
-                    sessionId = sessionId,
+                    sessid = sessionId,
                     sdp = sessionDescriptionString,
                     dialogParams = CallDialogParams(
                         callId = callId,
@@ -256,7 +255,7 @@ class Call(
             id = uuid,
             method = SocketMethod.MODIFY.methodName,
             params = ModifyParams(
-                sessionId = sessionId,
+                sessid = sessionId,
                 action = holdAction,
                 dialogParams = CallDialogParams(
                     callId = callId,
@@ -279,7 +278,7 @@ class Call(
             id = uuid,
             method = SocketMethod.INFO.methodName,
             params = InfoParams(
-                sessionId = sessionId,
+                sessid = sessionId,
                 dtmf = tone,
                 dialogParams = CallDialogParams(
                     callId = callId,

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -167,10 +167,10 @@ class TelnyxClient(
             credentialSessionConfig?.let {
                 credentialLogin(it)
             } ?: tokenLogin(tokenSessionConfig!!)
-        }
 
-        // Change an ongoing call's socket to the new socket.
-        call?.let { call?.socket = socket }
+            // Change an ongoing call's socket to the new socket.
+            call?.let { call?.socket = socket }
+        }
     }
 
     init {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -65,6 +65,7 @@ class TelnyxClient(
     private var mediaPlayer: MediaPlayer? = null
 
     private var sessionId: String? = null
+    var sessid: String // sessid used to recover calls when reconnecting
     val socketResponseLiveData = MutableLiveData<SocketResponse<ReceivedMessageBody>>()
     val wsMessagesResponseLiveDate = MutableLiveData<JsonObject>()
 
@@ -177,6 +178,9 @@ class TelnyxClient(
         if (!BuildConfig.IS_TESTING.get()) {
             Bugsnag.start(context)
         }
+
+        // Generate random UUID for sessid param, convert it to string and set globally
+        sessid = UUID.randomUUID().toString()
 
         socket = TxSocket(
             host_address = Config.TELNYX_PROD_HOST_ADDRESS,
@@ -333,7 +337,8 @@ class TelnyxClient(
                 login = user,
                 passwd = password,
                 userVariables = notificationJsonObject,
-                loginParams = arrayListOf()
+                loginParams = arrayListOf(),
+                sessid = sessid
             )
         )
 
@@ -374,7 +379,8 @@ class TelnyxClient(
                 login = null,
                 passwd = null,
                 userVariables = notificationJsonObject,
-                loginParams = arrayListOf()
+                loginParams = arrayListOf(),
+                sessid = sessid
             )
         )
         socket.send(loginMessage)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -81,17 +81,22 @@ class TelnyxClient(
      * Will return null if there has been no session established (No successful connection and login)
      * @return [Call]
      */
-    private fun buildCall(): Call {
-        sessid.let {
-            return Call(
-                context,
-                this,
-                socket,
-                sessid,
-                audioManager!!,
-                providedTurn!!,
-                providedStun!!
-            )
+    private fun buildCall(): Call? {
+        if (!BuildConfig.IS_TESTING.get()) {
+            sessid.let {
+                return Call(
+                    context,
+                    this,
+                    socket,
+                    sessid,
+                    audioManager!!,
+                    providedTurn!!,
+                    providedStun!!
+                )
+            }
+        } else {
+            // We are testing, and will instead return a mocked call.
+            return null
         }
     }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -121,7 +121,7 @@ class TelnyxClient(
     private val networkCallback = object : ConnectivityHelper.NetworkCallback() {
         override fun onNetworkAvailable() {
             Timber.d("[%s] :: There is a network available", this@TelnyxClient.javaClass.simpleName)
-            // There is no ongoing call which this reconnect logic will mess with
+            // User has been logged in
             if (reconnecting && credentialSessionConfig != null || tokenSessionConfig != null) {
                 runBlocking { reconnectToSocket() }
                 reconnecting = false

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/CallState.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/CallState.kt
@@ -19,6 +19,7 @@ package com.telnyx.webrtc.sdk.model
 enum class CallState {
     NEW,
     CONNECTING,
+    RECOVERING,
     RINGING,
     ACTIVE,
     HELD,

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/CauseCode.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/CauseCode.kt
@@ -9,7 +9,7 @@ package com.telnyx.webrtc.sdk.model
  * Enum class to represent the different Cause Codes that are received when an invitation is refused
  * with a given [code]
  *
- * @param code is the numerical representation of the cause, eg. 1 -> USER_BUSY
+ * @param code is the numerical representation of the cause, eg. 17 -> USER_BUSY
  *
  * @property USER_BUSY This cause is used to indicate that the called party is unable to accept another call because the user busy condition has been encountered.
  * @property NORMAL_CLEARING This cause indicates that the call is being cleared because one of the users involved in the call has requested that the call be cleared. Under normal situations, the source of this cause is not the network.
@@ -17,8 +17,8 @@ package com.telnyx.webrtc.sdk.model
  * @property ORIGINATOR_CANCEL This cause indicates that the user initiating the call cancelled it before it was answered
  */
 enum class CauseCode(var code: Int) {
-    USER_BUSY(1),
-    NORMAL_CLEARING(2),
-    INVALID_GATEWAY(3),
-    ORIGINATOR_CANCEL(4)
+    USER_BUSY(17),
+    NORMAL_CLEARING(16),
+    INVALID_GATEWAY(608),
+    ORIGINATOR_CANCEL(487)
 }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SocketMethod.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SocketMethod.kt
@@ -21,6 +21,7 @@ package com.telnyx.webrtc.sdk.model
  */
 enum class SocketMethod(var methodName: String) {
     ANSWER("telnyx_rtc.answer"),
+    ATTACH("telnyx_rtc.attach"),
     INVITE("telnyx_rtc.invite"),
     BYE("telnyx_rtc.bye"),
     MODIFY("telnyx_rtc.modify"),

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -123,8 +123,6 @@ class TxSocket(
                                 val message = result.get("message").asString
                                 if (message == "logged in" && isLoggedIn) {
                                     listener.onClientReady(jsonObject)
-                                } else {
-                                    listener.onSessionIdReceived(jsonObject)
                                 }
                             }
                         }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
@@ -89,4 +89,17 @@ interface TxSocketListener {
      * @see [IceCandidate]
      */
     fun onIceCandidateReceived(iceCandidate: IceCandidate)
+
+    /**
+     * Fires once a connection has been reestablished during an ongoing call and a session
+     * is being reattached
+     * @param jsonObject, the socket response in a jsonObject format
+     */
+    fun onAttachReceived(jsonObject: JsonObject)
+
+    /**
+     * Fires when network has dropped during an ongoing call. Signifies that the SDK will attempt
+     * to recover once network has returned
+     */
+    fun setCallRecovering()
 }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
@@ -21,13 +21,6 @@ interface TxSocketListener {
     fun onClientReady(jsonObject: JsonObject)
 
     /**
-     * Fires once we have received a sessionID from the Telnyx web socket.
-     * @param jsonObject, the socket response in a jsonObject format
-     * @see [TxSocket]
-     */
-    fun onSessionIdReceived(jsonObject: JsonObject)
-
-    /**
      * Fires once a Gateway state has been received. These are used to find a verified registration
      * @param gatewayState, the string representation of the gateway state received from the socket connection
      * @param sessionId, the string representation of the session ID received from the socket connection

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/receive/ReceivedResult.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/receive/ReceivedResult.kt
@@ -46,7 +46,7 @@ data class AnswerResponse(
  * @param sdp the Session Description Protocol that is received as a part of the answer to the call.
  * @param callerIdName the name of the person who sent the invitation
  * @param callerIdNumber the number of the person who sent the invitation
- * @param sessionId the Telnyx Session ID on the socket connection.
+ * @param sessid the Telnyx Session ID on the socket connection.
  */
 @Parcelize
 data class InviteResponse(
@@ -58,6 +58,6 @@ data class InviteResponse(
     val callerIdName: String,
     @SerializedName("callerIdNumber")
     val callerIdNumber: String,
-    @SerializedName("sessionId")
-    val sessionId: String
+    @SerializedName("sessid")
+    val sessid: String
 ) : ReceivedResult(), Parcelable

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/ParamRequest.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/ParamRequest.kt
@@ -15,11 +15,12 @@ data class LoginParam(
     val login: String?,
     val passwd: String?,
     val userVariables: JsonObject,
-    val loginParams: ArrayList<Any>?
+    val loginParams: ArrayList<Any>?,
+    val sessid: String
 ) : ParamRequest()
 
 data class CallParams(
-    val sessionId: String,
+    val sessid: String,
     val sdp: String,
     @SerializedName("User-Agent")
     val userAgent: String = "Android-" + BuildConfig.SDK_VERSION.toString(),
@@ -27,20 +28,20 @@ data class CallParams(
 ) : ParamRequest()
 
 data class ByeParams(
-    val sessionId: String,
+    val sessid: String,
     val causeCode: Int,
     val cause: String,
     val dialogParams: ByeDialogParams
 ) : ParamRequest()
 
 data class ModifyParams(
-    val sessionId: String,
+    val sessid: String,
     val action: String,
     val dialogParams: CallDialogParams
 ) : ParamRequest()
 
 data class InfoParams(
-    val sessionId: String,
+    val sessid: String,
     val dtmf: String,
     val dialogParams: CallDialogParams
 ) : ParamRequest()

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
@@ -40,12 +40,16 @@ class CallTest : BaseTest() {
 
     @MockK
     private lateinit var mockContext: Context
+
     @Spy
     lateinit var client: TelnyxClient
+
     @Spy
     lateinit var socket: TxSocket
+
     @Spy
     lateinit var call: Call
+
     @MockK
     lateinit var audioManager: AudioManager
 
@@ -153,7 +157,8 @@ class CallTest : BaseTest() {
         )
         call.dtmf(UUID.randomUUID(), "2")
         Thread.sleep(1000)
-        Mockito.verify(client.socket, Mockito.times(1)).send(ArgumentMatchers.any(SendingMessageBody::class.java))
+        Mockito.verify(client.socket, Mockito.times(1))
+            .send(ArgumentMatchers.any(SendingMessageBody::class.java))
     }
 
     @Test
@@ -205,24 +210,6 @@ class CallTest : BaseTest() {
                 Call(mockContext, client, client.socket, "123", audioManager)
             )
             call.onClientReady(JsonObject())
-        }
-    }
-
-    @Test
-    fun `NOOP onSessionIdReceived test`() {
-        assertDoesNotThrow {
-            client = Mockito.spy(TelnyxClient(mockContext))
-            client.socket = Mockito.spy(
-                TxSocket(
-                    host_address = "rtc.telnyx.com",
-                    port = 14938,
-                )
-            )
-
-            call = Mockito.spy(
-                Call(mockContext, client, client.socket, "123", audioManager)
-            )
-            call.onSessionIdReceived(JsonObject())
         }
     }
 

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -405,18 +405,6 @@ class TelnyxClientTest : BaseTest() {
     }*/
 
     @Test
-    fun `Check error socket Error response live data is sent if a sessionID is not sent`() {
-        client = Mockito.spy(TelnyxClient(mockContext))
-        // Lazily call buildCall() by calling arbitrary Call function
-        // -- call being created before connect will result in the desired socket response
-        client.call?.getTelnyxSessionId()
-        assertEquals(
-            client.socketResponseLiveData.getOrAwaitValue(),
-            SocketResponse.error("Session ID is not set, failed to build call")
-        )
-    }
-
-    @Test
     fun `Test getSocketResponse returns appropriate LiveData`() {
         client = Mockito.spy(TelnyxClient(mockContext))
         val socketResponse = client.getSocketResponse()


### PR DESCRIPTION
[WebRTC-2102 - implement reconnect functionality with attach flow.](https://telnyx.atlassian.net/browse/WEBRTC-2102)

---
<!-- Describe your changed here -->
This PR implements the attach flow so that calls can be reconnected when network drops. 

When network drops, the SDK needs to reconnect to a socket and log in. When this is done an Attach message will be received on the websocket, this can be responded to in the same fashion as a call invitation (creating a Peer Connection, adding ice candidates, sending a reply socket message etc).

The mechanism for the reconnection always existed (see line 121 in TelnyxClient), however, we were not receiving an attach message because a sessid param was not being included in the login message -- we were sending sessionId instead.

Because of this, this PR also replaces all instances of sessionId with sessid to align with the JS SDK. 

Lastly, the cause codes that we were using on the Android SDK were wrong. These are now aligned with iOS and Android. 

## :older_man: :baby: Behaviors
### Before changes
- Sending session ID instead of sessid
- Incorrect Cause Codes
- No attach message being received when network dropped (because of sessid)
- Not replying to attach messages

### After changes
- Replaced all instances of sessionId with sessid
- Fixed Cause Codes to align with iOS and JS
- Attach message now received when network drops and recovers during ongoing call
- Attach message is replied to with a listener call back
- New state implemented (RECOVERING) which is triggered when network drops while on a call

## ✋ Manual testing
1. Log into web dialer
2. Launch Android Sample app
3. Create a call between the two
4. Disconnect all network on your mobile device and wait a few seconds
5. Reenable network
6. Audio should soon flow from both ends once the reattach process completes 
