### PR TITLE
WEBRTC-2592: Home Screen Unregistered Profile UI Change

### DIFF
--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
@@ -106,7 +106,10 @@ fun HomeScreen(navController: NavHostController, telnyxViewModel: TelnyxViewMode
         }
     }
 
-    Scaffold(modifier = Modifier.padding(Dimens.mediumSpacing),
+    Scaffold(
+        modifier = Modifier
+            .padding(Dimens.mediumSpacing)
+            .background(background_color),
         topBar = {
             Column(
                 verticalArrangement = Arrangement.spacedBy(Dimens.smallSpacing),
@@ -132,8 +135,13 @@ fun HomeScreen(navController: NavHostController, telnyxViewModel: TelnyxViewMode
                             }
                     )
                 }
+                
+                // Added 108px total spacing between logo and text
+                Spacer(modifier = Modifier.height(108.dp - Dimens.mediumSpacing - Dimens.smallSpacing))
 
-                MediumTextBold(text = stringResource(id = R.string.login_info))
+                // Adjust x position with 24px padding on both sides
+                Column(modifier = Modifier.padding(horizontal = 24.dp)) {
+                    MediumTextBold(text = stringResource(id = R.string.login_info))
                 ConnectionState(state = (sessionState is TelnyxSessionState.ClientLoggedIn))
                 CurrentCallState(state = callState)
                 SessionItem(
@@ -536,17 +544,20 @@ fun ProfileItem(
 
 @Composable
 fun ProfileSwitcher(profileName: String, onProfileSwitch: () -> Unit = {}) {
-    Column {
+    Column(modifier = Modifier.padding(horizontal = 24.dp)) {
         RegularText(text = stringResource(id = R.string.profile))
         Row(
-            horizontalArrangement = Arrangement.spacedBy(Dimens.extraSmallSpacing),
+            horizontalArrangement = Arrangement.spacedBy(12.dp), // 12px padding between profile name and button
             verticalAlignment = Alignment.CenterVertically
         ) {
             RegularText(text = profileName)
             RoundSmallButton(
-                text = stringResource(R.string.switch_profile),
+                text = "Switch Profile", // Sentence case
                 textSize = 14.sp,
-                backgroundColor = MaterialTheme.colorScheme.secondary
+                backgroundColor = Color.Transparent, // Secondary button style
+                contentColor = MaterialTheme.colorScheme.primary,
+                borderStroke = 1.dp,
+                borderColor = MaterialTheme.colorScheme.primary
             ) {
                 onProfileSwitch()
             }
@@ -565,11 +576,15 @@ fun SessionItem(sessionId: String) {
 
 @Composable
 fun ConnectionState(state: Boolean) {
-    Column(verticalArrangement = Arrangement.spacedBy(Dimens.spacing4dp)) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(Dimens.spacing4dp),
+        modifier = Modifier.padding(horizontal = 24.dp)
+    ) {
         RegularText(text = stringResource(id = R.string.socket))
         Row(
             horizontalArrangement = Arrangement.spacedBy(Dimens.extraSmallSpacing),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(top = 8.dp, bottom = 32.dp)
         ) {
             Box(
                 modifier = Modifier
@@ -580,9 +595,7 @@ fun ConnectionState(state: Boolean) {
                     )
             )
             RegularText(
-                text = if (state) stringResource(id = R.string.client_ready) else stringResource(
-                    id = R.string.disconnected
-                )
+                text = if (state) "Connected" else "Disconnected"
             )
         }
     }
@@ -606,7 +619,9 @@ fun ConnectionStateButton(
     val context = LocalContext.current
     RoundedOutlinedButton(
         text = if (state) stringResource(R.string.disconnect) else stringResource(R.string.connect),
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(32.dp)
     ) {
         if (state) {
             telnyxViewModel.disconnect(context)

--- a/samples/xml_app/src/main/res/layout/activity_main.xml
+++ b/samples/xml_app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/background_color"
     tools:context="org.telnyx.webrtc.xml_app.MainActivity">
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -32,8 +33,10 @@
             style="@style/HeaderText"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="60dp"
+            android:layout_marginTop="108dp"
             android:text="@string/home_info"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/imageView" />
@@ -45,6 +48,8 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
             android:text="@string/socket"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/loginInfo" />
 
@@ -53,8 +58,11 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
+            android:layout_marginBottom="32dp"
             android:gravity="center"
             android:orientation="horizontal"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/socketLabel">
 
@@ -175,5 +183,15 @@
 
     </LinearLayout>
 
+    <TextView
+        android:id="@+id/versionInfo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Production TelnyxSDK [v1.2.0] - App [v1.2.0]"
+        android:textColor="#525252"
+        android:layout_marginBottom="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/samples/xml_app/src/main/res/values/strings.xml
+++ b/samples/xml_app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="session_id">Session ID</string>
     <string name="destination">Destination</string>
     <string name="disconnected">Disconnected</string>
-    <string name="client_ready">Client-ready</string>
+    <string name="client_ready">Connected</string>
     <string name="dash">-</string>
     <string name="session_pending">-</string>
     <string name="call">Call</string>


### PR DESCRIPTION
## Description
Implemented UI changes for the unregistered profile screen based on the Figma design.

## Changes
- Set background color to #FEFDF5
- Added 108px spacing between logo and text
- Updated socket status text to use sentence case
- Added 24px padding on both sides for text elements
- Added 32px padding between field items
- Updated "Switch Profile" to sentence case and made it use secondary button style
- Set 100px radius and 32px height for buttons
- Added version text at bottom with color #525252

## Jira Ticket
[WEBRTC-2592](https://telnyx.atlassian.net/browse/WEBRTC-2592)