### PR TITLE
WEBRTC-2661: Android SDK Proguard rules description

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ please keep in mind that you will need to add the following rules to the proguar
 
 #### **`app/proguard-rules.pro`**
 ```gradle
--keep class com.telnyx.webrtc.sdk.** { *; }
+-keep class com.telnyx.webrtc.** { *; }
 -dontwarn kotlin.Experimental$Level
 -dontwarn kotlin.Experimental
 -dontwarn kotlinx.coroutines.scheduling.ExperimentalCoroutineDispatcher

--- a/README.md
+++ b/README.md
@@ -409,8 +409,10 @@ please keep in mind that you will need to add the following rules to the proguar
 
 #### **`app/proguard-rules.pro`**
 ```gradle
--keep class org.webrtc.** { *; }
 -keep class com.telnyx.webrtc.sdk.** { *; }
+-dontwarn kotlin.Experimental$Level
+-dontwarn kotlin.Experimental
+-dontwarn kotlinx.coroutines.scheduling.ExperimentalCoroutineDispatcher
 ```
 
 -----

--- a/telnyx_rtc/proguard-rules.pro
+++ b/telnyx_rtc/proguard-rules.pro
@@ -20,8 +20,4 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
-# Kotlin experimental features warnings
--dontwarn kotlin.Experimental$Level
--dontwarn kotlin.Experimental
--dontwarn kotlinx.coroutines.scheduling.ExperimentalCoroutineDispatcher
 

--- a/telnyx_rtc/proguard-rules.pro
+++ b/telnyx_rtc/proguard-rules.pro
@@ -20,3 +20,8 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
+# Kotlin experimental features warnings
+-dontwarn kotlin.Experimental$Level
+-dontwarn kotlin.Experimental
+-dontwarn kotlinx.coroutines.scheduling.ExperimentalCoroutineDispatcher
+


### PR DESCRIPTION
## Description
This PR updates the Proguard rules for the Android SDK.

### Changes
- Removed reference to org.webrtc in README.md as it's no longer used
- Added Kotlin experimental warnings to proguard-rules.pro:
  - -dontwarn kotlin.Experimental$Level
  - -dontwarn kotlin.Experimental
  - -dontwarn kotlinx.coroutines.scheduling.ExperimentalCoroutineDispatcher
- Updated README.md with the new Proguard rules

## Jira Ticket
[WEBRTC-2661](https://telnyx.atlassian.net/browse/WEBRTC-2661)

[WEBRTC-2661]: https://telnyx.atlassian.net/browse/WEBRTC-2661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ