### PR TITLE
Reused PendingIntent with ACT_OPEN_TO_REPLY causing issues with multiple notifications

### DIFF
--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/CallNotificationService.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/CallNotificationService.kt
@@ -127,7 +127,8 @@ class CallNotificationService @RequiresApi(Build.VERSION_CODES.O) constructor(
             putExtra(MyFirebaseMessagingService.TX_PUSH_METADATA, txPushMetaData.toJson())
         }
         val fullScreenPendingIntent = PendingIntent.getActivity(
-            context, MyFirebaseMessagingService.OPEN_TO_REPLY_REQUEST_CODE, fullScreenIntent, PendingIntent.FLAG_MUTABLE
+            context, MyFirebaseMessagingService.OPEN_TO_REPLY_REQUEST_CODE, fullScreenIntent,
+            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
 
         // Answer call intent

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/LegacyCallNotificationService.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/LegacyCallNotificationService.kt
@@ -146,7 +146,7 @@ class LegacyCallNotificationService : Service() {
                 this,
                 MyFirebaseMessagingService.OPEN_TO_REPLY_REQUEST_CODE,
                 intent,
-                PendingIntent.FLAG_MUTABLE
+                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
             )
 
         val customSoundUri: Uri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)


### PR DESCRIPTION
…PEN_TO_REPLY_REQUEST_CODE

[ENGDESK-40223 - Ticket Description.](https://telnyx.atlassian.net/browse/ENGDESK-40223)

---
<!-- Describe your changed here -->
The issue arises because Android tries to reuse PendingIntent objects for efficiency. When you create a PendingIntent using PendingIntent.getActivity, the system checks if a PendingIntent with the same requestCode and matching Intent components (action, data, categories, component) already exists.

To solve this, we have added the PendingIntent.FLAG_UPDATE_CURRENT flag when creating the PendingIntent. This flag tells the system that if a PendingIntent with the same signature already exists, it should be kept, but its Intent's extras should be replaced with the extras from the new Intent.

TLDR; the PendingIntent extras were essentially being cached and resused. 

## :older_man: :baby: Behaviors
### Before changes
- Only using PendingIntent.FLAG_MUTABLE

### After changes
- We now use PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT for both CallNotificationService and LegacyCallNotificationService

## ✋ Manual testing
1. Receive push notification
2. Do not accept or decline, but instead click the notification to launch app to reply
3. Repeat this multiple times to make sure the flow works
