### PR TITLE
Saving voice_sdk_id after connection

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1249,6 +1249,14 @@ class TelnyxClient(
 
     // TxSocketListener Overrides
     override fun onClientReady(jsonObject: JsonObject) {
+        val voiceSdkID = jsonObject.getAsJsonPrimitive("voice_sdk_id")?.asString
+        if (voiceSdkID != null) {
+            Logger.d(message = "Voice SDK ID _ $voiceSdkID")
+            this@TelnyxClient.voiceSDKID = voiceSdkID
+        } else {
+            Logger.e(message = "No Voice SDK ID")
+        }
+
         if (gatewayState != GatewayState.REGED.state) {
             Logger.d(
                 message = Logger.formatMessage(


### PR DESCRIPTION
[ENGDESK-41158 - Connection not Recovered After Network Lost.](https://telnyx.atlassian.net/browse/ENGDESK-41158)

---
Issue 
When during outgoing call the network connection is lost and then it back, call won't be reconnected.

Solution
When the app is receiving onClientReady we need to keep voice_sdk_id and use it during another connection.

Steps to test:
- make outgoing call
- turn off network and turn on it again
- the active call should be reconnected
