### PR TITLE
WEBRTC-2538: Fix XML demo app crash during login

### DIFF
--- a/xml_app/src/main/AndroidManifest.xml
+++ b/xml_app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.MANAGE_OWN_CALLS"/>
 
     <application
+        android:name=".TelnyxXmlApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/xml_app/src/main/java/org/telnyx/webrtc/xml_app/TelnyxXmlApplication.kt
+++ b/xml_app/src/main/java/org/telnyx/webrtc/xml_app/TelnyxXmlApplication.kt
@@ -1,0 +1,11 @@
+package org.telnyx.webrtc.xml_app
+
+import android.app.Application
+import com.google.firebase.FirebaseApp
+
+class TelnyxXmlApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        FirebaseApp.initializeApp(this)
+    }
+}


### PR DESCRIPTION
## Description
This PR fixes the crash in the XML demo app that occurs during login due to uninitialized Firebase.

### Changes
- Added TelnyxXmlApplication class to initialize Firebase
- Updated AndroidManifest.xml to use the custom Application class

### Issue
The app was crashing with IllegalStateException because FirebaseApp was not initialized before accessing FirebaseMessaging.getInstance().

### Testing
1. Launch the XML demo app
2. Attempt to log in
3. Verify that the app no longer crashes

Fixes WEBRTC-2538