### PR TITLE
Is/bug fix/call state fix for caller

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -435,6 +435,7 @@ class Call(
                         )
                     )
                 )
+                callStateLiveData.postValue(CallState.ACTIVE)
             }
             else -> {
                 // There was no SDP in the response, there was an error.

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -555,6 +555,15 @@ class Call(
         } else {
             UUID.randomUUID()
         }
+        client.socketResponseLiveData.postValue(
+            SocketResponse.messageReceived(
+                ReceivedMessageBody(
+                    SocketMethod.RINGING.methodName,
+                    null
+                )
+            )
+        )
+
     }
 
     override fun onIceCandidateReceived(iceCandidate: IceCandidate) {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -221,6 +221,15 @@ class Call(
                 )
             )
         )
+        // send bye message to the UI
+        client.socketResponseLiveData.postValue(
+            SocketResponse.messageReceived(
+                ReceivedMessageBody(
+                    SocketMethod.BYE.methodName,
+                    null
+                )
+            )
+        )
         callStateLiveData.postValue(CallState.DONE)
         client.removeFromCalls(callId)
         client.callNotOngoing()

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -695,6 +695,14 @@ class TelnyxClient(
             jsonObject
         )
         call?.onRingingReceived(jsonObject)
+        socketResponseLiveData.postValue(
+            SocketResponse.messageReceived(
+                ReceivedMessageBody(
+                    SocketMethod.RINGING.methodName,
+                    null
+                )
+            )
+        )
     }
 
     override fun onIceCandidateReceived(iceCandidate: IceCandidate) {


### PR DESCRIPTION
[WebRTC-Clevio -  Call State is Connecting on Caller side whilst call is Active](https://telnyx.atlassian.net/jira/software/c/projects/TELAPPS/boards/98?modal=detail&selectedIssue=TELAPPS-4455&assignee=712020%3Ab1a9b25a-52c8-40d6-b13e-e80d50ca5db6)

---
<!-- Describe your changed here -->


## :older_man: :baby: Behaviors
### Before changes
Call state is connecting during active calls on the callers side. 

### After changes
1. Call state is Active for all active calls.
2. Ringing state is post to the UI as well, when there's a valid incoming or outgoing call, for either caller or callee
## ✋ Manual testing
1. Tested using the SDK in an implementing application 

