### PR TITLE
WEBRTC-2538: Fix XML demo app crash during login

### DIFF
--- a/xml_app/build.gradle.kts
+++ b/xml_app/build.gradle.kts
@@ -4,6 +4,7 @@ import java.util.*
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("com.google.gms.google-services")
 }
 
 android {
@@ -13,7 +14,7 @@ android {
     buildFeatures.buildConfig  = true
 
     defaultConfig {
-        applicationId = "org.telnyx.webrtc.xmlapp"
+        applicationId = "org.telnyx.webrtc.xml_app"
         minSdk = 27
         targetSdk = 35
         versionCode = 1

--- a/xml_app/google-services.json
+++ b/xml_app/google-services.json
@@ -1,0 +1,126 @@
+{
+  "project_info": {
+    "project_number": "894569387136",
+    "project_id": "telnyx-webrtc-notifications",
+    "storage_bucket": "telnyx-webrtc-notifications.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:894569387136:android:3c87242281f66d64c18265",
+        "android_client_info": {
+          "package_name": "com.telnyx.pushnotifications.call"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "894569387136-sfen79l81ptf6b884d8qma14r34uhred.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyA90_8C7Yv5JGxNOqKdQo242Y2XLfm_sb8"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "894569387136-sfen79l81ptf6b884d8qma14r34uhred.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:894569387136:android:f2deb7d5d5b8b131c18265",
+        "android_client_info": {
+          "package_name": "com.telnyx.telnyx_flutter_webrtc"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "894569387136-sfen79l81ptf6b884d8qma14r34uhred.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyA90_8C7Yv5JGxNOqKdQo242Y2XLfm_sb8"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "894569387136-sfen79l81ptf6b884d8qma14r34uhred.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:894569387136:android:ba55aa224418e38cc18265",
+        "android_client_info": {
+          "package_name": "com.telnyx.webrtc.sdk"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "894569387136-sfen79l81ptf6b884d8qma14r34uhred.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyA90_8C7Yv5JGxNOqKdQo242Y2XLfm_sb8"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "894569387136-sfen79l81ptf6b884d8qma14r34uhred.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:894569387136:android:0f40f0c9dc339ee1c18265",
+        "android_client_info": {
+          "package_name": "org.telnyx.webrtc.compose_app"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "894569387136-sfen79l81ptf6b884d8qma14r34uhred.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyA90_8C7Yv5JGxNOqKdQo242Y2XLfm_sb8"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "894569387136-sfen79l81ptf6b884d8qma14r34uhred.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/xml_app/google-services.json
+++ b/xml_app/google-services.json
@@ -120,6 +120,35 @@
           ]
         }
       }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:894569387136:android:0f40f0c9dc339ee1c18265",
+        "android_client_info": {
+          "package_name": "org.telnyx.webrtc.xml_app"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "894569387136-sfen79l81ptf6b884d8qma14r34uhred.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyA90_8C7Yv5JGxNOqKdQo242Y2XLfm_sb8"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "894569387136-sfen79l81ptf6b884d8qma14r34uhred.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
     }
   ],
   "configuration_version": "1"

--- a/xml_app/src/main/java/org/telnyx/webrtc/xml_app/MainActivity.kt
+++ b/xml_app/src/main/java/org/telnyx/webrtc/xml_app/MainActivity.kt
@@ -51,6 +51,12 @@ class MainActivity : AppCompatActivity(), DefaultLifecycleObserver {
         FirebaseApp.initializeApp(this)
         lifecycle.addObserver(this)
 
+        lifecycleScope.launch {
+            telnyxViewModel.initProfile(this@MainActivity)
+            checkPermission()
+            handleCallNotification(intent)
+        }
+
         enableEdgeToEdge()
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
@@ -69,12 +75,6 @@ class MainActivity : AppCompatActivity(), DefaultLifecycleObserver {
         appBarConfiguration = AppBarConfiguration(
             setOf(R.id.loginFragment)
         )
-
-        lifecycleScope.launch {
-            telnyxViewModel.initProfile(this@MainActivity)
-            checkPermission()
-            handleCallNotification(intent)
-        }
         
         setupGestureDetector()
         bindEvents()

--- a/xml_app/src/main/java/org/telnyx/webrtc/xml_app/MainActivity.kt
+++ b/xml_app/src/main/java/org/telnyx/webrtc/xml_app/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
+import com.google.firebase.FirebaseApp
 import com.karumi.dexter.Dexter
 import com.karumi.dexter.MultiplePermissionsReport
 import com.karumi.dexter.PermissionToken
@@ -47,6 +48,7 @@ class MainActivity : AppCompatActivity(), DefaultLifecycleObserver {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super<AppCompatActivity>.onCreate(savedInstanceState)
+        FirebaseApp.initializeApp(this)
         lifecycle.addObserver(this)
 
         enableEdgeToEdge()
@@ -68,8 +70,12 @@ class MainActivity : AppCompatActivity(), DefaultLifecycleObserver {
             setOf(R.id.loginFragment)
         )
 
-        checkPermission()
-        handleCallNotification(intent)
+        lifecycleScope.launch {
+            telnyxViewModel.initProfile(this@MainActivity)
+            checkPermission()
+            handleCallNotification(intent)
+        }
+        
         setupGestureDetector()
         bindEvents()
     }


### PR DESCRIPTION
## Description
This PR fixes the crash in the XML demo app that occurs during login due to uninitialized Firebase.

### Changes
- Added Firebase initialization in MainActivity
- Added initProfile call in a coroutine, similar to how it is done in the compose_app module

### Issue
The app was crashing with IllegalStateException because FirebaseApp was not initialized before accessing FirebaseMessaging.getInstance().

### Testing
1. Launch the XML demo app
2. Attempt to log in
3. Verify that the app no longer crashes

Fixes WEBRTC-2538