### PR TITLE
WEBRTC-2675: [Android] Autologin for token when reacting to push credential

### DIFF
--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/authentication/AuthenticateByToken.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/authentication/AuthenticateByToken.kt
@@ -2,7 +2,9 @@ package com.telnyx.webrtc.common.domain.authentication
 
 import android.content.Context
 import androidx.lifecycle.LiveData
+import com.telnyx.webrtc.common.ProfileManager
 import com.telnyx.webrtc.common.TelnyxCommon
+import com.telnyx.webrtc.common.model.Profile
 import com.telnyx.webrtc.sdk.TokenConfig
 import com.telnyx.webrtc.sdk.model.TxServerConfiguration
 import com.telnyx.webrtc.sdk.verto.receive.ReceivedMessageBody
@@ -28,6 +30,16 @@ class AuthenticateByToken(private val context: Context) {
             tokenConfig,
             txPushMetaData,
             autoLogin
+        )
+
+        ProfileManager.saveProfile(
+            context, Profile(
+                sipToken = tokenConfig.sipToken,
+                callerIdName = tokenConfig.sipCallerIDName,
+                callerIdNumber = tokenConfig.sipCallerIDNumber,
+                isUserLoggedIn = true,
+                fcmToken = tokenConfig.fcmToken
+            )
         )
 
         return telnyxClient.getSocketResponse()

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/AnswerIncomingPushCall.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/AnswerIncomingPushCall.kt
@@ -7,6 +7,7 @@ import com.telnyx.webrtc.common.ProfileManager
 import com.telnyx.webrtc.common.TelnyxCommon
 import com.telnyx.webrtc.common.domain.call.AcceptCall
 import com.telnyx.webrtc.common.util.toCredentialConfig
+import com.telnyx.webrtc.common.util.toTokenConfig
 import com.telnyx.webrtc.sdk.Call
 import com.telnyx.webrtc.sdk.model.SocketMethod
 import com.telnyx.webrtc.sdk.model.SocketStatus
@@ -50,9 +51,18 @@ class AnswerIncomingPushCall(private val context: Context) {
 
         val telnyxClient = TelnyxCommon.getInstance().getTelnyxClient(context)
         ProfileManager.getProfilesList(context).lastOrNull()?.let { lastProfile ->
+            val fcmToken = lastProfile.fcmToken ?: ""
+            
+            // Use TokenConfig when sipToken is not null, otherwise use CredentialConfig
+            val config = if (lastProfile.sipToken != null) {
+                lastProfile.toTokenConfig(fcmToken)
+            } else {
+                lastProfile.toCredentialConfig(fcmToken)
+            }
+            
             telnyxClient.connect(
                 TxServerConfiguration(),
-                lastProfile.toCredentialConfig(lastProfile.fcmToken ?: ""),
+                config,
                 txPushMetaData,
                 true
             )

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/AnswerIncomingPushCall.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/AnswerIncomingPushCall.kt
@@ -54,18 +54,23 @@ class AnswerIncomingPushCall(private val context: Context) {
             val fcmToken = lastProfile.fcmToken ?: ""
             
             // Use TokenConfig when sipToken is not null, otherwise use CredentialConfig
-            val config = if (lastProfile.sipToken != null) {
-                lastProfile.toTokenConfig(fcmToken)
+            if (lastProfile.sipToken != null) {
+                telnyxClient.connect(
+                    TxServerConfiguration(),
+                    lastProfile.toTokenConfig(fcmToken),
+                    txPushMetaData,
+                    true
+                )
             } else {
-                lastProfile.toCredentialConfig(fcmToken)
+                telnyxClient.connect(
+                    TxServerConfiguration(),
+                    lastProfile.toCredentialConfig(fcmToken),
+                    txPushMetaData,
+                    true
+                )
             }
             
-            telnyxClient.connect(
-                TxServerConfiguration(),
-                config,
-                txPushMetaData,
-                true
-            )
+
             telnyxClient.getSocketResponse().observeForever(incomingCallObserver)
         }
 


### PR DESCRIPTION
## Description
This PR implements autologin for token when reacting to push credential.

### Changes
- Modified the AnswerIncomingPushCall class to use TokenConfig when sipToken is not null in the user profile
- Falls back to CredentialConfig when sipToken is null

### Jira Ticket
[WEBRTC-2675](https://telnyx.atlassian.net/browse/WEBRTC-2675)

### Testing
- Verified that the code correctly checks for the presence of sipToken and uses the appropriate configuration


[WEBRTC-2675]: https://telnyx.atlassian.net/browse/WEBRTC-2675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ