### PR TITLE
Webrtc 2698 - Fix: Debug Stats are created when call metrics is enabled

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/WebRTCReporter.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/WebRTCReporter.kt
@@ -92,7 +92,10 @@ internal class WebRTCReporter(
             type = "debug_report_start",
             debugReportId = debugStatsId.toString(),
         )
-        socket.send(debugStartMessage)
+
+        if (socketDebug)
+            socket.send(debugStartMessage)
+
         peer.peerConnectionObserver = PeerConnectionObserver(this)
 
         sendAddConnectionMessage()
@@ -109,7 +112,9 @@ internal class WebRTCReporter(
         val debugStopMessage = InitiateOrStopStatPrams(
             debugReportId = debugStatsId.toString(),
         )
-        socket.send(debugStopMessage)
+
+        if (socketDebug)
+            socket.send(debugStopMessage)
 
         debugStatsId = null
 


### PR DESCRIPTION
[WebRTC-2698 - Debug Stats are created when call metrics is enabled.](https://telnyx.atlassian.net/browse/WEBRTC-2698)

---
Steps to reproduce:
- enable call metrics
- disable config stats
- after the call debug stats will be created
