### PR TITLE
WEBRTC-2676: [Android] Navigate to login / connect screen and clear call states after DROPPED

### DIFF
--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -610,7 +610,7 @@ class TelnyxViewModel : ViewModel() {
     }
 
     private fun handleError(response: SocketResponse<ReceivedMessageBody>) {
-        if (currentCall == null || currentCall?.state == CallState.ERROR || currentCall?.state == CallState.DROPPED) {
+        if (currentCall == null || currentCall?.callStateFlow?.value == CallState.ERROR) {
             _sessionsState.value = TelnyxSessionState.ClientDisconnected
             _uiState.value = TelnyxSocketEvent.InitState
         }

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -610,7 +610,7 @@ class TelnyxViewModel : ViewModel() {
     }
 
     private fun handleError(response: SocketResponse<ReceivedMessageBody>) {
-        if (currentCall == null) {
+        if (currentCall == null || currentCall?.state == CallState.ERROR || currentCall?.state == CallState.DROPPED) {
             _sessionsState.value = TelnyxSessionState.ClientDisconnected
             _uiState.value = TelnyxSocketEvent.InitState
         }

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -609,6 +609,13 @@ class TelnyxViewModel : ViewModel() {
         Timber.i("Loading...")
     }
 
+    /**
+     * Handles an error response from the socket.
+     * It will navigate to the login screen only in two cases:
+     * - there is an error and there is not active call
+     * - there is an error during active call. This is happening after unsuccessfully reconnection.
+     * @param response The error response to handle.
+     */
     private fun handleError(response: SocketResponse<ReceivedMessageBody>) {
         if (currentCall == null || currentCall?.callStateFlow?.value == CallState.ERROR) {
             _sessionsState.value = TelnyxSessionState.ClientDisconnected


### PR DESCRIPTION
## Description
This PR addresses the issue described in [WEBRTC-2676](https://telnyx.atlassian.net/browse/WEBRTC-2676).

### Changes
- Modified the  function in  to set sessionState as Disconnected not only when currentCall is null but also when currentCall state is Error.
- This ensures the app navigates back to the login/connect screen after reconnection timeout.

### Testing
- Verified that the app correctly navigates to the login/connect screen when a call is dropped due to network issues.

### Related Issues
- [WEBRTC-2674](https://telnyx.atlassian.net/browse/WEBRTC-2674)

[WEBRTC-2676]: https://telnyx.atlassian.net/browse/WEBRTC-2676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBRTC-2674]: https://telnyx.atlassian.net/browse/WEBRTC-2674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ