### PR TITLE
WEBRTC-2459: Migrate xmlapp to ViewBinding

### DIFF
--- a/xmlapp/build.gradle
+++ b/xmlapp/build.gradle
@@ -1,0 +1,54 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'org.telnyx.webrtc.xmlapp'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId "org.telnyx.webrtc.xmlapp"
+        minSdk 21
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+    
+    buildFeatures {
+        viewBinding true
+    }
+    
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+}
+
+dependencies {
+    implementation project(':telnyx_rtc')
+    
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.7.6'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.7.6'
+    
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+}

--- a/xmlapp/src/main/java/org/telnyx/webrtc/xmlapp/MainActivity.kt
+++ b/xmlapp/src/main/java/org/telnyx/webrtc/xmlapp/MainActivity.kt
@@ -5,16 +5,42 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.navigation.NavController
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.ui.AppBarConfiguration
+import androidx.navigation.ui.setupActionBarWithNavController
+import org.telnyx.webrtc.xmlapp.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityMainBinding
+    private lateinit var navController: NavController
+    private lateinit var appBarConfiguration: AppBarConfiguration
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContentView(R.layout.activity_main)
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.main) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
+
+        // Set up Navigation
+        val navHostFragment = supportFragmentManager
+            .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+        navController = navHostFragment.navController
+
+        appBarConfiguration = AppBarConfiguration(
+            setOf(R.id.loginFragment)
+        )
+
+        setupActionBarWithNavController(navController, appBarConfiguration)
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        return navController.navigateUp() || super.onSupportNavigateUp()
     }
 }

--- a/xmlapp/src/main/java/org/telnyx/webrtc/xmlapp/login/LoginBottomSheetFragment.kt
+++ b/xmlapp/src/main/java/org/telnyx/webrtc/xmlapp/login/LoginBottomSheetFragment.kt
@@ -4,58 +4,66 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
-import org.telnyx.webrtc.xmlapp.R
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import org.telnyx.webrtc.xmlapp.databinding.FragmentLoginBottomSheetBinding
 
+class LoginBottomSheetFragment : BottomSheetDialogFragment() {
+    private var _binding: FragmentLoginBottomSheetBinding? = null
+    private val binding get() = _binding!!
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentLoginBottomSheetBinding.inflate(inflater, container, false)
+        return binding.root
+    }
 
-/**
- * A simple [Fragment] subclass.
- * Use the [LoginBottomSheetFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
-class LoginBottomSheetFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
+        setupViews()
+        setupListeners()
+    }
+
+    private fun setupViews() {
+        binding.apply {
+            // Set up RecyclerView
+            allProfiles.layoutManager = LinearLayoutManager(requireContext())
+            // TODO: Set up adapter for profiles
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_login_bottom_sheet, container, false)
+    private fun setupListeners() {
+        binding.apply {
+            // Close button click
+            headerInfo.getChildAt(1).setOnClickListener {
+                dismiss()
+            }
+
+            // Add new profile button click
+            outlinedButton.setOnClickListener {
+                // TODO: Implement add new profile logic
+            }
+
+            // Confirm button click
+            connect.setOnClickListener {
+                // TODO: Implement profile selection confirmation
+                dismiss()
+            }
+
+            // Cancel button click
+            cancel.setOnClickListener {
+                dismiss()
+            }
+        }
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment LoginBottomSheerFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            LoginBottomSheetFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
-            }
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/xmlapp/src/main/java/org/telnyx/webrtc/xmlapp/login/LoginFragment.kt
+++ b/xmlapp/src/main/java/org/telnyx/webrtc/xmlapp/login/LoginFragment.kt
@@ -5,57 +5,62 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import org.telnyx.webrtc.xmlapp.R
+import org.telnyx.webrtc.xmlapp.databinding.FragmentLoginBinding
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-
-/**
- * A simple [Fragment] subclass.
- * Use the [LoginFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class LoginFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
+    private var _binding: FragmentLoginBinding? = null
+    private val binding get() = _binding!!
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentLoginBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupViews()
+        setupListeners()
+    }
+
+    private fun setupViews() {
+        // Initial view setup
+        binding.apply {
+            // Set initial profile ID
+            profileInfo.profileId.text = "xd34343"
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_login, container, false)
-    }
+    private fun setupListeners() {
+        binding.apply {
+            // Switch profile button click
+            profileInfo.outlinedButton.setOnClickListener {
+                findNavController().navigate(R.id.action_loginFragment_to_loginBottomSheetFragment)
+            }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment LoginFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            LoginFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
+            // Connect button click
+            connect.setOnClickListener {
+                // TODO: Implement connection logic
+            }
+
+            // Session switch toggle
+            sessionSwitch.getChildAt(0).setOnClickListener { switchView ->
+                if (switchView is com.google.android.material.switchmaterial.SwitchMaterial) {
+                    val textView = sessionSwitch.getChildAt(1) as android.widget.TextView
+                    textView.text = if (switchView.isChecked) getString(R.string.on) else getString(R.string.off)
                 }
             }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/xmlapp/src/main/res/layout/activity_main.xml
+++ b/xmlapp/src/main/res/layout/activity_main.xml
@@ -7,13 +7,16 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:defaultNavHost="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/nav_graph" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/xmlapp/src/main/res/navigation/nav_graph.xml
+++ b/xmlapp/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/loginFragment">
+
+    <fragment
+        android:id="@+id/loginFragment"
+        android:name="org.telnyx.webrtc.xmlapp.login.LoginFragment"
+        android:label="Login"
+        tools:layout="@layout/fragment_login">
+        <action
+            android:id="@+id/action_loginFragment_to_loginBottomSheetFragment"
+            app:destination="@id/loginBottomSheetFragment" />
+    </fragment>
+
+    <dialog
+        android:id="@+id/loginBottomSheetFragment"
+        android:name="org.telnyx.webrtc.xmlapp.login.LoginBottomSheetFragment"
+        android:label="Login Options"
+        tools:layout="@layout/fragment_login_bottom_sheet" />
+
+</navigation>


### PR DESCRIPTION
## Description
This PR migrates the xmlapp module to use ViewBinding, improving type safety and reducing boilerplate code.

### Changes
- Enable ViewBinding in xmlapp module
- Update MainActivity to use ViewBinding and navigation
- Convert LoginFragment to use ViewBinding
- Convert LoginBottomSheetFragment to use ViewBinding and proper bottom sheet behavior
- Set up navigation between fragments
- Add click listeners and basic UI interactions

### Testing
- [ ] Verify that all views are properly bound using ViewBinding
- [ ] Test navigation between LoginFragment and LoginBottomSheetFragment
- [ ] Verify that all click listeners work as expected
- [ ] Test bottom sheet behavior

Jira: [WEBRTC-2459](https://telnyx.atlassian.net/browse/WEBRTC-2459)

[WEBRTC-2459]: https://telnyx.atlassian.net/browse/WEBRTC-2459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ