### PR TITLE
WEBRTC-2596: [Android] Home Screen Active Call UI Change

### DIFF
--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/CallScreen.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/CallScreen.kt
@@ -102,11 +102,19 @@ fun CallScreen(telnyxViewModel: TelnyxViewModel) {
         modifier = Modifier.verticalScroll(rememberScrollState())
     ) {
         var destinationNumber by remember { mutableStateOf("") }
+        var isPhoneNumber by remember { mutableStateOf(true) }
+        
+        // Add the toggle button at the top
+        DestinationTypeSwitcher(isPhoneNumber) {
+            isPhoneNumber = it
+        }
+        
         OutlinedEdiText(
             text = destinationNumber,
             hint = stringResource(R.string.destination),
             modifier = Modifier.fillMaxWidth().testTag("callInput"),
-            imeAction = ImeAction.Done
+            imeAction = ImeAction.Done,
+            keyboardType = if (isPhoneNumber) androidx.compose.ui.text.input.KeyboardType.Phone else androidx.compose.ui.text.input.KeyboardType.Text
         ) {
             destinationNumber = it
         }
@@ -353,6 +361,34 @@ private fun onNumberClicked(number: Int) {
         }
     }
 
+}
+
+@Composable
+fun DestinationTypeSwitcher(isPhoneNumber: Boolean, onCheckedChange: (Boolean) -> Unit) {
+    Row(
+        modifier = Modifier
+            .padding(top = Dimens.spacing8dp)
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .clip(RoundedCornerShape(Dimens.size4dp))
+            .border(Dimens.borderStroke1dp,
+                Color.Black,
+                RoundedCornerShape(Dimens.size4dp)),
+        horizontalArrangement = Arrangement.Center
+    ) {
+        ToggleButton(
+            modifier = Modifier.weight(1f),
+            text = stringResource(id = R.string.phone_number_toggle),
+            isSelected = isPhoneNumber,
+            onClick = { onCheckedChange(true) }
+        )
+        ToggleButton(
+            modifier = Modifier.weight(1f),
+            text = stringResource(id = R.string.sip_address_toggle),
+            isSelected = !isPhoneNumber,
+            onClick = { onCheckedChange(false) }
+        )
+    }
 }
 
 private enum class CallUIState {

--- a/samples/compose_app/src/main/res/values/strings.xml
+++ b/samples/compose_app/src/main/res/values/strings.xml
@@ -87,4 +87,7 @@
     <string name="caller_number_hint">Enter caller number</string>
 
     <string name="production_label">production</string>
+    
+    <string name="phone_number_toggle">Phone number</string>
+    <string name="sip_address_toggle">SIP address</string>
 </resources>

--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/home/HomeCallFragment.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/home/HomeCallFragment.kt
@@ -50,6 +50,20 @@ class HomeCallFragment : Fragment() {
     }
 
     private fun setupUI() {
+        // Setup call type toggle
+        binding.callTypeSwitch.addOnButtonCheckedListener { _, checkedId, isChecked ->
+            if (isChecked) {
+                when (checkedId) {
+                    R.id.phoneNumberToggle -> {
+                        binding.callInput.inputType = android.text.InputType.TYPE_CLASS_PHONE
+                    }
+                    R.id.sipAddressToggle -> {
+                        binding.callInput.inputType = android.text.InputType.TYPE_CLASS_TEXT
+                    }
+                }
+            }
+        }
+        
         binding.call.setOnClickListener {
             binding.callInput.text?.let { editable ->
                 if (editable.isNotEmpty()) {

--- a/samples/xml_app/src/main/res/layout/fragment_home_call.xml
+++ b/samples/xml_app/src/main/res/layout/fragment_home_call.xml
@@ -13,7 +13,39 @@
         android:padding="24dp"
         >
 
+        <com.google.android.material.button.MaterialButtonToggleGroup
+            android:id="@+id/callTypeSwitch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            app:singleSelection="true"
+            app:checkedButton="@id/phoneNumberToggle"
+            app:selectionRequired="true"
+            android:layout_marginTop="10dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/phoneNumberToggle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/phone_number_toggle"
+                style="@style/ToggleButton"
+                app:backgroundTint="@color/main_green"
+                android:textColor="@color/white"/>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/sipAddressToggle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/sip_address_toggle"
+                style="@style/ToggleButton"
+                app:backgroundTint="@color/white"
+                android:textColor="@color/black"/>
+
+        </com.google.android.material.button.MaterialButtonToggleGroup>
 
         <LinearLayout
             android:id="@+id/destinationInfo"
@@ -22,7 +54,7 @@
             android:orientation="vertical"
             android:layout_marginTop="@dimen/spacing_small"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toBottomOf="@+id/callTypeSwitch">
 
 
             <TextView
@@ -46,6 +78,7 @@
                     android:id="@+id/callInput"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:inputType="phone"
                     />
 
             </com.google.android.material.textfield.TextInputLayout>

--- a/samples/xml_app/src/main/res/values/strings.xml
+++ b/samples/xml_app/src/main/res/values/strings.xml
@@ -75,4 +75,7 @@
 
     <string name="bottom_bar_production_text">Production TelnyxSDK [v1.6.1] - App [v%1$s]</string>
     <string name="production_label">production</string>
+    
+    <string name="phone_number_toggle">Phone number</string>
+    <string name="sip_address_toggle">SIP address</string>
 </resources>


### PR DESCRIPTION
## Description
This PR adds toggle buttons for 'Phone number' and 'SIP address' options in both XML and Compose apps. The toggle buttons change the keyboard type when the user focuses on the destination input field.

### Changes
- In XML app: Added MaterialButtonToggleGroup with two buttons at the top of the home call screen
- In Compose app: Added DestinationTypeSwitcher composable with two toggle buttons
- Added string resources for the toggle button labels
- Implemented the logic to change the input type based on the selected option

## Jira Ticket
[WEBRTC-2596](https://telnyx.atlassian.net/browse/WEBRTC-2596)