### PR TITLE
WEBRTC-2587: Fix UUID problem for PSTN Inbound Call

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -65,7 +65,10 @@ data class Call(
     var inviteResponse: InviteResponse? = null
     var answerResponse: AnswerResponse? = null
     lateinit var callId: UUID
-
+    
+    // Original callID string from the server (may not be a UUID)
+    internal var originalCallIdString: String? = null
+    
     internal var telnyxSessionId: UUID? = null
     internal var telnyxLegId: UUID? = null
 
@@ -323,6 +326,15 @@ data class Call(
      */
     fun getTelnyxLegId(): UUID? {
         return telnyxLegId
+    }
+    
+    /**
+     * Returns the original callID string received from the server
+     * This may be a UUID string or a non-UUID string like "420009675_133898086@206.147.68.154"
+     * @return [String] The original callID string or null if not set
+     */
+    fun getOriginalCallIdString(): String? {
+        return originalCallIdString
     }
 
     /**

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
@@ -12,6 +12,11 @@ import java.util.*
  * TxSocket interface containing the methods that the socket connection will fire
  */
 interface TxSocketListener {
+    
+    /**
+     * Maps original callID strings to UUIDs for non-UUID callIDs
+     */
+    val callIdStringToUuidMap: MutableMap<String, UUID>
 
     /**
      * Fires once the client is ready and gateway status updates can be received


### PR DESCRIPTION
## Description

This PR addresses the issue where PSTN inbound calls have callIDs that are not valid UUIDs, causing the SDK to throw an IllegalArgumentException and close the socket connection.

## Changes

- Add support for non-UUID callIDs in PSTN inbound calls
- Create a mapping between original callID strings and UUIDs
- Store the original callID string in the Call object
- Modify socket handlers to properly handle non-UUID callIDs
- Generate a UUID when a non-UUID callID is received
- Add helper methods to get calls by original callID string

## Testing

The changes have been tested with the example callID format provided in the ticket: "420009675_133898086@206.147.68.154"

## Jira Ticket
[WEBRTC-2587](https://telnyx.atlassian.net/browse/WEBRTC-2587)