### PR TITLE
Fix token login section not appearing on toggle

### DIFF
--- a/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
@@ -551,7 +551,7 @@ class MainActivity : AppCompatActivity() {
     private fun listenLoginTypeSwitch() {
         binding.loginSectionId.tokenLoginSwitch.setOnCheckedChangeListener { _, isChecked ->
             if (isChecked) {
-                binding.loginSectionId.loginSectionView.visibility = View.GONE
+                binding.loginSectionId.loginCredentialId.credentialLoginView.visibility = View.GONE
                 binding.loginSectionId.loginTokenId.loginTokenSectionView.visibility = View.VISIBLE
             } else {
                 binding.loginSectionId.loginCredentialId.credentialLoginView.visibility =


### PR DESCRIPTION
[WebRTC-2490 - Fix token login section not appearing on toggle.](https://telnyx.atlassian.net/browse/WEBRTC-2490)

---
<!-- Describe your changed here -->


## :older_man: :baby: Behaviors
### Before changes
- On token connection toggle we were hiding the entire login view (hiding both credential and token login sections)

### After changes
- Now we only hide the credential view - meaning token login still appears

## ✋ Manual testing
1. Use the app
2. Toggle token
3. See token login
4. Toggle back to credential
5. See credential login
