### PR TITLE
WEBRTC-2473: Connection Service / Foreground Service implementation for Calls

### DIFF
--- a/app/src/main/java/com/telnyx/webrtc/sdk/utility/telecom/call/TelecomCallService.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/utility/telecom/call/TelecomCallService.kt
@@ -2,13 +2,22 @@ package com.telnyx.webrtc.sdk.utility.telecom.call
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.Service
+import android.content.Context
 import android.content.Intent
+import android.media.AudioManager
+import android.media.RingtoneManager
 import android.net.Uri
 import android.os.Build
 import android.os.IBinder
+import androidx.core.app.NotificationCompat
 import androidx.core.content.PermissionChecker
+import com.telnyx.webrtc.sdk.R
 import com.telnyx.webrtc.sdk.utility.telecom.model.TelecomCall
+import com.telnyx.webrtc.sdk.utility.telecom.model.TelecomCallAction
 import com.telnyx.webrtc.sdk.utility.telecom.model.TelecomCallRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -42,6 +51,9 @@ class TelecomCallService : Service() {
         internal const val ACTION_INCOMING_CALL = "incoming_call"
         internal const val ACTION_OUTGOING_CALL = "outgoing_call"
         internal const val ACTION_UPDATE_CALL = "update_call"
+        
+        private const val NOTIFICATION_CHANNEL_ID = "telnyx_call_service"
+        private const val NOTIFICATION_ID = 1001
     }
 
     private lateinit var notificationManager: TelecomCallNotificationManager
@@ -60,6 +72,25 @@ class TelecomCallService : Service() {
                 telnyxCallManager
             )
 
+        // Create notification channel for Android O and above
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                NOTIFICATION_CHANNEL_ID,
+                "Telnyx Call Service",
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = "Keeps the call active when the screen is locked"
+                setSound(null, null)
+                enableVibration(false)
+            }
+
+            val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        // Start as a foreground service with a persistent notification
+        startForeground(NOTIFICATION_ID, createNotification())
+
         // Observe call status updates once the call is registered and update the service
         telecomRepository.currentCall
             .onEach { call ->
@@ -70,6 +101,18 @@ class TelecomCallService : Service() {
                 stopSelf()
             }
             .launchIn(scope)
+    }
+
+    private fun createNotification(): Notification {
+        return NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+            .setContentTitle("Telnyx Call Service")
+            .setContentText("Keeping your call active")
+            .setSmallIcon(R.drawable.ic_mic)
+            .setOngoing(true)
+            .setCategory(NotificationCompat.CATEGORY_CALL)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .build()
     }
 
     override fun onDestroy() {
@@ -122,8 +165,13 @@ class TelecomCallService : Service() {
 
         scope.launch {
             if (incoming) {
-                // Play ringtone for incoming calls
-                print("Play ringtone?");
+                // Play ringtone for incoming calls using system ringtone
+                val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+                if (audioManager.ringerMode == AudioManager.RINGER_MODE_NORMAL) {
+                    val ringtoneUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
+                    val ringtone = RingtoneManager.getRingtone(applicationContext, ringtoneUri)
+                    ringtone.play()
+                }
             }
 
             launch {
@@ -136,12 +184,12 @@ class TelecomCallService : Service() {
                 )
             }
 
-            //ToDo(Oli: Remove this)
-            /*if (!incoming) {
+            if (!incoming) {
+                // For outgoing calls, activate immediately
                 (telecomRepository.currentCall.value as? TelecomCall.Registered)?.processAction(
                     TelecomCallAction.Activate,
                 )
-            }*/
+            }
         }
     }
 
@@ -156,15 +204,38 @@ class TelecomCallService : Service() {
 
         when (call) {
             is TelecomCall.None -> {
-                // Stop any call tasks, in this demo we stop the audio loop
+                // Stop any call tasks and clean up
+                telnyxCallManager.endCall()
+                stopForeground(STOP_FOREGROUND_REMOVE)
             }
 
             is TelecomCall.Registered -> {
+                // Update the foreground notification with call state
+                val notification = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+                    .setContentTitle("Active Call")
+                    .setContentText(call.callAttributes.displayName)
+                    .setSmallIcon(R.drawable.ic_mic)
+                    .setOngoing(true)
+                    .setCategory(NotificationCompat.CATEGORY_CALL)
+                    .setPriority(NotificationCompat.PRIORITY_HIGH)
+                    .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                    .build()
 
+                startForeground(NOTIFICATION_ID, notification)
+
+                // Handle call state
+                if (call.isActive) {
+                    // Call is active, ensure audio routing is correct
+                    val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+                    audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+                    audioManager.isSpeakerphoneOn = false
+                }
             }
 
             is TelecomCall.Unregistered -> {
                 // Stop service and clean resources
+                telnyxCallManager.endCall()
+                stopForeground(STOP_FOREGROUND_REMOVE)
                 stopSelf()
             }
         }


### PR DESCRIPTION
## Description
This PR implements Android Connection Service and Foreground Service support for calls to ensure they stay active when the screen is locked.

### Changes
1. TelecomCallService:
   - Added foreground service support with persistent notification
   - Implemented proper call state handling
   - Added ringtone for incoming calls
   - Integrated with TelnyxCallManager

2. MainViewModel:
   - Added TelecomCallService integration for outgoing calls
   - Updated call handling to use Connection Service
   - Added proper call state management

3. CallInstanceFragment:
   - Added TelecomCallService integration
   - Improved call state handling
   - Added proper UI state updates

### Testing
- Tested incoming and outgoing calls
- Verified call stays active when screen is locked
- Tested ringtone for incoming calls
- Verified persistent notification
- Tested audio routing and speaker mode

### Related Issues
- Fixes WEBRTC-2473