### PR TITLE
fix: post value instead of setting MutableLiveData on each connection

### DIFF
--- a/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainActivity.kt
@@ -265,9 +265,9 @@ class MainActivity : AppCompatActivity() {
 
         }
         Timber.d("Connect to Socket and Observe")
+        observeSocketResponses()
         if (!isDev) {
             mainViewModel.initConnection(
-                applicationContext,
                 null,
                 credentialConfig = credentialConfig,
                 tokenConfig = tokenConfig,
@@ -275,7 +275,6 @@ class MainActivity : AppCompatActivity() {
             )
         } else {
             mainViewModel.initConnection(
-                applicationContext,
                 TxServerConfiguration(host = "rtcdev.telnyx.com"),
                 credentialConfig = credentialConfig,
                 tokenConfig = tokenConfig,
@@ -283,15 +282,15 @@ class MainActivity : AppCompatActivity() {
             )
 
         }
-        observeSocketResponses()
     }
 
     private fun observeSocketResponses() {
+        mainViewModel.initTelnyxClient(this)
         mainViewModel.getSocketResponse()?.observe(
             this,
             object : SocketObserver<ReceivedMessageBody>() {
                 override fun onConnectionEstablished() {
-                    Timber.d("OnConMan")
+                    Timber.d("Connection Established")
 
                 }
 

--- a/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainViewModel.kt
+++ b/app/src/main/java/com/telnyx/webrtc/sdk/ui/MainViewModel.kt
@@ -35,16 +35,16 @@ class MainViewModel @Inject constructor(
     private val holdedCalls = mutableSetOf<Call>()
     private var calls: Map<UUID, Call> = mapOf()
 
+    fun initTelnyxClient(context: Context) {
+        telnyxClient = TelnyxClient(context)
+    }
+
     fun initConnection(
-        context: Context,
         providedServerConfig: TxServerConfiguration?,
         credentialConfig: CredentialConfig?,
         tokenConfig: TokenConfig?,
         txPushMetaData: String?
     ) {
-        Timber.e("initConnection")
-        telnyxClient = TelnyxClient(context)
-
         providedServerConfig?.let {
             telnyxClient?.connect(it, credentialConfig!!, txPushMetaData, true)
         } ?: run {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -563,8 +563,7 @@ class TelnyxClient(
         txPushMetaData: String? = null,
     ) {
 
-        socketResponseLiveData =
-            MutableLiveData<SocketResponse<ReceivedMessageBody>>(SocketResponse.initialised())
+        socketResponseLiveData.postValue(SocketResponse.initialised())
         waitingForReg = true
         invalidateGatewayResponseTimer()
         resetGatewayCounters()
@@ -617,8 +616,7 @@ class TelnyxClient(
         autoLogin: Boolean = true,
     ) {
 
-        socketResponseLiveData =
-            MutableLiveData<SocketResponse<ReceivedMessageBody>>(SocketResponse.initialised())
+        socketResponseLiveData.postValue(SocketResponse.initialised())
         waitingForReg = true
         invalidateGatewayResponseTimer()
         resetGatewayCounters()
@@ -680,8 +678,7 @@ class TelnyxClient(
         autoLogin: Boolean = true,
     ) {
 
-        socketResponseLiveData =
-            MutableLiveData<SocketResponse<ReceivedMessageBody>>(SocketResponse.initialised())
+        socketResponseLiveData.postValue(SocketResponse.initialised())
         waitingForReg = true
         invalidateGatewayResponseTimer()
         resetGatewayCounters()


### PR DESCRIPTION
[WebRTC-2491](https://telnyx.atlassian.net/browse/WEBRTC-2491)

---
<!-- Describe your changed here -->


## :older_man: :baby: Behaviors
### Before changes
Any listeners declared before connecting would not receive events. 

### After changes
- We now post value instead of replace so that any previously established listeners receive events rather than being essentially orphaned. 

We now can follow the generally accepted pattern of:

1. Setup Listeners
2. Connect

instead of

1. Connect
2. Setup listeners. 

## ✋ Manual testing
1. Launch app
2. Connect
3. Make sure events are flowing 
