### PR TITLE
Fix: Push Notification call reject failed

### DIFF
--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -338,7 +338,7 @@ class TelnyxViewModel : ViewModel() {
         txPushMetaData: String?
     ) {
         _isLoading.value = true
-        TelnyxCommon.getInstance().setHandlingPush(false)
+        TelnyxCommon.getInstance().setHandlingPush(true)
         viewModelScope.launch {
             RejectIncomingPushCall(context = viewContext)
                 .invoke(txPushMetaData) {

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -597,6 +597,9 @@ class TelnyxViewModel : ViewModel() {
                 OnByeReceived().invoke(context, byeResponse.callId)
             }
 
+            // If we are handling a push notification, set the flag to false
+            TelnyxCommon.getInstance().setHandlingPush(false)
+
             _uiState.value = currentCall?.let {
                 TelnyxSocketEvent.OnCallAnswered(it.callId)
             } ?: TelnyxSocketEvent.OnCallEnded(byeResponse).also {


### PR DESCRIPTION
[WebRTC-2697 - Push Notification call reject failed.](https://telnyx.atlassian.net/browse/WEBRTC-2697)

---
Steps to reproduce the wrong state:

log in to the app

move app to the background

lock the screen

make incoming call

choose Reject option

After above steps the app will stuck in loading screen and call won’t be rejected.
