### PR TITLE
WEBRTC-2546: Android - Adding reconnection time out

### DIFF
--- a/compose_app/src/main/java/org/telnyx/webrtc/compose_app/MainActivity.kt
+++ b/compose_app/src/main/java/org/telnyx/webrtc/compose_app/MainActivity.kt
@@ -129,18 +129,3 @@ class MainActivity : ComponentActivity(), DefaultLifecycleObserver {
     }
 }
 
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    TelnyxAndroidWebRTCSDKTheme {
-        Greeting("Android")
-    }
-}

--- a/telnyx_rtc/CHANGELOG.md
+++ b/telnyx_rtc/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.6.0](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/1.5.0) (2025-03-07)
+
+### Enhancement
+- Added reconnect timeout functionality to handle call reconnection failures.
+
 ## [1.5.0](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/1.5.0) (2025-03-07)
 
 ### Enhancement

--- a/telnyx_rtc/build.gradle
+++ b/telnyx_rtc/build.gradle
@@ -14,9 +14,9 @@ apply plugin: 'maven-publish'
 android {
     namespace 'com.telnyx.webrtc.sdk.telnyx_rtc'
 }
- 01
+
 def getVersionName = { ->
-    return "1.4.4"
+    return "1.6.0"
 }
 
 def getArtifactId = { ->

--- a/telnyx_rtc/build.gradle
+++ b/telnyx_rtc/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'maven-publish'
 android {
     namespace 'com.telnyx.webrtc.sdk.telnyx_rtc'
 }
-
+ 01
 def getVersionName = { ->
     return "1.4.4"
 }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.asLiveData
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonSyntaxException
+import com.telnyx.webrtc.sdk.TelnyxClient.Companion.TIMEOUT_DIVISOR
 import com.telnyx.webrtc.sdk.model.CallState
 import com.telnyx.webrtc.sdk.model.SocketMethod
 import com.telnyx.webrtc.sdk.peer.Peer
@@ -361,7 +362,7 @@ data class Call(
      */
     fun setReconnectionTimeout() {
         mutableCallStateFlow.value = CallState.ERROR
-        Logger.e(null,"Call reconnection timed out after ${TelnyxClient.RECONNECT_TIMEOUT/1000} seconds")
+        Logger.e(null,"Call reconnection timed out after ${TelnyxClient.RECONNECT_TIMEOUT/TIMEOUT_DIVISOR} seconds")
     }
 
 }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -354,6 +354,13 @@ data class Call(
     fun setCallRecovering() {
         mutableCallStateFlow.value  = CallState.RECONNECTING
     }
-
+    
+    /**
+     * Sets the call state to ERROR when reconnection timeout occurs
+     */
+    fun setReconnectionTimeout() {
+        mutableCallStateFlow.value = CallState.ERROR
+        Timber.e("Call reconnection timed out after ${TelnyxClient.RECONNECT_TIMEOUT/1000} seconds")
+    }
 
 }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -16,6 +16,7 @@ import com.telnyx.webrtc.sdk.model.CallState
 import com.telnyx.webrtc.sdk.model.SocketMethod
 import com.telnyx.webrtc.sdk.peer.Peer
 import com.telnyx.webrtc.sdk.socket.TxSocket
+import com.telnyx.webrtc.sdk.utilities.Logger
 import com.telnyx.webrtc.sdk.verto.receive.*
 import com.telnyx.webrtc.sdk.verto.send.*
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -360,7 +361,7 @@ data class Call(
      */
     fun setReconnectionTimeout() {
         mutableCallStateFlow.value = CallState.ERROR
-        Timber.e("Call reconnection timed out after ${TelnyxClient.RECONNECT_TIMEOUT/1000} seconds")
+        Logger.e(null,"Call reconnection timed out after ${TelnyxClient.RECONNECT_TIMEOUT/1000} seconds")
     }
 
 }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -95,7 +95,10 @@ class TelnyxClient(
         const val RECONNECT_DELAY: Long = 1000
         
         /** Timeout in milliseconds for reconnection attempts (60 seconds) */
-        const val RECONNECT_TIMEOUT: Long = 10000
+        const val RECONNECT_TIMEOUT: Long = 60000
+
+        /** Timeout dividend*/
+        const val TIMEOUT_DIVISOR: Long = 1000
     }
 
     private var credentialSessionConfig: CredentialConfig? = null
@@ -1345,7 +1348,7 @@ class TelnyxClient(
                     getActiveCalls().forEach { (_, call) ->
                         call.setReconnectionTimeout()
                     }
-                    socketResponseLiveData.postValue(SocketResponse.error("Reconnection timeout after ${RECONNECT_TIMEOUT/1000} seconds"))
+                    socketResponseLiveData.postValue(SocketResponse.error("Reconnection timeout after ${RECONNECT_TIMEOUT/TIMEOUT_DIVISOR} seconds"))
 
                     // Reset reconnection state
                     reconnecting = false
@@ -1355,7 +1358,7 @@ class TelnyxClient(
                 // If we're no longer reconnecting, cancel the timer
                 cancelReconnectionTimer()
             }
-        }, RECONNECT_TIMEOUT) // Check every second
+        }, credentialSessionConfig?.reconnectionTimeout ?: tokenSessionConfig?.reconnectionTimeout ?: RECONNECT_TIMEOUT) // Check every second
     }
     
     /**

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxConfig.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxConfig.kt
@@ -46,7 +46,8 @@ data class CredentialConfig(
     val logLevel: LogLevel = LogLevel.NONE,
     val customLogger: TxLogger? = null,
     val autoReconnect: Boolean = false,
-    val debug: Boolean = false
+    val debug: Boolean = false,
+    val reconnectionTimeout: Long = 60000
 ) : TelnyxConfig()
 
 /**
@@ -73,5 +74,6 @@ data class TokenConfig(
     val logLevel: LogLevel = LogLevel.NONE,
     val customLogger: TxLogger? = null,
     val autoReconnect: Boolean = true,
-    val debug: Boolean = false
+    val debug: Boolean = false,
+    val reconnectionTimeout: Long = 60000
 ) : TelnyxConfig()

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
@@ -16,6 +16,7 @@ import com.telnyx.webrtc.sdk.Config.USERNAME
 import com.telnyx.webrtc.sdk.TelnyxClient
 import com.telnyx.webrtc.sdk.model.CallState
 import com.telnyx.webrtc.sdk.socket.TxSocket
+import com.telnyx.webrtc.sdk.utilities.Logger
 import org.webrtc.AudioSource
 import org.webrtc.AudioTrack
 import org.webrtc.DataChannel
@@ -382,18 +383,19 @@ internal class Peer(
      * Closes and disposes of current [PeerConnection]
      */
     fun disconnect() {
-        peerConnection?.close()
-        peerConnection?.dispose()
-        peerConnection = null
+        try {
+            peerConnection?.close()
+            peerConnection?.dispose()
+            peerConnection = null
+        }catch (e: IllegalStateException){
+            Logger.e(message = e.toString())
+        }
     }
 
     fun release() {
         if (peerConnection != null) {
             disconnect()
             peerConnectionFactory.dispose()
-        }
-        if (isDebugStats){
-            //stopTimer()
         }
     }
 


### PR DESCRIPTION
## Description
Implements a timeout mechanism for reconnection attempts in the telnyx_rtc module.

## Changes
- Added RECONNECT_TIMEOUT constant (60 seconds)
- Implemented reconnection timer to track duration
- Added timeout handling in network callback methods
- Created setReconnectionTimeout method in Call class
- Added proper error handling and user notification

## Testing
Manually tested by simulating network changes and verifying that calls are properly terminated after 60 seconds of reconnection attempts.


https://github.com/user-attachments/assets/b695eba7-fbbd-4723-a496-a4df0f7274cb



## Jira Ticket
[WEBRTC-2546](https://telnyx.atlassian.net/browse/WEBRTC-2546)

[WEBRTC-2546]: https://telnyx.atlassian.net/browse/WEBRTC-2546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ