### PR TITLE
WEBRTC-2699: [Android] Call Quality Metrics UI Redesign

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 [WebRTC-XXX - Ticket Description.](https://telnyx.atlassian.net/browse/WEBRTC-XXX)
 
 ---
-<!-- Describe your changed here -->
+<!-- Describe your changes here -->
 
 <!-- Doing a release? Please remove the section above and instead copy the following test matrix markdown: -->
 <!-- https://app.getguru.com/card/ijMaorgT/WebRTC-Squad-Mobile-Voice-SDK-Release-Checklist- -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,8 @@
 ---
 <!-- Describe your changed here -->
 
+<!-- Doing a release? Please remove the section above and instead copy the following test matrix markdown: -->
+<!-- https://app.getguru.com/card/ijMaorgT/WebRTC-Squad-Mobile-Voice-SDK-Release-Checklist- -->
 
 ## :older_man: :baby: Behaviors
 ### Before changes

--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/components/CallQualityDisplay.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/components/CallQualityDisplay.kt
@@ -1,6 +1,7 @@
 package org.telnyx.webrtc.compose_app.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,7 +10,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -18,12 +21,20 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.telnyx.webrtc.sdk.stats.CallQuality
 import com.telnyx.webrtc.sdk.stats.CallQualityMetrics
+import org.telnyx.webrtc.compose_app.R
+import org.telnyx.webrtc.compose_app.ui.theme.Dimens
+import org.telnyx.webrtc.compose_app.ui.theme.secondary_background_color
 import org.telnyx.webrtc.compose_app.ui.viewcomponents.AudioWaveform
+import org.telnyx.webrtc.compose_app.ui.viewcomponents.MediumTextBold
+import org.telnyx.webrtc.compose_app.ui.viewcomponents.RegularText
+import org.telnyx.webrtc.compose_app.utils.capitalizeFirstChar
 
 /**
  * A composable that displays call quality metrics.
@@ -42,107 +53,98 @@ fun CallQualityDisplay(
 ) {
     if (metrics == null && inboundLevels.isEmpty() && outboundLevels.isEmpty()) return
 
-    Card(
-        modifier = modifier
+    Column(
+        modifier = Modifier
             .fillMaxWidth()
-            .padding(16.dp),
-        shape = RoundedCornerShape(8.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(Dimens.spacing16dp)
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        ) {
-            // Show detailed metrics once quality is known
-            Text(
-                text = "Call Quality Metrics",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold
+        if (metrics?.quality == CallQuality.UNKNOWN) {
+            // Show loading indicator if quality is unknown
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(modifier = Modifier.width(24.dp)) // Adjust size as needed
+            }
+        } else {
+            // Jitter
+            MetricRow(
+                label = stringResource(R.string.call_quality_metrics_jitter),
+                value = String.format("%.2f ms", metrics?.jitter?.times(1000) ?: 0.0)
+            )
+
+            // MOS score
+            MetricRow(
+                label = stringResource(R.string.call_quality_metrics_mos),
+                value = String.format("%.2f", metrics?.mos ?: 0.0)
+            )
+
+            // Quality
+            MetricRow(
+                label = stringResource(R.string.call_quality_metrics_quality),
+                value = metrics?.quality?.name?.capitalizeFirstChar() ?: stringResource(
+                    R.string.unknown_label)
+            )
+
+            // Round-trip time
+            MetricRow(
+                label = stringResource(R.string.call_quality_metrics_round_trip_time),
+                value = String.format("%.2f ms", metrics?.rtt?.times(1000) ?: 0.0)
+            )
+
+            //Inbound audio
+            RegularText(text = stringResource(R.string.call_quality_metrics_inbound_audio),
+                size = Dimens.textSize16sp,
+                fontWeight = FontWeight.SemiBold)
+
+            metrics?.inboundAudio?.forEach { (key, value) ->
+                MetricRow(key.capitalizeFirstChar() ?: stringResource(R.string.unknown_label), value.toString())
+            }
+
+            //Outbound audio
+            RegularText(text = stringResource(R.string.call_quality_metrics_outbound_audio),
+                size = Dimens.textSize16sp,
+                fontWeight = FontWeight.SemiBold)
+
+            metrics?.outboundAudio?.forEach { (key, value) ->
+                MetricRow(key.capitalizeFirstChar() ?: stringResource(R.string.unknown_label), value.toString())
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Inbound Waveform
+            RegularText(text = stringResource(R.string.call_quality_metrics_inbound_audio_level),
+                size = Dimens.textSize16sp,
+                fontWeight = FontWeight.SemiBold)
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            AudioWaveform(
+                audioLevels = inboundLevels,
+                barColor = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(50.dp)
             )
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            if (metrics?.quality == CallQuality.UNKNOWN) {
-                // Show loading indicator if quality is unknown
-                Box(
-                    modifier = Modifier.fillMaxWidth(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator(modifier = Modifier.width(24.dp)) // Adjust size as needed
-                }
-            } else {
+            // Outbound Waveform
+            RegularText(text = stringResource(R.string.call_quality_metrics_outbound_audio_level),
+                size = Dimens.textSize16sp,
+                fontWeight = FontWeight.SemiBold)
 
-                // Quality indicator
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text(
-                        text = "Quality:",
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Bold
-                    )
+            Spacer(modifier = Modifier.height(4.dp))
 
-                    Spacer(modifier = Modifier.width(8.dp))
-
-                    QualityIndicator(quality = metrics?.quality ?: CallQuality.UNKNOWN)
-                }
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                // MOS score
-                MetricRow(
-                    label = "MOS Score:",
-                    value = String.format("%.2f", metrics?.mos ?: 0.0)
-                )
-
-                // Jitter
-                MetricRow(
-                    label = "Jitter:",
-                    value = String.format("%.2f ms", metrics?.jitter?.times(1000) ?: 0.0)
-                )
-
-                // Round-trip time
-                MetricRow(
-                    label = "Round-trip Time:",
-                    value = String.format("%.2f ms", metrics?.rtt?.times(1000) ?: 0.0)
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Inbound Waveform
-                Text(
-                    text = "Inbound Level:",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Bold
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                AudioWaveform(
-                    audioLevels = inboundLevels,
-                    barColor = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(50.dp)
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Outbound Waveform
-                Text(
-                    text = "Outbound Level:",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Bold
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                AudioWaveform(
-                    audioLevels = outboundLevels,
-                    barColor = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(50.dp)
-                )
-            }
+            AudioWaveform(
+                audioLevels = outboundLevels,
+                barColor = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(50.dp)
+            )
         }
     }
 }
@@ -161,62 +163,23 @@ private fun MetricRow(
     modifier: Modifier = Modifier
 ) {
     Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier.fillMaxWidth()
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.Bold
-        )
-
-        Spacer(modifier = Modifier.width(8.dp))
-
-        Text(
-            text = value,
-            style = MaterialTheme.typography.bodyMedium
-        )
-    }
-}
-
-/**
- * A visual indicator of call quality.
- *
- * @param quality The call quality to display.
- * @param modifier Optional modifier for the component.
- */
-@Composable
-private fun QualityIndicator(
-    quality: CallQuality,
-    modifier: Modifier = Modifier
-) {
-    val (color, text) = when (quality) {
-        CallQuality.EXCELLENT -> Color(0xFF4CAF50) to "Excellent"
-        CallQuality.GOOD -> Color(0xFF8BC34A) to "Good"
-        CallQuality.FAIR -> Color(0xFFFFC107) to "Fair"
-        CallQuality.POOR -> Color(0xFFFF9800) to "Poor"
-        CallQuality.BAD -> Color(0xFFF44336) to "Bad"
-        CallQuality.UNKNOWN -> Color(0xFF9E9E9E) to "Unknown"
-    }
-
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(Dimens.size4dp))
+            .background(secondary_background_color)
+            .padding(start = Dimens.mediumPadding, end = Dimens.mediumPadding, top = Dimens.smallPadding, bottom = Dimens.smallPadding),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        // Color indicator
-        Spacer(
+        RegularText(
             modifier = Modifier
-                .width(16.dp)
-                .height(16.dp)
-                .background(color, RoundedCornerShape(4.dp))
-        )
+                .padding(end = Dimens.smallPadding),
+            text = label)
 
-        Spacer(modifier = Modifier.width(8.dp))
+        Spacer(modifier = Modifier.weight(1f))
 
-        // Quality text
-        Text(
-            text = text,
-            style = MaterialTheme.typography.bodyMedium
-        )
+        RegularText(text = value,
+            size = Dimens.textSize16sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1)
     }
 }

--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
@@ -83,6 +83,7 @@ import org.telnyx.webrtc.compose_app.ui.viewcomponents.MediumTextBold
 import org.telnyx.webrtc.compose_app.ui.viewcomponents.RegularText
 import org.telnyx.webrtc.compose_app.ui.viewcomponents.RoundSmallButton
 import org.telnyx.webrtc.compose_app.ui.viewcomponents.RoundedOutlinedButton
+import org.telnyx.webrtc.compose_app.utils.capitalizeFirstChar
 import timber.log.Timber
 
 @Serializable
@@ -730,7 +731,7 @@ fun BottomBar(
                     stringResource(R.string.development_label)
                 } else {
                     stringResource(R.string.production_label)
-                }.replaceFirstChar { it.uppercaseChar() }
+                }.capitalizeFirstChar()!!
 
                 RegularText(text = stringResource(R.string.bottom_bar_production_text, environmentLabel, TelnyxClient.SDK_VERSION, BuildConfig.VERSION_NAME),
                         color = MaterialTheme.colorScheme.tertiary,

--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/theme/Color.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/theme/Color.kt
@@ -24,3 +24,8 @@ val MainGreen = Color(0xFF008563)
 
 val DroppedIconColor = Color(0xFF93928D)
 val RingingIconColor = Color(0xFF3434EF)
+
+val CallQualityGoodColor = Color(0xFF8BC34A)
+val CallQualityFairColor = Color(0xFFFFC107)
+val CallQualityPoorColor = Color(0xFFFF9800)
+val CallQualityBadColor = Color(0xFFF44336)

--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/viewcomponents/Text.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/viewcomponents/Text.kt
@@ -111,17 +111,20 @@ fun RegularText(
     color: Color = MaterialTheme.colorScheme.onSurface,
     size: TextUnit = 14.sp,
     textAlign: TextAlign = TextAlign.Start,
-    fontStyle: FontStyle = FontStyle.Normal
+    fontStyle: FontStyle = FontStyle.Normal,
+    fontWeight: FontWeight = FontWeight.Normal,
+    maxLines: Int = 2
 ) {
     Text(
         text ?: "",
         modifier = modifier,
         color = color,
         fontSize = size,
-        fontWeight = FontWeight.Normal,
+        fontWeight = fontWeight,
         textAlign = textAlign,
         fontStyle = fontStyle,
-        overflow = TextOverflow.Ellipsis
+        overflow = TextOverflow.Ellipsis,
+        maxLines = maxLines
     )
 }
 

--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/utils/StringExtensions.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/utils/StringExtensions.kt
@@ -1,0 +1,5 @@
+package org.telnyx.webrtc.compose_app.utils
+
+fun String?.capitalizeFirstChar(): String? {
+    return this?.lowercase()?.replaceFirstChar { it.titlecase() }
+}

--- a/samples/compose_app/src/main/res/values/strings.xml
+++ b/samples/compose_app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="end_and_accept">End and Accept</string>
     <string name="reject_incoming">Reject Incoming</string>
     <string name="hold_and_accept">Hold and Accept</string>
+    <string name="unknown_label">Unknown</string>
 
     <string name="end">End</string>
 
@@ -100,4 +101,16 @@
     <string name="call_state_connecting">Connecting</string>
     <string name="call_state_dropped">Dropped</string>
     <string name="call_state_reconnecting">Reconnecting</string>
+    
+    <string name="call_metrics_label">Call quality</string>
+    <string name="call_metrics_button">View all call metrics</string>
+    <string name="call_quality_metrics_title">Call Quality Metrics</string>
+    <string name="call_quality_metrics_jitter">Jitter:</string>
+    <string name="call_quality_metrics_mos">MOS:</string>
+    <string name="call_quality_metrics_round_trip_time">Round-trip Time:</string>
+    <string name="call_quality_metrics_quality">Quality:</string>
+    <string name="call_quality_metrics_inbound_audio">Inbound Audio</string>
+    <string name="call_quality_metrics_outbound_audio">Outbound Audio</string>
+    <string name="call_quality_metrics_inbound_audio_level">Inbound Level:</string>
+    <string name="call_quality_metrics_outbound_audio_level">Outbound Level:</string>
 </resources>

--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/MainActivity.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/MainActivity.kt
@@ -107,9 +107,6 @@ class MainActivity : AppCompatActivity(), DefaultLifecycleObserver {
         lifecycleScope.launch {
             telnyxViewModel.sessionsState.collect { sessionState ->
                 when (sessionState) {
-                    is TelnyxSessionState.OnClientError -> {
-                        Toast.makeText(this@MainActivity, sessionState.message, Toast.LENGTH_LONG).show()
-                    }
                     is TelnyxSessionState.ClientLoggedIn -> {
                         binding.socketStatusIcon.isEnabled = true
                         binding.socketStatusInfo.text = getString(R.string.client_ready)
@@ -143,6 +140,12 @@ class MainActivity : AppCompatActivity(), DefaultLifecycleObserver {
                         binding.callStateLabel.visibility = View.GONE
                     }
                 }
+            }
+        }
+
+        lifecycleScope.launch {
+            telnyxViewModel.sessionStateError.collect { error ->
+                error?.let { Toast.makeText(this@MainActivity, it, Toast.LENGTH_LONG).show() }
             }
         }
 

--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/home/CallQualityBottomSheetFragment.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/home/CallQualityBottomSheetFragment.kt
@@ -1,0 +1,102 @@
+package org.telnyx.webrtc.xml_app.home
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.fragment.app.activityViewModels
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.telnyx.webrtc.common.TelnyxViewModel
+import com.telnyx.webrtc.sdk.stats.CallQuality
+import com.telnyx.webrtc.sdk.stats.CallQualityMetrics
+import org.telnyx.webrtc.xmlapp.R
+import org.telnyx.webrtc.xmlapp.databinding.CallQualityBottomSheetBinding
+import java.util.Locale
+
+class CallQualityBottomSheetFragment : BottomSheetDialogFragment() {
+
+    private var _binding: CallQualityBottomSheetBinding? = null
+    private val binding get() = _binding!!
+
+    private val telnyxViewModel: TelnyxViewModel by activityViewModels()
+    private var metrics: CallQualityMetrics? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = CallQualityBottomSheetBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.closeButton.setOnClickListener {
+            dismiss()
+        }
+
+        // Get the current metrics from the ViewModel
+        metrics = telnyxViewModel.callQualityMetrics.value
+        updateUI(metrics)
+    }
+
+    private fun updateUI(metrics: CallQualityMetrics?) {
+        if (metrics == null) {
+            binding.progressQualityLoading.visibility = View.VISIBLE
+            binding.qualityDetailsLayout.visibility = View.GONE
+            return
+        }
+
+        binding.progressQualityLoading.visibility = View.GONE
+        binding.qualityDetailsLayout.visibility = View.VISIBLE
+
+        // Update basic metrics
+        binding.textJitterValue.text = String.format(Locale.US, "%.2f ms", metrics.jitter * 1000)
+        binding.textMosValue.text = String.format(Locale.US, "%.2f", metrics.mos)
+        binding.textQualityValue.text = capitalizeFirstChar(metrics.quality.name)
+        binding.textRttValue.text = String.format(Locale.US, "%.2f ms", metrics.rtt * 1000)
+
+        // Clear and update inbound audio metrics
+        binding.inboundAudioContainer.removeAllViews()
+        metrics.inboundAudio?.forEach { (key, value) ->
+            addMetricRow(binding.inboundAudioContainer, capitalizeFirstChar(key), value.toString())
+        }
+
+        // Clear and update outbound audio metrics
+        binding.outboundAudioContainer.removeAllViews()
+        metrics.outboundAudio?.forEach { (key, value) ->
+            addMetricRow(binding.outboundAudioContainer, capitalizeFirstChar(key), value.toString())
+        }
+
+        // In a real implementation, you would update the waveform views here
+        // For now, we'll just use placeholder views
+    }
+
+    private fun addMetricRow(container: LinearLayout, label: String, value: String) {
+        val inflater = LayoutInflater.from(requireContext())
+        val rowView = inflater.inflate(R.layout.metric_row_item, container, false)
+        
+        rowView.findViewById<TextView>(R.id.metric_label).text = label
+        rowView.findViewById<TextView>(R.id.metric_value).text = value
+        
+        container.addView(rowView)
+    }
+
+    private fun capitalizeFirstChar(str: String?): String {
+        if (str.isNullOrEmpty()) return ""
+        return str.lowercase().replaceFirstChar { it.uppercase() }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        const val TAG = "CallQualityBottomSheetFragment"
+    }
+}

--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/home/HomeCallFragment.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/home/HomeCallFragment.kt
@@ -44,7 +44,7 @@ class HomeCallFragment : Fragment() {
     private val telnyxViewModel: TelnyxViewModel by activityViewModels()
 
     private lateinit var dialpadFragment: DialpadFragment
-    private var callQualityBottomSheetFragment: CallQualityBottomSheetFragment? = null
+    private lateinit var callQualityBottomSheetFragment: CallQualityBottomSheetFragment
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -59,6 +59,7 @@ class HomeCallFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         dialpadFragment = DialpadFragment()
+        callQualityBottomSheetFragment = CallQualityBottomSheetFragment()
 
         setupUI()
         bindEvents()
@@ -128,14 +129,12 @@ class HomeCallFragment : Fragment() {
     }
 
     private fun showCallQualityBottomSheet() {
-        if (callQualityBottomSheetFragment == null) {
-            callQualityBottomSheetFragment = CallQualityBottomSheetFragment()
+        if (!callQualityBottomSheetFragment.isAdded) {
+            callQualityBottomSheetFragment.show(
+                requireActivity().supportFragmentManager,
+                CallQualityBottomSheetFragment.TAG
+            )
         }
-        
-        callQualityBottomSheetFragment?.show(
-            requireActivity().supportFragmentManager,
-            CallQualityBottomSheetFragment.TAG
-        )
     }
 
     private fun bindEvents() {
@@ -184,6 +183,9 @@ class HomeCallFragment : Fragment() {
         binding.callInput.isEnabled = true
         callQualitySummaryBinding.root.visibility = View.GONE
         callQualityBinding.root.visibility = View.GONE
+        if (callQualityBottomSheetFragment.isAdded) {
+            callQualityBottomSheetFragment.dismiss()
+        }
     }
 
     private fun onCallActive() {
@@ -204,6 +206,10 @@ class HomeCallFragment : Fragment() {
         binding.destinationInfo.visibility = View.GONE
         callQualitySummaryBinding.root.visibility = View.GONE
         callQualityBinding.root.visibility = View.GONE
+
+        if (callQualityBottomSheetFragment.isAdded) {
+            callQualityBottomSheetFragment.dismiss()
+        }
 
         binding.callAnswer.setOnClickListener {
             telnyxViewModel.answerCall(requireContext(), callId, callerIdNumber, true) // Enable call quality stats
@@ -276,14 +282,21 @@ class HomeCallFragment : Fragment() {
     }
 
     private fun getQualityIndicatorData(quality: CallQuality): Pair<Int, String> {
-        return when (quality) {
-            CallQuality.EXCELLENT -> R.color.quality_excellent to "Excellent"
-            CallQuality.GOOD -> R.color.quality_good to "Good"
-            CallQuality.FAIR -> R.color.quality_fair to "Fair"
-            CallQuality.POOR -> R.color.quality_poor to "Poor"
-            CallQuality.BAD -> R.color.quality_bad to "Bad"
-            CallQuality.UNKNOWN -> R.color.quality_unknown to "Unknown"
+        val color = when (quality) {
+            CallQuality.EXCELLENT -> R.color.quality_excellent
+            CallQuality.GOOD -> R.color.quality_good
+            CallQuality.FAIR -> R.color.quality_fair
+            CallQuality.POOR -> R.color.quality_poor
+            CallQuality.BAD -> R.color.quality_bad
+            CallQuality.UNKNOWN -> R.color.quality_unknown
         }
+
+        return Pair(color, capitalizeFirstChar(quality.name))
+    }
+
+    private fun capitalizeFirstChar(str: String?): String {
+        if (str.isNullOrEmpty()) return ""
+        return str.lowercase().replaceFirstChar { it.uppercase() }
     }
 
     override fun onDestroyView() {

--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/utils/FloatExtensions.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/utils/FloatExtensions.kt
@@ -1,0 +1,9 @@
+package org.telnyx.webrtc.xml_app.utils
+
+import android.content.Context
+
+fun Float.dpToPx(context: Context): Int =
+    (this * context.resources.displayMetrics.density).toInt()
+
+fun Int.dpToPx(context: Context): Int =
+    (this * context.resources.displayMetrics.density).toInt()

--- a/samples/xml_app/src/main/res/drawable/metric_row_background.xml
+++ b/samples/xml_app/src/main/res/drawable/metric_row_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/colorSecondary" />
+    <corners android:radius="4dp" />
+</shape>

--- a/samples/xml_app/src/main/res/drawable/quality_dot_shape.xml
+++ b/samples/xml_app/src/main/res/drawable/quality_dot_shape.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/quality_unknown" />
+</shape>

--- a/samples/xml_app/src/main/res/layout/call_quality_bottom_sheet.xml
+++ b/samples/xml_app/src/main/res/layout/call_quality_bottom_sheet.xml
@@ -4,7 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="16dp">
+    android:padding="16dp"
+    android:focusable="true"
+    >
 
     <LinearLayout
         android:id="@+id/header_container"
@@ -34,7 +36,7 @@
             android:src="@drawable/ic_close" />
     </LinearLayout>
 
-    <ScrollView
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_marginTop="16dp"
@@ -224,11 +226,15 @@
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
                     android:textStyle="bold" />
 
-                <View
+                <LinearLayout
                     android:id="@+id/inbound_audio_waveform"
                     android:layout_width="match_parent"
                     android:layout_height="50dp"
-                    android:background="@color/colorSecondary" />
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:layout_margin="8dp"
+                    android:baselineAligned="false"
+                    android:background="@color/colorSecondary"/>
 
                 <!-- Outbound Level -->
                 <TextView
@@ -240,13 +246,17 @@
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
                     android:textStyle="bold" />
 
-                <View
+                <LinearLayout
                     android:id="@+id/outbound_audio_waveform"
                     android:layout_width="match_parent"
                     android:layout_height="50dp"
-                    android:background="@color/colorSecondary" />
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:layout_margin="8dp"
+                    android:baselineAligned="false"
+                    android:background="@color/colorSecondary"/>
 
             </LinearLayout>
         </LinearLayout>
-    </ScrollView>
+    </androidx.core.widget.NestedScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/samples/xml_app/src/main/res/layout/call_quality_bottom_sheet.xml
+++ b/samples/xml_app/src/main/res/layout/call_quality_bottom_sheet.xml
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:id="@+id/header_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/title_call_quality"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/call_quality_metrics_title"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
+            android:textStyle="bold" />
+
+        <ImageButton
+            android:id="@+id/close_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/close_button_dessc"
+            android:padding="8dp"
+            android:src="@drawable/ic_close" />
+    </LinearLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/header_container">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <ProgressBar
+                android:id="@+id/progress_quality_loading"
+                style="?android:attr/progressBarStyleSmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginTop="16dp"
+                android:visibility="gone" />
+
+            <LinearLayout
+                android:id="@+id/quality_details_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:visibility="visible">
+
+                <!-- Jitter -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:background="@drawable/metric_row_background"
+                    android:orientation="horizontal"
+                    android:padding="12dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/call_quality_metrics_jitter"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+                    <Space
+                        android:layout_width="0dp"
+                        android:layout_height="1dp"
+                        android:layout_weight="1" />
+
+                    <TextView
+                        android:id="@+id/text_jitter_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                        android:textStyle="bold"
+                        tools:text="10.2 ms" />
+                </LinearLayout>
+
+                <!-- MOS -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:background="@drawable/metric_row_background"
+                    android:orientation="horizontal"
+                    android:padding="12dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/call_quality_metrics_mos"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+                    <Space
+                        android:layout_width="0dp"
+                        android:layout_height="1dp"
+                        android:layout_weight="1" />
+
+                    <TextView
+                        android:id="@+id/text_mos_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                        android:textStyle="bold"
+                        tools:text="4.50" />
+                </LinearLayout>
+
+                <!-- Quality -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:background="@drawable/metric_row_background"
+                    android:orientation="horizontal"
+                    android:padding="12dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/call_quality_metrics_quality"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+                    <Space
+                        android:layout_width="0dp"
+                        android:layout_height="1dp"
+                        android:layout_weight="1" />
+
+                    <TextView
+                        android:id="@+id/text_quality_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                        android:textStyle="bold"
+                        tools:text="Good" />
+                </LinearLayout>
+
+                <!-- Round-trip Time -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:background="@drawable/metric_row_background"
+                    android:orientation="horizontal"
+                    android:padding="12dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/call_quality_metrics_round_trip_time"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+                    <Space
+                        android:layout_width="0dp"
+                        android:layout_height="1dp"
+                        android:layout_weight="1" />
+
+                    <TextView
+                        android:id="@+id/text_rtt_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                        android:textStyle="bold"
+                        tools:text="150.5 ms" />
+                </LinearLayout>
+
+                <!-- Inbound Audio Section -->
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginBottom="8dp"
+                    android:text="@string/call_quality_metrics_inbound_audio"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                    android:textStyle="bold" />
+
+                <LinearLayout
+                    android:id="@+id/inbound_audio_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+                    <!-- Inbound audio metrics will be added dynamically -->
+                </LinearLayout>
+
+                <!-- Outbound Audio Section -->
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginBottom="8dp"
+                    android:text="@string/call_quality_metrics_outbound_audio"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                    android:textStyle="bold" />
+
+                <LinearLayout
+                    android:id="@+id/outbound_audio_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+                    <!-- Outbound audio metrics will be added dynamically -->
+                </LinearLayout>
+
+                <!-- Inbound Level -->
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginBottom="8dp"
+                    android:text="@string/call_quality_metrics_inbound_audio_level"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                    android:textStyle="bold" />
+
+                <View
+                    android:id="@+id/inbound_audio_waveform"
+                    android:layout_width="match_parent"
+                    android:layout_height="50dp"
+                    android:background="@color/colorSecondary" />
+
+                <!-- Outbound Level -->
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginBottom="8dp"
+                    android:text="@string/call_quality_metrics_outbound_audio_level"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                    android:textStyle="bold" />
+
+                <View
+                    android:id="@+id/outbound_audio_waveform"
+                    android:layout_width="match_parent"
+                    android:layout_height="50dp"
+                    android:background="@color/colorSecondary" />
+
+            </LinearLayout>
+        </LinearLayout>
+    </ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/samples/xml_app/src/main/res/layout/call_quality_summary.xml
+++ b/samples/xml_app/src/main/res/layout/call_quality_summary.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingBottom="16dp">
+
+    <TextView
+        android:id="@+id/call_quality_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/call_quality_label"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <LinearLayout
+        android:id="@+id/quality_indicator_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/call_quality_label">
+
+        <View
+            android:id="@+id/quality_dot"
+            android:layout_width="12dp"
+            android:layout_height="12dp"
+            android:background="@drawable/quality_dot_shape" />
+
+        <TextView
+            android:id="@+id/quality_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+            tools:text="Good" />
+
+        <Space
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_weight="1" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/view_all_metrics_button"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:layout_width="wrap_content"
+            android:layout_height="32dp"
+            android:text="@string/view_all_call_metrics"
+            android:textSize="14sp"
+            app:cornerRadius="16dp"
+            app:strokeColor="@color/main_green"
+            app:strokeWidth="1dp" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/samples/xml_app/src/main/res/layout/call_quality_summary.xml
+++ b/samples/xml_app/src/main/res/layout/call_quality_summary.xml
@@ -15,7 +15,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/quality_indicator_container"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -30,7 +30,10 @@
             android:id="@+id/quality_dot"
             android:layout_width="12dp"
             android:layout_height="12dp"
-            android:background="@drawable/quality_dot_shape" />
+            android:background="@drawable/quality_dot_shape"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
 
         <TextView
             android:id="@+id/quality_text"
@@ -38,23 +41,27 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
-            tools:text="Good" />
+            tools:text="Good"
+            app:layout_constraintStart_toEndOf="@id/quality_dot"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
 
-        <Space
-            android:layout_width="0dp"
-            android:layout_height="1dp"
-            android:layout_weight="1" />
-
-        <com.google.android.material.button.MaterialButton
+        <Button
             android:id="@+id/view_all_metrics_button"
-            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
             android:layout_width="wrap_content"
-            android:layout_height="32dp"
+            android:layout_height="@dimen/spacing_medium"
+            android:layout_marginStart="@dimen/spacing_normal"
             android:text="@string/view_all_call_metrics"
-            android:textSize="14sp"
-            app:cornerRadius="16dp"
-            app:strokeColor="@color/main_green"
-            app:strokeWidth="1dp" />
-    </LinearLayout>
+            android:textAllCaps="false"
+            android:paddingStart="@dimen/spacing_tiny"
+            android:paddingEnd="@dimen/spacing_tiny"
+            android:layout_marginTop="1dp"
+            style="@style/CustomOutlinedButton"
+            android:textSize="@dimen/font_button"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/samples/xml_app/src/main/res/layout/fragment_home_call.xml
+++ b/samples/xml_app/src/main/res/layout/fragment_home_call.xml
@@ -114,6 +114,14 @@
                 app:layout_constraintTop_toBottomOf="@+id/destinationInfo"
                 android:visibility="gone">
 
+                <!-- Call Quality Summary - New UI -->
+                <include
+                    android:id="@+id/call_quality_summary"
+                    layout="@layout/call_quality_summary"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone" />
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -182,6 +190,7 @@
 
                 </LinearLayout>
 
+                <!-- Old Call Quality Display - Will be shown in bottom sheet now -->
                 <include
                     android:id="@+id/call_quality_display"
                     layout="@layout/call_quality_display"

--- a/samples/xml_app/src/main/res/layout/metric_row_item.xml
+++ b/samples/xml_app/src/main/res/layout/metric_row_item.xml
@@ -13,7 +13,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
-        tools:text="Metric Label" />
+        tools:text="Metric Label"
+        android:layout_marginEnd="@dimen/spacing_tiny"/>
 
     <Space
         android:layout_width="0dp"
@@ -26,5 +27,7 @@
         android:layout_height="wrap_content"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
         android:textStyle="bold"
-        tools:text="Metric Value" />
+        tools:text="Metric Value"
+        android:ellipsize="end"
+        android:maxLines="1"/>
 </LinearLayout>

--- a/samples/xml_app/src/main/res/layout/metric_row_item.xml
+++ b/samples/xml_app/src/main/res/layout/metric_row_item.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp"
+    android:background="@drawable/metric_row_background"
+    android:orientation="horizontal"
+    android:padding="12dp">
+
+    <TextView
+        android:id="@+id/metric_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+        tools:text="Metric Label" />
+
+    <Space
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_weight="1" />
+
+    <TextView
+        android:id="@+id/metric_value"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+        android:textStyle="bold"
+        tools:text="Metric Value" />
+</LinearLayout>

--- a/samples/xml_app/src/main/res/values/strings.xml
+++ b/samples/xml_app/src/main/res/values/strings.xml
@@ -86,4 +86,17 @@
     <string name="call_state_connecting">Connecting</string>
     <string name="call_state_dropped">Dropped</string>
     <string name="call_state_reconnecting">Reconnecting</string>
+    
+    <string name="call_quality_label">Call quality</string>
+    <string name="view_all_call_metrics">View all call metrics</string>
+    <string name="call_quality_metrics_title">Call Quality Metrics</string>
+    <string name="call_quality_metrics_jitter">Jitter:</string>
+    <string name="call_quality_metrics_mos">MOS:</string>
+    <string name="call_quality_metrics_round_trip_time">Round-trip Time:</string>
+    <string name="call_quality_metrics_quality">Quality:</string>
+    <string name="call_quality_metrics_inbound_audio">Inbound Audio</string>
+    <string name="call_quality_metrics_outbound_audio">Outbound Audio</string>
+    <string name="call_quality_metrics_inbound_audio_level">Inbound Level:</string>
+    <string name="call_quality_metrics_outbound_audio_level">Outbound Level:</string>
+    <string name="unknown_label">Unknown</string>
 </resources>

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -609,8 +609,15 @@ class TelnyxViewModel : ViewModel() {
         Timber.i("Loading...")
     }
 
+    /**
+     * Handles an error response from the socket.
+     * It will navigate to the login screen only in two cases:
+     * - there is an error and there is not active call
+     * - there is an error during active call. This is happening after unsuccessfully reconnection.
+     * @param response The error response to handle.
+     */
     private fun handleError(response: SocketResponse<ReceivedMessageBody>) {
-        if (currentCall == null) {
+        if (currentCall == null || currentCall?.callStateFlow?.value == CallState.ERROR) {
             _sessionsState.value = TelnyxSessionState.ClientDisconnected
             _uiState.value = TelnyxSocketEvent.InitState
         }

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -338,7 +338,7 @@ class TelnyxViewModel : ViewModel() {
         txPushMetaData: String?
     ) {
         _isLoading.value = true
-        TelnyxCommon.getInstance().setHandlingPush(false)
+        TelnyxCommon.getInstance().setHandlingPush(true)
         viewModelScope.launch {
             RejectIncomingPushCall(context = viewContext)
                 .invoke(txPushMetaData) {
@@ -596,6 +596,9 @@ class TelnyxViewModel : ViewModel() {
             context?.let {
                 OnByeReceived().invoke(context, byeResponse.callId)
             }
+
+            // If we are handling a push notification, set the flag to false
+            TelnyxCommon.getInstance().setHandlingPush(false)
 
             _uiState.value = currentCall?.let {
                 TelnyxSocketEvent.OnCallAnswered(it.callId)

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -338,7 +338,7 @@ class TelnyxViewModel : ViewModel() {
         txPushMetaData: String?
     ) {
         _isLoading.value = true
-        TelnyxCommon.getInstance().setHandlingPush(true)
+        TelnyxCommon.getInstance().setHandlingPush(false)
         viewModelScope.launch {
             RejectIncomingPushCall(context = viewContext)
                 .invoke(txPushMetaData) {

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -42,6 +42,8 @@ import com.telnyx.webrtc.sdk.model.CallState
 import com.telnyx.webrtc.sdk.model.TxServerConfiguration
 import com.telnyx.webrtc.sdk.stats.CallQualityMetrics
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import java.io.IOException
 import java.util.*
 import kotlin.coroutines.resume
@@ -63,7 +65,6 @@ sealed class TelnyxSocketEvent {
 sealed class TelnyxSessionState {
     data class ClientLoggedIn(val message: LoginResponse) : TelnyxSessionState()
     data object ClientDisconnected : TelnyxSessionState()
-    data class OnClientError(val message: String): TelnyxSessionState()
 }
 
 /**
@@ -90,6 +91,13 @@ class TelnyxViewModel : ViewModel() {
     private val _sessionsState: MutableStateFlow<TelnyxSessionState> =
         MutableStateFlow(TelnyxSessionState.ClientDisconnected)
     val sessionsState: StateFlow<TelnyxSessionState> = _sessionsState.asStateFlow()
+
+    /**
+     * State flow for socket errors.
+     * Observe this flow to react to errors in the socket connection.
+     */
+    private val _sessionStateError = MutableSharedFlow<String?>()
+    val sessionStateError: SharedFlow<String?> = _sessionStateError
 
     /**
      * State flow for loading state.
@@ -605,11 +613,13 @@ class TelnyxViewModel : ViewModel() {
         if (currentCall == null) {
             _sessionsState.value = TelnyxSessionState.ClientDisconnected
             _uiState.value = TelnyxSocketEvent.InitState
-        } else {
-            _sessionsState.value = TelnyxSessionState.OnClientError(
-                    response.errorMessage ?: "An Unknown Error Occurred"
-                )
         }
+
+        viewModelScope.launch {
+            _sessionStateError.emit(response.errorMessage ?: "An Unknown Error Occurred")
+        }
+
+        _isLoading.value = false
     }
 
     private fun handleDisconnect() {

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/AnswerIncomingPushCall.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/AnswerIncomingPushCall.kt
@@ -15,6 +15,7 @@ import com.telnyx.webrtc.sdk.model.TxServerConfiguration
 import com.telnyx.webrtc.sdk.verto.receive.InviteResponse
 import com.telnyx.webrtc.sdk.verto.receive.ReceivedMessageBody
 import com.telnyx.webrtc.sdk.verto.receive.SocketResponse
+import timber.log.Timber
 
 /**
  * Class responsible for handling the acceptance of incoming push calls.
@@ -52,7 +53,7 @@ class AnswerIncomingPushCall(private val context: Context) {
         val telnyxClient = TelnyxCommon.getInstance().getTelnyxClient(context)
         ProfileManager.getProfilesList(context).lastOrNull()?.let { lastProfile ->
             val fcmToken = lastProfile.fcmToken ?: ""
-            
+
             // Use TokenConfig when sipToken is not null, otherwise use CredentialConfig
             if (lastProfile.sipToken != null) {
                 telnyxClient.connect(
@@ -69,7 +70,6 @@ class AnswerIncomingPushCall(private val context: Context) {
                     true
                 )
             }
-            
 
             telnyxClient.getSocketResponse().observeForever(incomingCallObserver)
         }

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/RejectIncomingPushCall.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/RejectIncomingPushCall.kt
@@ -7,6 +7,7 @@ import com.telnyx.webrtc.common.ProfileManager
 import com.telnyx.webrtc.common.TelnyxCommon
 import com.telnyx.webrtc.common.domain.call.EndCurrentAndUnholdLast
 import com.telnyx.webrtc.common.util.toCredentialConfig
+import com.telnyx.webrtc.common.util.toTokenConfig
 import com.telnyx.webrtc.sdk.model.SocketMethod
 import com.telnyx.webrtc.sdk.model.SocketStatus
 import com.telnyx.webrtc.sdk.model.TxServerConfiguration
@@ -45,12 +46,25 @@ class RejectIncomingPushCall(private val context: Context) {
 
         val telnyxClient = TelnyxCommon.getInstance().getTelnyxClient(context)
         ProfileManager.getProfilesList(context).lastOrNull()?.let { lastProfile ->
-            telnyxClient.connect(
-                TxServerConfiguration(),
-                lastProfile.toCredentialConfig(lastProfile.fcmToken ?: ""),
-                txPushMetaData,
-                true
-            )
+            val fcmToken = lastProfile.fcmToken ?: ""
+
+            // Use TokenConfig when sipToken is not null, otherwise use CredentialConfig
+            if (lastProfile.sipToken != null) {
+                telnyxClient.connect(
+                    TxServerConfiguration(),
+                    lastProfile.toTokenConfig(fcmToken),
+                    txPushMetaData,
+                    true
+                )
+            } else {
+                telnyxClient.connect(
+                    TxServerConfiguration(),
+                    lastProfile.toCredentialConfig(fcmToken),
+                    txPushMetaData,
+                    true
+                )
+            }
+
             telnyxClient.getSocketResponse().observeForever(incomingCallObserver)
         }
 

--- a/telnyx_rtc/CHANGELOG.md
+++ b/telnyx_rtc/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.7.0](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/1.7.0) (2025-05-08)
+
+### Enhancement
+- Add Call Quality metrics to the SDK to provide insights into call performance and quality. This is handled on a per call basis via a debug parameter and is different to the debug parameter passed at a config level.
+
+### Bug Fixing
+- Ice Candidate Collection is now handled in the call object rather than universally in TelnyxClient, allowing for concurrent outgoing calls to be made without interference. This change improves the handling of multiple calls and ensures that each call's ICE candidates are managed independently.
+
 ## [1.6.4](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/1.6.3) (2025-04-23)
 
 ### Bug Fixing

--- a/telnyx_rtc/CHANGELOG.md
+++ b/telnyx_rtc/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bug Fixing
 - Ice Candidate Collection is now handled in the call object rather than universally in TelnyxClient, allowing for concurrent outgoing calls to be made without interference. This change improves the handling of multiple calls and ensures that each call's ICE candidates are managed independently.
+- Connection is now recovered after Network lost
 
 ## [1.6.4](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/1.6.3) (2025-04-23)
 

--- a/telnyx_rtc/build.gradle
+++ b/telnyx_rtc/build.gradle
@@ -16,7 +16,7 @@ android {
 }
 
 def getVersionName = { ->
-    return "1.6.3"
+    return "1.7.0"
 }
 
 def getArtifactId = { ->

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1249,6 +1249,14 @@ class TelnyxClient(
 
     // TxSocketListener Overrides
     override fun onClientReady(jsonObject: JsonObject) {
+        val voiceSdkID = jsonObject.getAsJsonPrimitive("voice_sdk_id")?.asString
+        if (voiceSdkID != null) {
+            Logger.d(message = "Voice SDK ID _ $voiceSdkID")
+            this@TelnyxClient.voiceSDKID = voiceSdkID
+        } else {
+            Logger.e(message = "No Voice SDK ID")
+        }
+
         if (gatewayState != GatewayState.REGED.state) {
             Logger.d(
                 message = Logger.formatMessage(

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/WebRTCReporter.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/WebRTCReporter.kt
@@ -92,7 +92,10 @@ internal class WebRTCReporter(
             type = "debug_report_start",
             debugReportId = debugStatsId.toString(),
         )
-        socket.send(debugStartMessage)
+
+        if (socketDebug)
+            socket.send(debugStartMessage)
+
         peer.peerConnectionObserver = PeerConnectionObserver(this)
 
         sendAddConnectionMessage()
@@ -109,7 +112,9 @@ internal class WebRTCReporter(
         val debugStopMessage = InitiateOrStopStatPrams(
             debugReportId = debugStatsId.toString(),
         )
-        socket.send(debugStopMessage)
+
+        if (socketDebug)
+            socket.send(debugStopMessage)
 
         debugStatsId = null
 


### PR DESCRIPTION
## Description
This PR implements the UI redesign for call quality metrics as requested in WEBRTC-2699.

### Changes
- Added a call quality summary section with colored dot and quality name
- Added 'View all call metrics' button with transparent background and rounded corners
- Moved detailed CallQualityDisplay to a ModalBottomSheet
- Implemented bottom sheet to show detailed metrics when button is pressed

### Testing
- Tested with different call quality states to ensure proper display
- Verified that the button correctly shows the detailed metrics in a bottom sheet

### Screenshots
N/A

### Jira Ticket
[WEBRTC-2699](https://telnyx.atlassian.net/browse/WEBRTC-2699)

[WEBRTC-2699]: https://telnyx.atlassian.net/browse/WEBRTC-2699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ