### PR TITLE
WEBRTC-2591: [Android] Splash Screen UI Change

### DIFF
--- a/samples/compose_app/src/main/res/values/colors.xml
+++ b/samples/compose_app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="telnyx_green">#00E3AA</color>
 </resources>

--- a/samples/compose_app/src/main/res/values/themes.xml
+++ b/samples/compose_app/src/main/res/values/themes.xml
@@ -12,5 +12,8 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
+        
+        <!-- Splash screen configuration for Android 12+ -->
+        <item name="android:windowSplashScreenBackground" tools:targetApi="31">@color/telnyx_green</item>
     </style>
 </resources>

--- a/samples/xml_app/src/main/res/values/colors.xml
+++ b/samples/xml_app/src/main/res/values/colors.xml
@@ -3,7 +3,7 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 
-    <color name="telnyx_green">#31b886</color>
+    <color name="telnyx_green">#00E3AA</color>
     <color name="reject_red">#ff4d4f</color>
     <color name="background_color">#FEFDF5</color>
     <color name="colorPrimary">#1D1D1D</color>

--- a/samples/xml_app/src/main/res/values/themes.xml
+++ b/samples/xml_app/src/main/res/values/themes.xml
@@ -13,7 +13,8 @@
         <item name="colorSecondary">@color/telnyx_green</item>
         <item name="colorOnSecondary">@color/white</item>
 
-
+        <!-- Splash screen configuration for Android 12+ -->
+        <item name="android:windowSplashScreenBackground" tools:targetApi="31">@color/telnyx_green</item>
     </style>
 
     <style name="Theme.TelnyxAndroidWebRTCSDK" parent="Base.Theme.TelnyxAndroidWebRTCSDK" />


### PR DESCRIPTION
## Description
This PR changes the splash screen background color to #00E3AA for both the compose_app and xml_app modules as requested in [WEBRTC-2591](https://telnyx.atlassian.net/browse/WEBRTC-2591).

## Changes
- Added/updated the telnyx_green color to #00E3AA in both modules' color resources
- Added Android 12+ splash screen configuration to both modules' theme files using the android:windowSplashScreenBackground attribute

## Testing
- Verified that the splash screen background color is set to the specified green color (#00E3AA) for both the compose_app and xml_app modules.

## Related Issues
- [WEBRTC-2591](https://telnyx.atlassian.net/browse/WEBRTC-2591)

[WEBRTC-2591]: https://telnyx.atlassian.net/browse/WEBRTC-2591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBRTC-2591]: https://telnyx.atlassian.net/browse/WEBRTC-2591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ