### PR TITLE
PSTN call answer from push not connecting

### DIFF
--- a/samples/compose_app/build.gradle.kts
+++ b/samples/compose_app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "org.telnyx.webrtc.compose_app"
         minSdk = 27
         targetSdk = 35
-        versionCode = 7
-        versionName = "7.0"
+        versionCode = 9
+        versionName = "9.0"
 
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/samples/compose_app/src/main/AndroidManifest.xml
+++ b/samples/compose_app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.MANAGE_OWN_CALLS"/>
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 
     <application

--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/MainActivity.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/MainActivity.kt
@@ -87,10 +87,16 @@ class MainActivity : ComponentActivity(), DefaultLifecycleObserver {
             val txPushMetaData =
                 intent.extras?.getString(MyFirebaseMessagingService.TX_PUSH_METADATA)
             Timber.d("Action: $action  ${txPushMetaData ?: "No Metadata"}")
-            if (action == MyFirebaseMessagingService.ACT_ANSWER_CALL) {
-                viewModel.answerIncomingPushCall(this, txPushMetaData)
-            } else if (action == MyFirebaseMessagingService.ACT_REJECT_CALL) {
-                viewModel.rejectIncomingPushCall(this, txPushMetaData)
+            when (action) {
+                MyFirebaseMessagingService.ACT_ANSWER_CALL -> {
+                    viewModel.answerIncomingPushCall(this, txPushMetaData)
+                }
+                MyFirebaseMessagingService.ACT_REJECT_CALL -> {
+                    viewModel.rejectIncomingPushCall(this, txPushMetaData)
+                }
+                MyFirebaseMessagingService.ACT_OPEN_TO_REPLY -> {
+                    viewModel.connectWithLastUsedConfig(this, txPushMetaData)
+                }
             }
         }
     }

--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
@@ -150,6 +150,7 @@ fun HomeScreen(navController: NavHostController, telnyxViewModel: TelnyxViewMode
             }
         },
         bottomBar = {
+            if (callState == CallState.DONE || callState == CallState.ERROR)
             ConnectionStateButton(
                 state = (sessionState is TelnyxSessionState.ClientLoggedIn),
                 telnyxViewModel,

--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/LoginBottomSheet.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/LoginBottomSheet.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import com.telnyx.webrtc.common.model.Profile
 import org.telnyx.webrtc.compose_app.R
@@ -58,6 +59,7 @@ fun CredentialTokenView(
             OutlinedEdiText(
                 text = sipUsername,
                 hint = "SIP Username",
+                imeAction = ImeAction.Next,
                 modifier = Modifier.fillMaxWidth().testTag("sipUsername")
             ) { value ->
                 sipUsername = value
@@ -66,6 +68,7 @@ fun CredentialTokenView(
                 text = sipPassword,
                 hint = "SIP Password",
                 keyboardType = KeyboardType.Password,
+                imeAction = ImeAction.Next,
                 modifier = Modifier.fillMaxWidth().testTag("sipPassword")
             ) { value ->
                 sipPassword = value
@@ -74,6 +77,7 @@ fun CredentialTokenView(
             OutlinedEdiText(
                 text = sipToken,
                 hint = "Token",
+                imeAction = ImeAction.Next,
                 modifier = Modifier.fillMaxWidth()
             ) { value ->
                 sipToken = value
@@ -83,6 +87,7 @@ fun CredentialTokenView(
         OutlinedEdiText(
             text = callerIdName,
             hint = "Caller ID Name",
+            imeAction = ImeAction.Next,
             modifier = Modifier.fillMaxWidth().testTag("callerIDName")
         ) { value ->
             callerIdName = value
@@ -91,6 +96,8 @@ fun CredentialTokenView(
         OutlinedEdiText(
             text = callerIdNumber,
             hint = "Caller ID Number",
+            keyboardType = KeyboardType.Phone,
+            imeAction = ImeAction.Done,
             modifier = Modifier.fillMaxWidth().testTag("callerIDNumber")
         ) { value ->
             callerIdNumber = value

--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/MainActivity.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/MainActivity.kt
@@ -75,7 +75,7 @@ class MainActivity : AppCompatActivity(), DefaultLifecycleObserver {
         appBarConfiguration = AppBarConfiguration(
             setOf(R.id.loginFragment)
         )
-        
+
         setupGestureDetector()
         bindEvents()
     }
@@ -142,10 +142,18 @@ class MainActivity : AppCompatActivity(), DefaultLifecycleObserver {
         action?.let {
             val txPushMetaData =
                 intent.extras?.getString(MyFirebaseMessagingService.TX_PUSH_METADATA)
-            if (action == MyFirebaseMessagingService.ACT_ANSWER_CALL) {
-                telnyxViewModel.answerIncomingPushCall(this, txPushMetaData)
-            } else if (action == MyFirebaseMessagingService.ACT_REJECT_CALL) {
-                telnyxViewModel.rejectIncomingPushCall(this, txPushMetaData)
+            when (action) {
+                MyFirebaseMessagingService.ACT_ANSWER_CALL -> {
+                    telnyxViewModel.answerIncomingPushCall(this, txPushMetaData)
+                }
+
+                MyFirebaseMessagingService.ACT_REJECT_CALL -> {
+                    telnyxViewModel.rejectIncomingPushCall(this, txPushMetaData)
+                }
+
+                MyFirebaseMessagingService.ACT_OPEN_TO_REPLY -> {
+                    telnyxViewModel.connectWithLastUsedConfig(this, txPushMetaData)
+                }
             }
         }
     }

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -293,21 +293,21 @@ class TelnyxViewModel : ViewModel() {
         }
     }
 
-    fun connectWithLastUsedConfig(viewContext: Context) {
+    fun connectWithLastUsedConfig(viewContext: Context, txPushMetaData: String? = null) {
         viewModelScope.launch {
             _currentProfile.value?.let { lastUsedProfile ->
                 if (lastUsedProfile.sipToken?.isEmpty() == false) {
                     tokenLogin(
                         viewContext,
                         lastUsedProfile,
-                        null,
+                        txPushMetaData,
                         true
                     )
                 } else {
                     credentialLogin(
                         viewContext,
                         lastUsedProfile,
-                        null,
+                        txPushMetaData,
                         true
                     )
                 }

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/AnswerIncomingPushCall.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/AnswerIncomingPushCall.kt
@@ -71,6 +71,7 @@ class AnswerIncomingPushCall(private val context: Context) {
         if (response.status == SocketStatus.MESSAGERECEIVED) {
             if (response.data?.method == SocketMethod.INVITE.methodName) {
                 (response.data?.result as? InviteResponse)?.let { inviteResponse ->
+                    Thread.sleep(Call.ICE_CANDIDATE_DELAY) // Minor delay to ensure ICE candidates are gathered.
                     val answeredCall = AcceptCall(context).invoke(
                         inviteResponse.callId,
                         inviteResponse.callerIdNumber,

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/CallNotificationService.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/CallNotificationService.kt
@@ -122,10 +122,12 @@ class CallNotificationService @RequiresApi(Build.VERSION_CODES.O) constructor(
 
         // Intent for full screen activity
         val fullScreenIntent = Intent(context, targetActivityClass).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            action = Intent.ACTION_VIEW
+            putExtra(MyFirebaseMessagingService.EXT_KEY_DO_ACTION, MyFirebaseMessagingService.ACT_OPEN_TO_REPLY)
+            putExtra(MyFirebaseMessagingService.TX_PUSH_METADATA, txPushMetaData.toJson())
         }
         val fullScreenPendingIntent = PendingIntent.getActivity(
-            context, 0, fullScreenIntent, PendingIntent.FLAG_MUTABLE
+            context, MyFirebaseMessagingService.OPEN_TO_REPLY_REQUEST_CODE, fullScreenIntent, PendingIntent.FLAG_MUTABLE
         )
 
         // Answer call intent

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/MyFirebaseMessagingService.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/MyFirebaseMessagingService.kt
@@ -100,6 +100,7 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
     companion object {
         const val ANSWER_REQUEST_CODE = 0
         const val REJECT_REQUEST_CODE = 1
+        const val OPEN_TO_REPLY_REQUEST_CODE = 2
         const val END_CALL_REQUEST_CODE = 1202
 
         const val TX_PUSH_METADATA = "tx_push_metadata"
@@ -108,5 +109,6 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
         const val EXT_KEY_DO_ACTION = "ext_key_do_action"
         const val ACT_ANSWER_CALL = "answer"
         const val ACT_REJECT_CALL = "reject"
+        const val ACT_OPEN_TO_REPLY = "open_to_reply"
     }
 }

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/NotificationsService.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/NotificationsService.kt
@@ -133,10 +133,21 @@ class NotificationsService : Service() {
         val targetActivityClass = Class.forName(getActivityClassName())
 
         val intent = Intent(this, targetActivityClass).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            action = Intent.ACTION_VIEW
+            putExtra(
+                MyFirebaseMessagingService.EXT_KEY_DO_ACTION,
+                MyFirebaseMessagingService.ACT_OPEN_TO_REPLY
+            )
+            putExtra(MyFirebaseMessagingService.TX_PUSH_METADATA, txPushMetaData.toJson())
         }
+
         val pendingIntent: PendingIntent =
-            PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_MUTABLE)
+            PendingIntent.getActivity(
+                this,
+                MyFirebaseMessagingService.OPEN_TO_REPLY_REQUEST_CODE,
+                intent,
+                PendingIntent.FLAG_MUTABLE
+            )
 
         val customSoundUri: Uri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
 

--- a/telnyx_rtc/build.gradle
+++ b/telnyx_rtc/build.gradle
@@ -173,7 +173,7 @@ dependencies {
     implementation deps.material
     implementation deps.constraint_layout
 
-    implementation "io.getstream:stream-webrtc-android:1.1.2"
+    implementation "io.getstream:stream-webrtc-android:1.3.8"
 
     implementation deps.gson
     implementation deps.retrofit.runtime

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -59,7 +59,6 @@ data class Call(
 
     internal var peerConnection: Peer? = null
 
-
     internal var earlySDP = false
 
     var inviteResponse: InviteResponse? = null

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -93,7 +93,7 @@ class TelnyxClient(
 
         /** Delay in milliseconds before attempting to reconnect */
         const val RECONNECT_DELAY: Long = 1000
-        
+
         /** Timeout in milliseconds for reconnection attempts (60 seconds) */
         const val RECONNECT_TIMEOUT: Long = 60000
 
@@ -106,7 +106,7 @@ class TelnyxClient(
     private val iceCandidateList: MutableList<String> = mutableListOf()
 
     private var reconnecting = false
-    
+
     // Reconnection timeout timer
     private var reconnectTimeOutJob: Job? = null
 
@@ -117,7 +117,7 @@ class TelnyxClient(
     private var registrationRetryCounter = 0
     private var connectRetryCounter = 0
     private var gatewayState = "idle"
-    private var speakerState: SpeakerMode = SpeakerMode.UNASSIGNED
+    private var speakerState: SpeakerMode = UNASSIGNED
 
     internal var socket: TxSocket
     private var providedHostAddress: String? = null
@@ -125,7 +125,7 @@ class TelnyxClient(
     internal var providedTurn: String? = null
     internal var providedStun: String? = null
     private var voiceSDKID: String? = null
-    private var iceCandidateTimer:Timer? = null
+    private var iceCandidateTimer: Timer? = null
 
     private var isDebug = false
 
@@ -293,16 +293,16 @@ class TelnyxClient(
             val call = this
 
 
-
             // Create new peer
             peerConnection = Peer(context, client, providedTurn, providedStun, callId) {
                 iceCandidateList.add(it)
             }.also {
-                    if (isDebug) {
-                        webRTCReporter = WebRTCReporter(socket, callId, this.getTelnyxLegId()?.toString(), it)
-                        webRTCReporter?.startStats()
-                    }
+                if (isDebug) {
+                    webRTCReporter =
+                        WebRTCReporter(socket, callId, this.getTelnyxLegId()?.toString(), it)
+                    webRTCReporter?.startStats()
                 }
+            }
 
 
 
@@ -426,7 +426,12 @@ class TelnyxClient(
     internal var isNetworkCallbackRegistered = false
     private val networkCallback = object : ConnectivityHelper.NetworkCallback() {
         override fun onNetworkAvailable() {
-            Logger.d(message = Logger.formatMessage("[%s] :: There is a network available", this@TelnyxClient.javaClass.simpleName))
+            Logger.d(
+                message = Logger.formatMessage(
+                    "[%s] :: There is a network available",
+                    this@TelnyxClient.javaClass.simpleName
+                )
+            )
             // User has been logged in
             resetGatewayCounters()
             if (reconnecting && credentialSessionConfig != null || tokenSessionConfig != null) {
@@ -436,8 +441,10 @@ class TelnyxClient(
 
         override fun onNetworkUnavailable() {
             Logger.d(
-                message = Logger.formatMessage("[%s] :: There is no network available",
-                this@TelnyxClient.javaClass.simpleName)
+                message = Logger.formatMessage(
+                    "[%s] :: There is no network available",
+                    this@TelnyxClient.javaClass.simpleName
+                )
             )
             reconnecting = true
 
@@ -884,6 +891,7 @@ class TelnyxClient(
                     userVariables = UserVariables(storedConfig.fcmToken ?: "")
                 )
             }
+
             is TokenConfig -> {
                 TokenDisablePushParams(
                     loginToken = storedConfig.sipToken,
@@ -972,7 +980,6 @@ class TelnyxClient(
     }
 
 
-
     /**
      * Sets the global SDK log level
      * Logging is implemented with the Logger provided via the [Config],
@@ -1016,10 +1023,12 @@ class TelnyxClient(
                     audioManager?.startBluetoothSco()
                     audioManager?.isBluetoothScoOn = true
                 } else {
-                    Logger.d(message = Logger.formatMessage(
-                        "[%s] :: No Bluetooth device detected",
-                        this@TelnyxClient.javaClass.simpleName
-                    ))
+                    Logger.d(
+                        message = Logger.formatMessage(
+                            "[%s] :: No Bluetooth device detected",
+                            this@TelnyxClient.javaClass.simpleName
+                        )
+                    )
                 }
             }
 
@@ -1050,7 +1059,7 @@ class TelnyxClient(
      */
     internal fun playRingtone() {
         // set speakerState to current audioManager settings
-        speakerState = if (speakerState != SpeakerMode.UNASSIGNED) {
+        speakerState = if (speakerState != UNASSIGNED) {
             if (audioManager?.isSpeakerphoneOn == true) {
                 SpeakerMode.SPEAKER
             } else {
@@ -1101,7 +1110,7 @@ class TelnyxClient(
                 audioManager?.isSpeakerphoneOn = false
             }
 
-            SpeakerMode.UNASSIGNED -> audioManager?.isSpeakerphoneOn = false
+            UNASSIGNED -> audioManager?.isSpeakerphoneOn = false
         }
     }
 
@@ -1170,9 +1179,11 @@ class TelnyxClient(
      */
     internal fun onLoginSuccessful(receivedLoginSessionId: String) {
         Logger.d(
-            message = Logger.formatMessage("[%s] :: onLoginSuccessful :: [%s] :: Ready to make calls",
-            this@TelnyxClient.javaClass.simpleName,
-            receivedLoginSessionId)
+            message = Logger.formatMessage(
+                "[%s] :: onLoginSuccessful :: [%s] :: Ready to make calls",
+                this@TelnyxClient.javaClass.simpleName,
+                receivedLoginSessionId
+            )
         )
         sessid = receivedLoginSessionId
         socketResponseLiveData.postValue(
@@ -1208,8 +1219,10 @@ class TelnyxClient(
     override fun onClientReady(jsonObject: JsonObject) {
         if (gatewayState != GatewayState.REGED.state) {
             Logger.d(
-                message = Logger.formatMessage("[%s] :: onClientReady :: retrieving gateway state",
-                this@TelnyxClient.javaClass.simpleName)
+                message = Logger.formatMessage(
+                    "[%s] :: onClientReady :: retrieving gateway state",
+                    this@TelnyxClient.javaClass.simpleName
+                )
             )
             if (waitingForReg) {
                 requestGatewayStatus()
@@ -1222,9 +1235,11 @@ class TelnyxClient(
                             }
                             registrationRetryCounter++
                         } else {
-                            Logger.d(message = Logger.formatMessage(
-                                "[%s] :: Gateway registration has timed out",
-                                this@TelnyxClient.javaClass.simpleName)
+                            Logger.d(
+                                message = Logger.formatMessage(
+                                    "[%s] :: Gateway registration has timed out",
+                                    this@TelnyxClient.javaClass.simpleName
+                                )
                             )
                             socketResponseLiveData.postValue(SocketResponse.error("Gateway registration has timed out"))
                         }
@@ -1233,9 +1248,11 @@ class TelnyxClient(
                 )
             }
         } else {
-            Logger.d(message = Logger.formatMessage(
-                "[%s] :: onClientReady :: Ready to make calls",
-                this@TelnyxClient.javaClass.simpleName)
+            Logger.d(
+                message = Logger.formatMessage(
+                    "[%s] :: onClientReady :: Ready to make calls",
+                    this@TelnyxClient.javaClass.simpleName
+                )
             )
 
             socketResponseLiveData.postValue(
@@ -1277,9 +1294,11 @@ class TelnyxClient(
             (GatewayState.FAIL_WAIT.state), (GatewayState.DOWN.state) -> {
                 if (autoReconnectLogin && connectRetryCounter < RETRY_CONNECT_TIME) {
                     connectRetryCounter++
-                    Logger.d(message = Logger.formatMessage(
-                        "[%s] :: Attempting reconnection :: attempt $connectRetryCounter / $RETRY_CONNECT_TIME",
-                        this@TelnyxClient.javaClass.simpleName)
+                    Logger.d(
+                        message = Logger.formatMessage(
+                            "[%s] :: Attempting reconnection :: attempt $connectRetryCounter / $RETRY_CONNECT_TIME",
+                            this@TelnyxClient.javaClass.simpleName
+                        )
                     )
                     runBlocking { reconnectToSocket() }
                 } else {
@@ -1326,7 +1345,7 @@ class TelnyxClient(
         registrationRetryCounter = 0
         connectRetryCounter = 0
     }
-    
+
     /**
      * Starts the reconnection timer to track reconnection attempts.
      * If reconnection takes longer than RECONNECT_TIMEOUT, it will trigger an error.
@@ -1338,7 +1357,10 @@ class TelnyxClient(
         reconnectTimeOutJob = null
         // Create a new timer to check for timeout
         reconnectTimeOutJob = CoroutineScope(Dispatchers.Default).launch {
-            delay( credentialSessionConfig?.reconnectionTimeout ?: tokenSessionConfig?.reconnectionTimeout ?: RECONNECT_TIMEOUT)
+            delay(
+                credentialSessionConfig?.reconnectionTimeout
+                    ?: tokenSessionConfig?.reconnectionTimeout ?: RECONNECT_TIMEOUT
+            )
             if (reconnecting) {
                 Logger.d(message = "Reconnection timeout reached after ${RECONNECT_TIMEOUT}ms")
                 reconnecting = false
@@ -1347,7 +1369,7 @@ class TelnyxClient(
                     getActiveCalls().forEach { (_, call) ->
                         call.setReconnectionTimeout()
                     }
-                    socketResponseLiveData.postValue(SocketResponse.error("Reconnection timeout after ${RECONNECT_TIMEOUT/TIMEOUT_DIVISOR} seconds"))
+                    socketResponseLiveData.postValue(SocketResponse.error("Reconnection timeout after ${RECONNECT_TIMEOUT / TIMEOUT_DIVISOR} seconds"))
 
                     // Reset reconnection state
                     reconnecting = false
@@ -1359,7 +1381,7 @@ class TelnyxClient(
             }
         }
     }
-    
+
     /**
      * Cancels the reconnection timer if it's running.
      */
@@ -1370,7 +1392,12 @@ class TelnyxClient(
     }
 
     override fun onConnectionEstablished() {
-        Logger.d(message = Logger.formatMessage("[%s] :: onConnectionEstablished", this@TelnyxClient.javaClass.simpleName))
+        Logger.d(
+            message = Logger.formatMessage(
+                "[%s] :: onConnectionEstablished",
+                this@TelnyxClient.javaClass.simpleName
+            )
+        )
         socketResponseLiveData.postValue(SocketResponse.established())
 
     }
@@ -1386,7 +1413,12 @@ class TelnyxClient(
         Logger.d(message = Logger.formatMessage("[%s] :: onByeReceived", this.javaClass.simpleName))
         val byeCall = calls[callId]
         byeCall?.apply {
-            Logger.d(message = Logger.formatMessage("[%s] :: onByeReceived", this.javaClass.simpleName))
+            Logger.d(
+                message = Logger.formatMessage(
+                    "[%s] :: onByeReceived",
+                    this.javaClass.simpleName
+                )
+            )
             val byeResponse = ByeResponse(
                 callId
             )
@@ -1531,10 +1563,12 @@ class TelnyxClient(
 
     override fun onOfferReceived(jsonObject: JsonObject) {
         if (jsonObject.has("params")) {
-            Logger.d(message = Logger.formatMessage(
-                "[%s] :: onOfferReceived [%s]",
-                this@TelnyxClient.javaClass.simpleName,
-                jsonObject)
+            Logger.d(
+                message = Logger.formatMessage(
+                    "[%s] :: onOfferReceived [%s]",
+                    this@TelnyxClient.javaClass.simpleName,
+                    jsonObject
+                )
             )
             val offerCall = call!!.copy(
                 context = context,
@@ -1567,7 +1601,6 @@ class TelnyxClient(
                 val call = this
 
 
-
                 //retrieve custom headers
                 val customHeaders =
                     params.get("dialogParams")?.asJsonObject?.get("custom_headers")?.asJsonArray
@@ -1575,11 +1608,11 @@ class TelnyxClient(
                 peerConnection = Peer(context, client, providedTurn, providedStun, offerCallId) {
                     iceCandidateList.add(it)
                 }.also {
-                            if (isDebug) {
-                                webRTCReporter = WebRTCReporter(socket, callId, telnyxLegId?.toString(), it)
-                                webRTCReporter?.startStats()
-                            }
-                        }
+                    if (isDebug) {
+                        webRTCReporter = WebRTCReporter(socket, callId, telnyxLegId?.toString(), it)
+                        webRTCReporter?.startStats()
+                    }
+                }
 
                 peerConnection?.startLocalAudioCapture()
 
@@ -1614,9 +1647,11 @@ class TelnyxClient(
                 )
             )
         } else {
-            Logger.d(message = Logger.formatMessage(
-                "[%s] :: Invalid offer received, missing required parameters [%s]",
-                this.javaClass.simpleName, jsonObject)
+            Logger.d(
+                message = Logger.formatMessage(
+                    "[%s] :: Invalid offer received, missing required parameters [%s]",
+                    this.javaClass.simpleName, jsonObject
+                )
             )
         }
 
@@ -1627,10 +1662,12 @@ class TelnyxClient(
     }
 
     override fun onRingingReceived(jsonObject: JsonObject) {
-        Logger.d(message = Logger.formatMessage(
-            "[%s] :: onRingingReceived [%s]",
-            this@TelnyxClient.javaClass.simpleName,
-            jsonObject)
+        Logger.d(
+            message = Logger.formatMessage(
+                "[%s] :: onRingingReceived [%s]",
+                this@TelnyxClient.javaClass.simpleName,
+                jsonObject
+            )
         )
         val params = jsonObject.getAsJsonObject("params")
         val callId = params.get("callID").asString
@@ -1675,10 +1712,12 @@ class TelnyxClient(
     }
 
     override fun onDisablePushReceived(jsonObject: JsonObject) {
-        Logger.d(message = Logger.formatMessage(
-            "[%s] :: onDisablePushReceived [%s]",
-            this@TelnyxClient.javaClass.simpleName,
-            jsonObject)
+        Logger.d(
+            message = Logger.formatMessage(
+                "[%s] :: onDisablePushReceived [%s]",
+                this@TelnyxClient.javaClass.simpleName,
+                jsonObject
+            )
         )
         val errorMessage = jsonObject.get("result").asJsonObject.get("message").asString
         val disablePushResponse = DisablePushResponse(
@@ -1770,7 +1809,12 @@ class TelnyxClient(
     }
 
     override fun pingPong() {
-        Logger.d(message = Logger.formatMessage("[%s] :: pingPong ", this@TelnyxClient.javaClass.simpleName))
+        Logger.d(
+            message = Logger.formatMessage(
+                "[%s] :: pingPong ",
+                this@TelnyxClient.javaClass.simpleName
+            )
+        )
     }
 
     internal fun onRemoteSessionErrorReceived(errorMessage: String?) {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1377,7 +1377,7 @@ class TelnyxClient(
 
     override fun onErrorReceived(jsonObject: JsonObject) {
         val errorMessage = jsonObject.get("error").asJsonObject.get("message").asString
-        Logger.d(message = "onErrorReceived " + errorMessage)
+        Logger.d(message = "onErrorReceived $errorMessage")
         socketResponseLiveData.postValue(SocketResponse.error(errorMessage))
     }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SocketError.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SocketError.kt
@@ -12,8 +12,10 @@ package com.telnyx.webrtc.sdk.model
  *
  * @property TOKEN_ERROR there was an issue with a token - either invalid or expired
  * @property CREDENTIAL_ERROR there was an issue with the credentials used - likely invalid.
+ * @property CODEC_ERROR there was an issue with the SDP handshake, likely due to codec issues.
  */
 enum class SocketError(var errorCode: Int) {
     TOKEN_ERROR(-32000),
-    CREDENTIAL_ERROR(-32001)
+    CREDENTIAL_ERROR(-32001),
+    CODEC_ERROR(-32002)
 }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
@@ -196,7 +196,7 @@ internal class Peer(
      */
     private fun buildPeerConnection(): PeerConnection? {
         val config = PeerConnection.RTCConfiguration(iceServer).apply {
-            //iceTransportsType = PeerConnection.IceTransportsType.NOHOST
+            iceTransportsType = PeerConnection.IceTransportsType.NOHOST
             bundlePolicy = PeerConnection.BundlePolicy.MAXCOMPAT
         }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -9,6 +9,7 @@ import com.google.gson.JsonObject
 import com.telnyx.webrtc.sdk.Config
 import com.telnyx.webrtc.sdk.TelnyxClient
 import com.telnyx.webrtc.sdk.model.PushMetaData
+import com.telnyx.webrtc.sdk.model.SocketError
 import com.telnyx.webrtc.sdk.model.SocketError.CREDENTIAL_ERROR
 import com.telnyx.webrtc.sdk.model.SocketError.TOKEN_ERROR
 import com.telnyx.webrtc.sdk.model.SocketMethod.*
@@ -243,6 +244,14 @@ class TxSocket(
                                     }
 
                                     TOKEN_ERROR.errorCode -> {
+                                        listener.onErrorReceived(jsonObject)
+                                    }
+
+                                    SocketError.CODEC_ERROR.errorCode -> {
+                                        listener.onErrorReceived(jsonObject)
+                                    }
+
+                                    else -> {
                                         listener.onErrorReceived(jsonObject)
                                     }
                                 }


### PR DESCRIPTION
[WebRTC-2368 - PSTN call answer from push not connecting.](https://telnyx.atlassian.net/browse/WEBRTC-2368)

---
<!-- Describe your changed here -->
Some changes recently made seem to affect our ability to answer PSTN calls from push

## :older_man: :baby: Behaviors
### Before changes
- Using NOHOST transport type
- Not properly handling codec error (call would stay on)
- always showing disconnect button
- no full screen pending intent for push notifications to handle when no action is pressed

### After changes
- Still manually skipping local ice candidates, but no longer using NOHOST transport type
- Call will end on client side when we receive codec error to avoid confusion
- Only show disconnect / connect button while on a call
- full screen pending intent for push notification when no action is pressed allowing user to reply when app is connected
- Bump WebRTC library version

## ✋ Manual testing
1. Test standard inbound SIP call
2. Test standard inbound push notification SIP call
3. Test PSTN inbound call
4. Test PSTN inbound push notification call
