### PR TITLE
Feat/engdesk 37034

### DIFF
--- a/app/src/main/java/com/telnyx/webrtc/sdk/NotificationsService.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/NotificationsService.kt
@@ -146,8 +146,8 @@ class NotificationsService : Service() {
 
         val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_stat_contact_phone)
-            .setContentTitle("Incoming Call")
-            .setContentText("Incoming call from: ")
+            .setContentTitle("Incoming Call : ${txPushMetaData.callerName}")
+            .setContentText("Incoming call from: ${txPushMetaData.callerNumber} ")
             .setPriority(NotificationCompat.PRIORITY_MAX)
             .setContentIntent(pendingIntent)
             .setSound(customSoundUri)

--- a/app/src/main/java/com/telnyx/webrtc/sdk/utility/MyFirebaseMessagingService.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/utility/MyFirebaseMessagingService.kt
@@ -16,8 +16,6 @@ import timber.log.Timber
 
 class MyFirebaseMessagingService : FirebaseMessagingService() {
 
-
-
     /**
      * Called when message is received.
      *
@@ -40,24 +38,14 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
                 putExtra("action", NotificationsService.STOP_ACTION)
             }
             serviceIntent.setAction(NotificationsService.STOP_ACTION)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                startForegroundService(serviceIntent)
-            }else {
-                startService(serviceIntent)
-            }
+            startMessagingService(serviceIntent)
             return
-        }else{
-            Timber.d("No Missed Call")
         }
 
         val serviceIntent = Intent(this, NotificationsService::class.java).apply {
             putExtra("metadata", metadata)
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            startForegroundService(serviceIntent)
-        }else {
-            startService(serviceIntent)
-        }
+        startMessagingService(serviceIntent)
     }
 
 
@@ -81,12 +69,12 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
         Timber.d("sendRegistrationTokenToServer($token)")
     }
 
-    /**
-     * Create and show a simple notification containing the received FCM message.
-     *
-     * @param messageBody FCM message body received.
-     */
-    private fun sendNotification(messageBody: String) {
+    private fun startMessagingService(serviceIntent: Intent) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(serviceIntent)
+        } else {
+            startService(serviceIntent)
+        }
     }
 
     companion object {

--- a/docs-markdown/push-notification/app-setup.md
+++ b/docs-markdown/push-notification/app-setup.md
@@ -74,3 +74,22 @@ You are now ready to receive push notifications via Firebase Messaging Service.
            android:foregroundServiceType="phoneCall"
            android:exported="true" />
    ```
+   ### Handling Missed Call Notifications
+   The backend sends a missed call notification when a call is ended while the socket is not yet connected. It comes with the `Missed call!` message. In order to handle missed call notifications, you can use the following code snippet in the FirebaseMessagingService class:
+   ``` kotlin
+        const val Missed_Call = "Missed call!"
+        val params = remoteMessage.data
+        val objects = JSONObject(params as Map<*, *>)
+        val metadata = objects.getString("metadata")
+        val isMissedCall: Boolean = objects.getString("message").equals(Missed_Call) // 
+
+        if(isMissedCall){
+            Timber.d("Missed Call")
+            val serviceIntent = Intent(this, NotificationsService::class.java).apply {
+                putExtra("action", NotificationsService.STOP_ACTION)
+            }
+            serviceIntent.setAction(NotificationsService.STOP_ACTION)
+            startMessagingService(serviceIntent)
+            return
+        }
+   ```


### PR DESCRIPTION
[ENGDESK-37034](https://telnyx.atlassian.net/browse/ENGDESK-37034)
APP keeps ringing after Caller CANCELs and Missed Call notification is successfully sent. 
---
<!-- Describe your changed here -->
This has been  handled in the FirebaseMessagingService of the demo App to CANCEL push notification if a missed call notification is sent

## :older_man: :baby: Behaviors
### Before changes
There would be a second push notification if this was not handled on the client side.

## ✋ Manual testing
Call ends when there's a Call end before socket is connected 

[ENGDESK-37034]: https://telnyx.atlassian.net/browse/ENGDESK-37034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## TODO

Backend needs to reformat the incoming call json message for easy access to message keys. 
e,g the miseed call cal notification comes with a message string `message = Missed Call!`