### PR TITLE
WEBRTC-2677: Fix infinite loading dialog on login error

### DIFF
--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/MainActivity.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/MainActivity.kt
@@ -107,9 +107,6 @@ class MainActivity : AppCompatActivity(), DefaultLifecycleObserver {
         lifecycleScope.launch {
             telnyxViewModel.sessionsState.collect { sessionState ->
                 when (sessionState) {
-                    is TelnyxSessionState.OnClientError -> {
-                        Toast.makeText(this@MainActivity, sessionState.message, Toast.LENGTH_LONG).show()
-                    }
                     is TelnyxSessionState.ClientLoggedIn -> {
                         binding.socketStatusIcon.isEnabled = true
                         binding.socketStatusInfo.text = getString(R.string.client_ready)
@@ -143,6 +140,12 @@ class MainActivity : AppCompatActivity(), DefaultLifecycleObserver {
                         binding.callStateLabel.visibility = View.GONE
                     }
                 }
+            }
+        }
+
+        lifecycleScope.launch {
+            telnyxViewModel.sessionStateError.collect { error ->
+                error?.let { Toast.makeText(this@MainActivity, it, Toast.LENGTH_LONG).show() }
             }
         }
 

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -610,6 +610,7 @@ class TelnyxViewModel : ViewModel() {
                     response.errorMessage ?: "An Unknown Error Occurred"
                 )
         }
+        _isLoading.value = false
     }
 
     private fun handleDisconnect() {

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -42,6 +42,8 @@ import com.telnyx.webrtc.sdk.model.CallState
 import com.telnyx.webrtc.sdk.model.TxServerConfiguration
 import com.telnyx.webrtc.sdk.stats.CallQualityMetrics
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import java.io.IOException
 import java.util.*
 import kotlin.coroutines.resume
@@ -63,7 +65,6 @@ sealed class TelnyxSocketEvent {
 sealed class TelnyxSessionState {
     data class ClientLoggedIn(val message: LoginResponse) : TelnyxSessionState()
     data object ClientDisconnected : TelnyxSessionState()
-    data class OnClientError(val message: String): TelnyxSessionState()
 }
 
 /**
@@ -90,6 +91,13 @@ class TelnyxViewModel : ViewModel() {
     private val _sessionsState: MutableStateFlow<TelnyxSessionState> =
         MutableStateFlow(TelnyxSessionState.ClientDisconnected)
     val sessionsState: StateFlow<TelnyxSessionState> = _sessionsState.asStateFlow()
+
+    /**
+     * State flow for socket errors.
+     * Observe this flow to react to errors in the socket connection.
+     */
+    private val _sessionStateError = MutableSharedFlow<String?>()
+    val sessionStateError: SharedFlow<String?> = _sessionStateError
 
     /**
      * State flow for loading state.
@@ -605,11 +613,12 @@ class TelnyxViewModel : ViewModel() {
         if (currentCall == null) {
             _sessionsState.value = TelnyxSessionState.ClientDisconnected
             _uiState.value = TelnyxSocketEvent.InitState
-        } else {
-            _sessionsState.value = TelnyxSessionState.OnClientError(
-                    response.errorMessage ?: "An Unknown Error Occurred"
-                )
         }
+
+        viewModelScope.launch {
+            _sessionStateError.emit(response.errorMessage ?: "An Unknown Error Occurred")
+        }
+
         _isLoading.value = false
     }
 


### PR DESCRIPTION
## Description
This PR fixes the issue where the loading dialog would remain visible indefinitely when a login error occurs (e.g., incorrect password).

## Changes
- Updated the `handleError` method in `TelnyxViewModel` to set `_isLoading.value = false` when an error occurs, ensuring the loading dialog is dismissed.

## Jira Ticket
[WEBRTC-2677](https://telnyx.atlassian.net/browse/WEBRTC-2677)

[WEBRTC-2677]: https://telnyx.atlassian.net/browse/WEBRTC-2677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ