### PR TITLE
Native Crash on Android When ending a Call not yet Ringing/(Ending calls in quick succession)

### DIFF
--- a/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
@@ -74,7 +74,7 @@ class MainActivity : AppCompatActivity() {
 
         FirebaseApp.initializeApp(this)
 
-        mainViewModel = ViewModelProvider(this@MainActivity).get(MainViewModel::class.java)
+        mainViewModel = ViewModelProvider(this@MainActivity)[MainViewModel::class.java]
 
         checkPermissions()
         initViews()

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -237,6 +237,7 @@ class Call(
         resetCallOptions()
         client.stopMediaPlayer()
         peerConnection?.release()
+        peerConnection = null
     }
 
     /**


### PR DESCRIPTION
[WebRTC-Native Crash on Android When ending a Call not yet Ringing/(Ending calls in quick succession) - Ticket Description.](https://telnyx.atlassian.net/jira/software/c/projects/TELAPPS/boards/98?modal=detail&selectedIssue=TELAPPS-4488&assignee=712020%3Ab1a9b25a-52c8-40d6-b13e-e80d50ca5db6)

---
<!-- Describe your changed here -->
Dispose off Peer_connection after every endCall


## ✋ Manual testing
1. End call does not produce the `nativeClose` Crash

