### PR TITLE
WebRTC-2701 - Enhance Call State and Termination Reason Reporting in SDK

### DIFF
--- a/docs-markdown/error-handling/ErrorHandling.md
+++ b/docs-markdown/error-handling/ErrorHandling.md
@@ -140,6 +140,21 @@ When implementing error handling for the Telnyx WebRTC Android SDK:
 - **Cause**: Device is offline or has poor connectivity
 - **Solution**: Monitor network state changes and reconnect when network becomes available
 
+## Error Constants Reference
+
+The following table lists all error constants used in the SDK:
+
+| ERROR MESSAGE | ERROR CODE | DESCRIPTION |
+|---------------|------------|-------------|
+| Token registration error | -32000 | Error during token registration |
+| Credential registration error | -32001 | Error during credential registration |
+| Codec error | -32002 | Error related to codec operation |
+| Gateway registration timeout | -32003 | Gateway registration timed out |
+| Gateway registration failed | -32004 | Gateway registration failed |
+| Call not found | N/A | The specified call cannot be found |
+
+These error constants are defined in the SDK's error handling system and can be used to identify specific error conditions in your application code.
+
 ## Additional Resources
 
 - [Telnyx WebRTC Android SDK GitHub Repository](https://github.com/team-telnyx/telnyx-webrtc-android)

--- a/docs-markdown/error-handling/ErrorHandling.md
+++ b/docs-markdown/error-handling/ErrorHandling.md
@@ -144,14 +144,14 @@ When implementing error handling for the Telnyx WebRTC Android SDK:
 
 The following table lists all error constants used in the SDK:
 
-| ERROR MESSAGE | ERROR CODE | DESCRIPTION |
-|---------------|------------|-------------|
-| Token registration error | -32000 | Error during token registration |
-| Credential registration error | -32001 | Error during credential registration |
-| Codec error | -32002 | Error related to codec operation |
-| Gateway registration timeout | -32003 | Gateway registration timed out |
-| Gateway registration failed | -32004 | Gateway registration failed |
-| Call not found | N/A | The specified call cannot be found |
+| ERROR MESSAGE | ERROR CODE | DESCRIPTION                                                                                                                     |
+|---------------|------------|---------------------------------------------------------------------------------------------------------------------------------|
+| Token registration error | -32000 | The token used for authentication was invalid                                                                                   |
+| Credential registration error | -32001 | Either the username or password used for authentication was invalid                                                             |
+| Codec error | -32002 | This means that the SDP handhsake failed and there were no matching codecs and / or ICE Candidates to use to establish the call |
+| Gateway registration timeout | -32003 | Gateway registration timed out while trying to register                                                                         |
+| Gateway registration failed | -32004 | Gateway registration has timed out multiple times and has now failed                                                            |
+| Call not found | N/A | An action on a call was attemped (such as hold, DTMF) however the call no longer exists and was not found                       |
 
 These error constants are defined in the SDK's error handling system and can be used to identify specific error conditions in your application code.
 

--- a/docs-markdown/error-handling/ErrorHandling.md
+++ b/docs-markdown/error-handling/ErrorHandling.md
@@ -1,14 +1,15 @@
-This document describes the error handling mechanisms in the Telnyx WebRTC Android SDK, specifically focusing on when and why error events are triggered and how they are processed through the SDK.
+This document describes the error handling mechanisms and call state event details in the Telnyx WebRTC Android SDK, specifically focusing on when and why error events are triggered, how call state changes are reported, and how they are processed through the SDK.
 
 ## Error Handling Architecture
 
 The Android SDK implements a structured approach to error handling through several key components:
 
-1. **TxSocketListener Interface**: Defines the `onErrorReceived` method that is triggered when socket errors occur
-2. **SocketResponse Class**: Provides a data structure for encapsulating error states with the `error()` factory method
-3. **TelnyxClient Implementation**: Processes errors and exposes them through LiveData for application consumption
+1. **TxSocketListener Interface**: Defines the `onErrorReceived` method that is triggered when socket errors occur. It also defines methods like `onByeReceived` which now provide more detailed information for call termination.
+2. **SocketResponse Class**: Provides a data structure for encapsulating error states with the `error()` factory method, and for successful message responses.
+3. **TelnyxClient Implementation**: Processes errors and exposes them through LiveData for application consumption. It also manages and exposes call state transitions.
+4. **CallState Sealed Class**: Represents various states a call can be in, with some states now carrying detailed reasons for transitions (e.g., `DROPPED`, `RECONNECTING`, `DONE`).
 
-## Error Scenarios
+## Error Scenarios and Informative Call State Transitions
 
 ### 1. Gateway Registration Status
 
@@ -51,20 +52,64 @@ override fun onErrorReceived(jsonObject: JsonObject) {
 }
 ```
 
-### 3. Network Connectivity Issues
+### 3. Network Connectivity Issues and Related Call States
 
-The SDK detects network connectivity problems and reports them as errors:
+The SDK detects network connectivity problems and reports them as errors or specific call states:
 
-* When attempting to connect without an active network connection
-* When network is lost during an active session
-* These errors help applications handle offline scenarios gracefully
+* **Error on Connect Attempt**: When attempting to connect without an active network connection
+* **CallState.DROPPED**: When network is lost during an active session and reconnection is not possible or fails
+* **CallState.RECONNECTING**: When the SDK attempts to reconnect a call after a network disruption (e.g., switching from Wi-Fi to LTE)
 
 Example:
 ```kotlin
-if (!isNetworkAvailable()) {
+if (!ConnectivityHelper.isNetworkEnabled(context)) {
     socketResponseLiveData.postValue(SocketResponse.error("No Network Connection"))
     return
 }
+```
+
+### 4. Call Termination Details (`CallState.DONE` and `ByeResponse`)
+
+When a call ends, the SDK provides detailed reasons for termination:
+
+* **CallState.DONE**: This state now optionally includes a `CallTerminationReason` object
+* **Bye Event (`onByeReceived`)**: The `TxSocketListener.onByeReceived` method now accepts a `JsonObject`
+
+Example of consuming `CallState.DONE`:
+```kotlin
+// In your ViewModel or UI observer for Call.callStateFlow
+aCall.callStateFlow.collect { state ->
+    if (state is CallState.DONE) {
+        val reason = state.reason
+        if (reason != null) {
+            // Display detailed termination reason to the user
+            val message = "Call ended: ${reason.cause ?: "Unknown cause"}" +
+                          (reason.sipCode?.let { " (SIP: $it ${reason.sipReason ?: ""})" } ?: "")
+            Log.i("CallEnd", message)
+            // Show popup or toast with this message
+        } else {
+            Log.i("CallEnd", "Call ended without a specific reason provided.")
+        }
+    }
+}
+```
+
+Example of consuming the enriched `ByeResponse` from `socketResponseLiveData`:
+```kotlin
+// In your observer for TelnyxClient.socketResponseLiveData
+telnyxClient.socketResponseLiveData.observe(this, Observer { response ->
+    if (response.status == SocketStatus.MESSAGERECEIVED && response.data?.method == SocketMethod.BYE.methodName) {
+        val byeResponse = response.data.result as? com.telnyx.webrtc.sdk.verto.receive.ByeResponse
+        if (byeResponse != null) {
+            val terminationMessage = "Remote party ended call (${byeResponse.callId}). " +
+                                     "Reason: ${byeResponse.cause ?: "N/A"}" +
+                                     (byeResponse.sipCode?.let { " (SIP: $it ${byeResponse.sipReason ?: ""})" } ?: "")
+            Log.i("TelnyxSDK", terminationMessage)
+            // Update UI accordingly
+        }
+    }
+    // ... handle other statuses and methods
+})
 ```
 
 ## SocketResponse.error Implementation
@@ -82,12 +127,11 @@ This factory method creates a `SocketResponse` object with:
 - `null` data (since there is no valid data during an error)
 - An error message describing what went wrong
 
-## Consuming Errors in Your Application
+## Consuming Errors and Call Events in Your Application
 
-The SDK exposes errors through the `socketResponseLiveData` LiveData object, which applications can observe to handle errors appropriately.
+The SDK exposes errors and call-related events through the `socketResponseLiveData` LiveData object and individual `Call` objects' `callStateFlow`. Applications should observe these to handle events appropriately.
 
-Example implementation:
-
+Example implementation for general errors:
 ```kotlin
 telnyxClient.socketResponseLiveData.observe(this, Observer { response ->
     when (response.status) {
@@ -99,15 +143,15 @@ telnyxClient.socketResponseLiveData.observe(this, Observer { response ->
             when {
                 response.errorMessage?.contains("Gateway registration") == true -> {
                     // Handle gateway registration failure
-                    attemptReconnection()
+                    // attemptReconnection()
                 }
                 response.errorMessage?.contains("No Network Connection") == true -> {
                     // Handle network connectivity issues
-                    showOfflineUI()
+                    // showOfflineUI()
                 }
                 else -> {
                     // Handle other types of errors
-                    showErrorToUser(response.errorMessage)
+                    // showErrorToUser(response.errorMessage)
                 }
             }
         }
@@ -116,15 +160,24 @@ telnyxClient.socketResponseLiveData.observe(this, Observer { response ->
 })
 ```
 
-## Error Handling Best Practices
+## Error Handling and Call State Best Practices
 
-When implementing error handling for the Telnyx WebRTC Android SDK:
+When implementing error handling and observing call states:
 
-1. **Always observe the socketResponseLiveData**: This is the primary channel for receiving error notifications
-2. **Log errors for debugging purposes**: Capture error messages for troubleshooting
-3. **Implement appropriate error recovery mechanisms**: Different errors may require different recovery strategies
-4. **Display user-friendly error messages**: Translate technical error messages into user-friendly notifications
-5. **Implement reconnection logic when appropriate**: For network or gateway issues, automatic reconnection may be appropriate
+1. **Always observe `socketResponseLiveData`**: For general SDK errors and message-based events like incoming `bye`.
+2. **Observe `call.callStateFlow` for each `Call` object**: For detailed state transitions of individual calls (e.g., `ACTIVE`, `DROPPED`, `RECONNECTING`, `DONE` with reasons).
+3. **Log errors and state changes for debugging purposes**: Capture messages for troubleshooting.
+4. **Implement appropriate recovery mechanisms**: Different errors or states may require different recovery strategies (e.g., reconnection for `DROPPED` or `RECONNECTING` states).
+5. **Display user-friendly messages**: Translate technical errors or state reasons into clear notifications.
+    * For `CallState.DONE(reason)`, use the `CallTerminationReason` fields (`cause`, `sipCode`, `sipReason`) to inform the user. The Telnyx support documentation can be helpful for mapping these to user-friendly messages.
+6. **Implement reconnection logic when appropriate**: For network or gateway issues.
+
+## SIP Response Codes and Common Causes
+
+For a detailed understanding of SIP response codes and common call failure reasons, refer to the official Telnyx troubleshooting guide:
+[Troubleshooting Call Completion](https://support.telnyx.com/en/articles/5025298-troubleshooting-call-completion)
+
+This guide provides valuable insights into why calls might fail with specific SIP codes (e.g., 403 Forbidden, 404 Not Found, 503 Service Unavailable) and their corresponding causes (e.g., Invalid Caller ID, Unallocated Number). Use this information in conjunction with the `sipCode` and `sipReason` from `CallTerminationReason` to provide more accurate feedback to users.
 
 ## Common Error Scenarios and Solutions
 
@@ -136,22 +189,27 @@ When implementing error handling for the Telnyx WebRTC Android SDK:
 - **Cause**: Network interruption or server issues
 - **Solution**: Implement automatic reconnection with exponential backoff
 
-### No Network Connection
-- **Cause**: Device is offline or has poor connectivity
-- **Solution**: Monitor network state changes and reconnect when network becomes available
+### No Network Connection / Call Dropped
+- **Cause**: Device is offline or has poor connectivity. `CallState.DROPPED(CallNetworkChangeReason.NETWORK_LOST)` will be triggered.
+- **Solution**: Monitor network state changes. Inform the user. Reconnect when network becomes available.
+
+### Call Reconnecting
+- **Cause**: Temporary network disruption, like a network switch (e.g., Wi-Fi to mobile data). `CallState.RECONNECTING(CallNetworkChangeReason.NETWORK_SWITCH)` will be triggered.
+- **Solution**: Inform the user that the call is attempting to reconnect. The SDK handles the reconnection attempt.
 
 ## Error Constants Reference
 
-The following table lists all error constants used in the SDK:
+The following table lists some error constants/messages that might be observed:
 
-| ERROR MESSAGE | ERROR CODE | DESCRIPTION                                                                                                                     |
-|---------------|------------|---------------------------------------------------------------------------------------------------------------------------------|
-| Token registration error | -32000 | The token used for authentication was invalid                                                                                   |
-| Credential registration error | -32001 | Either the username or password used for authentication was invalid                                                             |
-| Codec error | -32002 | This means that the SDP handhsake failed and there were no matching codecs and / or ICE Candidates to use to establish the call |
-| Gateway registration timeout | -32003 | Gateway registration timed out while trying to register                                                                         |
-| Gateway registration failed | -32004 | Gateway registration has timed out multiple times and has now failed                                                            |
-| Call not found | N/A | An action on a call was attemped (such as hold, DTMF) however the call no longer exists and was not found                       |
+| ERROR MESSAGE                 | ERROR CODE (Example) | DESCRIPTION                                                                                                    |
+|-------------------------------|----------------------|----------------------------------------------------------------------------------------------------------------|
+| Token registration error      | -32000               | The token used for authentication was invalid.                                                                 |
+| Credential registration error | -32001               | Either the username or password used for authentication was invalid.                                           |
+| Codec error                   | -32002               | SDP handshake failed; no matching codecs and/or ICE Candidates.                                                |
+| Gateway registration timeout  | -32003               | Gateway registration timed out.                                                                                |
+| Gateway registration failed   | -32004               | Gateway registration has timed out multiple times and has now failed.                                          |
+| Call not found                | N/A                  | An action on a call was attempted (e.g., hold, DTMF) but the call no longer exists.                            |
+| *Various SIP Errors*          | *SIP Codes (e.g. 403, 404)* | Refer to `sipCode` and `sipReason` in `CallTerminationReason` and the [Telnyx Troubleshooting Guide](https://support.telnyx.com/en/articles/5025298-troubleshooting-call-completion). |
 
 These error constants are defined in the SDK's error handling system and can be used to identify specific error conditions in your application code.
 

--- a/docs-markdown/error-handling/ErrorHandling.md
+++ b/docs-markdown/error-handling/ErrorHandling.md
@@ -6,15 +6,18 @@ This section provides a reference for the various error conditions and call stat
 
 ### 1. Socket-Level Errors (via `SocketResponse`)
 
-These errors are typically reported through the `TelnyxClient.socketResponseLiveData` when `SocketResponse.status` is `SocketStatus.ERROR`.
+These errors are typically reported through the `TelnyxClient.socketResponseLiveData` when `SocketResponse.status` is `SocketStatus.ERROR`. The `SocketResponse` for errors now includes an optional `errorCode: Int?` field in addition to the `errorMessage: String?`.
 
 *   **Gateway Registration Issues**:
-    *   `"Gateway registration has timed out"`: Triggered if the gateway status is not "REGED" (registered) after an initial attempt and retry (e.g., `GatewayState.NOREG`).
-    *   `"Gateway registration has failed"`: Triggered if the gateway status is "FAILED" after multiple retries.
-*   **WebSocket Error Messages**:
-    *   Custom error messages from the server sent via WebSocket (e.g., authentication failures, server-side issues). The `errorMessage` field in `SocketResponse` will contain the server-provided message.
+    *   `errorMessage`: "Gateway registration has timed out", `errorCode`: -32003 (Triggered if gateway status is not "REGED" e.g., `GatewayState.NOREG`, or `GatewayState.EXPIRED`).
+    *   `errorMessage`: "Gateway registration has failed", `errorCode`: -32004 (Triggered if gateway status is "FAILED" or results in `GatewayState.FAIL_WAIT`).
+*   **WebSocket Error Messages from Server**:
+    *   The `errorMessage` will contain the server-provided message.
+    *   The `errorCode` will contain the server-provided error code (e.g., -32000 for token error, -32001 for credential error) if available in the JSON payload from the server.
 *   **No Network Connection (on initial connect)**:
-    *   `"No Network Connection"`: Triggered if an attempt to connect to the Telnyx platform is made when the device has no active network connection.
+    *   `errorMessage`: "No Network Connection", `errorCode`: `null` (Triggered if an attempt to connect is made when the device has no active network connection).
+*   **Client-Side Reconnection Timeout**:
+    *   `errorMessage`: "Reconnection timeout after X seconds", `errorCode`: `null` (Triggered if the SDK's internal reconnection timer expires).
 
 ### 2. Call-Specific States & Reasons (via `Call.callStateFlow`)
 
@@ -37,7 +40,7 @@ Individual `Call` objects emit their state changes through `callStateFlow`. Seve
         *   `sipCode: Int?`: The SIP response code, if applicable (e.g., 403, 486, 404).
         *   `sipReason: String?`: The SIP reason phrase, if applicable (e.g., "Forbidden", "Busy Here", "Not Found").
 *   **`CallState.ERROR`**:
-    *   A general error occurred related to this specific call (e.g., failure to create offer/answer, media negotiation issues).
+    *   A general error occurred related to this specific call (e.g., failure to create offer/answer, media negotiation issues). This state itself does not carry a detailed reason object; specific error details might be logged internally or manifest as a transition to `CallState.DONE` with a reason.
 
 ### 3. Enriched `ByeResponse` Details (via `socketResponseLiveData`)
 
@@ -48,28 +51,28 @@ When a call is terminated by the remote party, a `BYE` message is received. The 
 
 ### 4. Error/Cause Code Reference Table
 
-This table provides common causes, codes, and potential SIP responses. For a comprehensive list of SIP codes and detailed troubleshooting, always refer to the [Telnyx Troubleshooting Guide for Call Completion](https://support.telnyx.com/en/articles/5025298-troubleshooting-call-completion).
+This table provides common causes and codes. For a comprehensive list of SIP codes and detailed troubleshooting, always refer to the [Telnyx Troubleshooting Guide for Call Completion](https://support.telnyx.com/en/articles/5025298-troubleshooting-call-completion).
 
-| Category                      | `cause` String (Example) | `causeCode` (Example) | `sipCode` (Example) | `sipReason` (Example)         | Description / Common Scenario                                                               |
-|-------------------------------|--------------------------|-----------------------|---------------------|-------------------------------|---------------------------------------------------------------------------------------------|
-| **General Call Clearing**     | `NORMAL_CLEARING`        | 16                    | N/A                 | N/A                           | Call ended normally by one of the parties.                                                    |
-|                               | `USER_BUSY`              | 17                    | 486                 | "Busy Here"                   | The called party is busy.                                                                     |
-|                               | `CALL_REJECTED`          | 21                    | 403                 | "Forbidden"                   | Call was rejected (e.g., invalid caller ID, destination not whitelisted, authentication failure). |
-|                               | `UNALLOCATED_NUMBER`     | 1                     | 404                 | "Not Found" / "Invalid Number" | The dialed number does not exist or is not assigned.                                          |
-|                               | `NO_ANSWER`              | 19                    | 480                 | "Temporarily Unavailable"     | Callee did not answer.                                                                        |
-|                               | `INCOMPATIBLE_DESTINATION`| 88                   | 488/606             | "Not Acceptable Here"       | Media negotiation failure (codec mismatch, SRTP issues).                                     |
-|                               | `RECOVERY_ON_TIMER_EXPIRE`| 102                  | N/A (often 408)     | "Request Timeout"             | A necessary response was not received in time (e.g., INVITE timeout).                         |
-| **Gateway/Network Issues**    | N/A                      | N/A                   | N/A                 | N/A                           | Refer to `CallState.DROPPED` or `CallState.RECONNECTING` with their `CallNetworkChangeReason`. |
-| **SDK Internal Errors**       | `AnswerError`            | N/A                   | N/A                 | "No SDP in answer response"   | SDK specific error during call setup                                                |
-|                               | `MediaError`             | N/A                   | N/A                 | "No SDP in media response"    | SDK specific error during media processing                                      |
-| **Registration Errors**       | N/A                      | -32000                | N/A                 | N/A                           | Token registration error                                           |
-|                               | N/A                      | -32001                | N/A                 | N/A                           | Credential registration error                                         |
-|                               | N/A                      | -32003                | N/A                 | N/A                           | Gateway registration timeout                                              |
-|                               | N/A                      | -32004                | N/A                 | N/A                           | Gateway registration failed                                              |
+| Error Source / Category       | `errorMessage` (Example) / `cause` (Example) | `errorCode` (from `SocketResponse`) / `causeCode` (from `CallTerminationReason`) | `sipCode` (from `CallTerminationReason`) | `sipReason` (Example)         | Description / Common Scenario                                                                  |
+|-------------------------------|----------------------------------------------|--------------------------------------------------------------------------------|------------------------------------------|-------------------------------|------------------------------------------------------------------------------------------------|
+| **SocketResponse Errors**     | "Gateway registration has timed out"       | `SocketError.GATEWAY_TIMEOUT_ERROR.errorCode` (-32003)                         | N/A                                      | N/A                           | Gateway registration timed out.                                                                |
+|                               | "Gateway registration has failed"          | `SocketError.GATEWAY_FAILURE_ERROR.errorCode` (-32004)                         | N/A                                      | N/A                           | Gateway registration failed after retries.                                                   |
+|                               | "Login Incorrect"                            | `SocketError.CREDENTIAL_ERROR.errorCode` (-32001) (if from server JSON)        | N/A                                      | N/A                           | Credential authentication error.                                                               |
+|                               | "Invalid Token"                              | `SocketError.TOKEN_ERROR.errorCode` (-32000) (if from server JSON)             | N/A                                      | N/A                           | Token authentication error.                                                                    |
+|                               | "No Network Connection"                      | `null`                                                                         | N/A                                      | N/A                           | Client-side detection: no network on connect.                                                  |
+| **CallTerminationReason (from `CallState.DONE` or `ByeResponse`)** ||||||
+| General Call Clearing         | `NORMAL_CLEARING`                            | 16                                                                             | N/A                                      | N/A                           | Call ended normally.                                                                           |
+|                               | `USER_BUSY`                                  | 17                                                                             | 486                                      | "Busy Here"                   | Called party is busy.                                                                          |
+|                               | `CALL_REJECTED`                              | 21                                                                             | 403                                      | "Forbidden"                   | Call rejected (invalid caller ID, auth failure, etc.).                                       |
+|                               | `UNALLOCATED_NUMBER`                         | 1                                                                              | 404                                      | "Not Found"                   | Dialed number does not exist.                                                                  |
+|                               | `NO_ANSWER`                                  | 19                                                                             | 480                                      | "Temporarily Unavailable"     | Callee did not answer.                                                                           |
+|                               | `INCOMPATIBLE_DESTINATION`                   | 88                                                                             | 488/606                                  | "Not Acceptable Here"       | Media negotiation failure.                                                                     |
+|                               | `RECOVERY_ON_TIMER_EXPIRE`                   | 102                                                                            | N/A (often 408)                          | "Request Timeout"             | Necessary response not received in time.                                                       |
+| SDK Internal Errors           | `AnswerError` (example `cause`)              | N/A                                                                            | N/A                                      | "No SDP in answer response"   | SDK specific error during call setup.                                                            |
 
-*Note: `cause`, `causeCode`, `sipCode`, and `sipReason` may not all be present for every `DONE` state. Presence depends on how the call was terminated.*
+*Note: Not all fields (`cause`, `causeCode`, `sipCode`, `sipReason`, `errorCode`) will be present for every error or `DONE` state. Presence depends on the nature and source of the event.*
 
-More SIP codes and their meanings can be found in the [Telnyx Troubleshooting Guide for Call Completion](https://support.telnyx.com/en/articles/4409457-telnyx-sip-response-codes).
+More SIP codes and their meanings can be found in the [Telnyx SIP Response Codes Guide](https://support.telnyx.com/en/articles/4409457-telnyx-sip-response-codes).
 
 ## Guide: Consuming Errors and Call Events
 
@@ -77,16 +80,16 @@ This section explains how to effectively use the error and state information pro
 
 ### Observing `socketResponseLiveData` (for General SDK Events & Errors)
 
-`TelnyxClient.socketResponseLiveData` is the primary channel for general SDK events, including connection status, errors, and messages like incoming `BYE`.
+`TelnyxClient.socketResponseLiveData` is the primary channel for general SDK events, including connection status, errors (now with `errorCode`), and messages like incoming `BYE`.
 
 ```kotlin
 // In your Activity or ViewModel
 telnyxClient.socketResponseLiveData.observe(this, Observer { response ->
     when (response.status) {
         SocketStatus.ERROR -> {
-            Log.e("TelnyxSDK", "General SDK Error: ${response.errorMessage}")
+            Log.e("TelnyxSDK", "General SDK Error: ${response.errorMessage}, Code: ${response.errorCode}")
+            // Example: if (response.errorCode == -32003) { /* Handle Gateway Timeout */ }
             // Handle gateway registration issues, WebSocket errors, no network on connect, etc.
-            // Example: if (response.errorMessage?.contains("Gateway registration") == true) { ... }
         }
         SocketStatus.MESSAGERECEIVED -> {
             response.data?.let { receivedMessageBody ->
@@ -94,10 +97,9 @@ telnyxClient.socketResponseLiveData.observe(this, Observer { response ->
                     val byeResponse = receivedMessageBody.result as? com.telnyx.webrtc.sdk.verto.receive.ByeResponse
                     byeResponse?.let {
                         val terminationMessage = "Remote party ended call (${it.callId}). " +
-                                                 "Reason: ${it.cause ?: "N/A"}" +
+                                                 "Reason: ${it.cause ?: "N/A"} (${it.causeCode ?: "N/A"})" +
                                                  (it.sipCode?.let { sc -> " (SIP: $sc ${it.sipReason ?: ""})" } ?: "")
                         Log.i("TelnyxSDK_Bye", terminationMessage)
-                        // This provides info that remote ended the call.
                         // The specific Call object's callStateFlow will also transition to CallState.DONE with this reason.
                     }
                 }
@@ -151,16 +153,18 @@ myCall.callStateFlow.collect { state ->
 
 ## Best Practices for Error and State Handling
 
-1.  **Observe Both Channels**: Use `socketResponseLiveData` for global SDK status/errors and `call.callStateFlow` for individual call lifecycle management.
-2.  **Log Extensively**: During development, log error messages, call states, and reasons to aid in debugging.
+1.  **Observe Both Channels**: Use `socketResponseLiveData` for global SDK status/errors (including `errorCode`) and `call.callStateFlow` for individual call lifecycle management.
+2.  **Log Extensively**: During development, log error messages (with codes), call states, and reasons to aid in debugging.
 3.  **Provide Clear User Feedback**: Translate technical error codes and states into user-understandable messages.
+    *   Use `SocketResponse.errorCode` to distinguish specific socket/gateway errors.
     *   For `CallState.DONE` with a `reason`, use the `cause`, `sipCode`, and `sipReason` to provide specific feedback (e.g., "User Busy", "Invalid Number", "Call Rejected: Restricted Area"). Refer to the [Telnyx Troubleshooting Guide](https://support.telnyx.com/en/articles/5025298-troubleshooting-call-completion) for common interpretations.
     *   For `CallState.DROPPED` or `CallState.RECONNECTING`, inform the user about network issues.
-4.  **Implement Recovery/Retry Logic**: For network-related drops or gateway issues, consider implementing reconnection attempts or prompting the user.
-5.  **Graceful Degradation**: If critical errors occur (e.g., persistent gateway failure), ensure your app handles this gracefully, perhaps by disabling calling features and informing the user.
+4.  **Implement Recovery/Retry Logic**: For network-related drops or gateway issues (identified by specific error codes or call states), consider implementing reconnection attempts or prompting the user.
+5.  **Graceful Degradation**: If critical errors occur (e.g., persistent gateway failure - `errorCode` -32004), ensure your app handles this gracefully, perhaps by disabling calling features and informing the user.
 
 ## Additional Resources
 
 - [Telnyx WebRTC Android SDK GitHub Repository](https://github.com/team-telnyx/telnyx-webrtc-android)
 - [API Documentation](https://developers.telnyx.com/docs/v2/webrtc)
 - [Telnyx Troubleshooting Guide for Call Completion](https://support.telnyx.com/en/articles/5025298-troubleshooting-call-completion) (Essential for interpreting SIP codes and call failure reasons)
+- [Telnyx SIP Response Codes Guide](https://support.telnyx.com/en/articles/4409457-telnyx-sip-response-codes) (For a detailed list of SIP codes)

--- a/docs-markdown/socket/ReceivedMessageBody.md
+++ b/docs-markdown/socket/ReceivedMessageBody.md
@@ -43,3 +43,57 @@ Method names:
 * MEDIA received media from destination, such as a dialtone
 * MEDIA send information to the destination such as DTMF
 * LOGIN the response to a login request.
+
+The `ReceivedMessageBody` data class is a crucial part of the Telnyx WebRTC SDK, serving as a standardized wrapper for all messages received over the WebSocket connection. It provides a consistent structure for handling different types of Verto protocol messages.
+
+## Structure
+
+```kotlin
+data class ReceivedMessageBody(
+    val method: String,      // The Telnyx Message Method (e.g., "telnyx_rtc.invite", "telnyx_rtc.bye")
+    val result: ReceivedResult? // The content of the actual message
+)
+```
+
+- **`method: String`**: This field indicates the type of message received. It corresponds to one of the `SocketMethod` enums (e.g., `SocketMethod.INVITE`, `SocketMethod.ANSWER`, `SocketMethod.BYE`). Your application will typically use this field in a `when` statement to determine how to process the `result`.
+
+- **`result: ReceivedResult?`**: This field holds the actual payload of the message. `ReceivedResult` is a sealed class, and the concrete type of `result` will depend on the `method`. For example:
+    - If `method` is `SocketMethod.LOGIN.methodName`, `result` will be a `LoginResponse`.
+    - If `method` is `SocketMethod.INVITE.methodName`, `result` will be an `InviteResponse`.
+    - If `method` is `SocketMethod.ANSWER.methodName`, `result` will be an `AnswerResponse`.
+    - If `method` is `SocketMethod.BYE.methodName`, `result` will be a `com.telnyx.webrtc.sdk.verto.receive.ByeResponse`. Importantly, this `ByeResponse` now includes detailed termination information such as `cause`, `causeCode`, `sipCode`, and `sipReason`, in addition to the `callId`.
+    - Other `ReceivedResult` subtypes include `RingingResponse`, `MediaResponse`, and `DisablePushResponse`.
+
+## Usage
+
+When you observe `TelnyxClient.socketResponseLiveData`, you receive a `SocketResponse<ReceivedMessageBody>`. If the status is `SocketStatus.MESSAGERECEIVED`, the `data` field of `SocketResponse` will contain the `ReceivedMessageBody`.
+
+```kotlin
+telnyxClient.socketResponseLiveData.observe(this, Observer { response ->
+    if (response.status == SocketStatus.MESSAGERECEIVED) {
+        response.data?.let { receivedMessageBody ->
+            Log.d("SDK_APP", "Method: ${receivedMessageBody.method}")
+            when (receivedMessageBody.method) {
+                SocketMethod.LOGIN.methodName -> {
+                    val loginResponse = receivedMessageBody.result as? LoginResponse
+                    // Process login response
+                }
+                SocketMethod.INVITE.methodName -> {
+                    val inviteResponse = receivedMessageBody.result as? InviteResponse
+                    // Process incoming call invitation
+                }
+                SocketMethod.BYE.methodName -> {
+                    val byeResponse = receivedMessageBody.result as? com.telnyx.webrtc.sdk.verto.receive.ByeResponse
+                    byeResponse?.let {
+                        // Process call termination, access it.cause, it.sipCode, etc.
+                        Log.i("SDK_APP", "Call ${it.callId} ended. Reason: ${it.cause}, SIP Code: ${it.sipCode}")
+                    }
+                }
+                // Handle other methods...
+            }
+        }
+    }
+})
+```
+
+By checking the `method` and casting the `result` to its expected type, your application can effectively handle the diverse messages sent by the Telnyx platform.

--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
@@ -676,7 +676,14 @@ fun CurrentCallState(state: TelnyxSocketEvent) {
     val callStateName = when (state) {
         is TelnyxSocketEvent.InitState -> stringResource(R.string.call_state_connecting)
         is TelnyxSocketEvent.OnIncomingCall -> stringResource(R.string.call_state_incoming)
-        is TelnyxSocketEvent.OnCallEnded -> stringResource(R.string.call_state_ended)
+        is TelnyxSocketEvent.OnCallEnded -> {
+            val cause = state.message?.cause
+            if (cause != null) {
+                "Done - $cause"
+            } else {
+                "Done"
+            }
+        }
         is TelnyxSocketEvent.OnRinging -> stringResource(R.string.call_state_ringing)
         is TelnyxSocketEvent.OnCallDropped -> stringResource(R.string.call_state_dropped)
         is TelnyxSocketEvent.OnCallReconnecting -> stringResource(R.string.call_state_reconnecting)

--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
@@ -103,8 +103,8 @@ fun HomeScreen(navController: NavHostController, telnyxViewModel: TelnyxViewMode
     var selectedUserProfile by remember { mutableStateOf<Profile?>(null) }
     val context = LocalContext.current
     val sessionState by telnyxViewModel.sessionsState.collectAsState()
-    val callState by telnyxViewModel.currentCall?.callStateFlow?.collectAsState()
-        ?: remember { mutableStateOf(CallState.DONE) }
+    val callState by telnyxViewModel.currentCall?.callStateFlow?.collectAsState(initial = CallState.DONE())
+        ?: remember { mutableStateOf(CallState.DONE()) }
     val uiState by telnyxViewModel.uiState.collectAsState()
     val isLoading by telnyxViewModel.isLoading.collectAsState()
 
@@ -164,7 +164,7 @@ fun HomeScreen(navController: NavHostController, telnyxViewModel: TelnyxViewMode
             }
         },
         bottomBar = {
-            if (callState == CallState.DONE || callState == CallState.ERROR)
+            if (callState is CallState.DONE || callState is CallState.ERROR)
             BottomBar(
                 state = (sessionState !is TelnyxSessionState.ClientDisconnected),
                 telnyxViewModel,

--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
@@ -35,6 +35,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -111,6 +114,10 @@ fun HomeScreen(navController: NavHostController, telnyxViewModel: TelnyxViewMode
     val missingSessionIdLabel = stringResource(R.string.dash)
     var sessionId by remember { mutableStateOf(missingSessionIdLabel) }
 
+    var showErrorDialog by remember { mutableStateOf(false) }
+    var dialogErrorMessage by remember { mutableStateOf<String?>(null) }
+    var lastShownErrorMessage by remember { mutableStateOf<String?>(null) }
+
     LaunchedEffect(sessionState) {
         when (sessionState) {
             is TelnyxSessionState.ClientLoggedIn -> {
@@ -126,10 +133,27 @@ fun HomeScreen(navController: NavHostController, telnyxViewModel: TelnyxViewMode
     LaunchedEffect(Unit) {
         telnyxViewModel.sessionStateError.collectLatest { errorMessage ->
             errorMessage?.let {
-                Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
+                if (it != lastShownErrorMessage) {
+                    dialogErrorMessage = it
+                    showErrorDialog = true
+                    lastShownErrorMessage = it
+                }
                 telnyxViewModel.stopLoading()
             }
         }
+    }
+
+    if (showErrorDialog) {
+        AlertDialog(
+            onDismissRequest = { showErrorDialog = false },
+            title = { Text(text = "Error") },
+            text = { dialogErrorMessage?.let { Text(text = it) } },
+            confirmButton = {
+                TextButton(onClick = { showErrorDialog = false }) {
+                    Text(stringResource(id = android.R.string.ok))
+                }
+            }
+        )
     }
 
     Scaffold(

--- a/samples/connection_service_app/src/main/java/com/telnyx/webrtc/sdk/utility/telecom/call/TelecomCallManager.kt
+++ b/samples/connection_service_app/src/main/java/com/telnyx/webrtc/sdk/utility/telecom/call/TelecomCallManager.kt
@@ -38,7 +38,7 @@ class TelecomCallManager @Inject constructor(
     private var pendingPushInvitation = false
     private var acceptPushCall: Boolean? = null
 
-    private val _callState = MutableStateFlow(CallState.NEW)
+    private val _callState: MutableStateFlow<CallState> = MutableStateFlow(CallState.DONE())
     val callState: StateFlow<CallState> = _callState
 
     init {
@@ -110,7 +110,7 @@ class TelecomCallManager @Inject constructor(
             SocketMethod.BYE.methodName -> {
                 Timber.i("CallManager: Call ended")
                 // The call ended from the remote side
-                _callState.value = CallState.DONE
+                _callState.value = CallState.DONE()
                 currentCall = null
             }
         }
@@ -157,11 +157,11 @@ class TelecomCallManager @Inject constructor(
         }
         currentCall?.let { c ->
             telnyxClient.endCall(c.callId)
-            _callState.value = CallState.DONE
+            _callState.value = CallState.DONE()
             currentCall = null
         } ?: currentInvite?.let { invite ->
             telnyxClient.endCall(invite.callId)
-            _callState.value = CallState.DONE
+            _callState.value = CallState.DONE()
             currentInvite = null
         }
     }
@@ -173,7 +173,7 @@ class TelecomCallManager @Inject constructor(
             return
         }
         telnyxClient.endCall(callId)
-        _callState.value = CallState.DONE
+        _callState.value = CallState.DONE()
         currentCall = null
     }
 

--- a/samples/connection_service_app/src/main/java/com/telnyx/webrtc/sdk/utility/telecom/call/TelecomCallScreen.kt
+++ b/samples/connection_service_app/src/main/java/com/telnyx/webrtc/sdk/utility/telecom/call/TelecomCallScreen.kt
@@ -112,10 +112,10 @@ fun TelecomCallScreen(
     onCallFinished: () -> Unit
 ) {
 
-    val telnyxCallState by produceState(CallState.NEW) {
+    val telnyxCallState by produceState<CallState>(CallState.NEW) {
         manager.callState.collect {
             value = it
-            if (it == CallState.DONE) {
+            if (it is CallState.DONE) {
                 val call = repository.getCurrentRegisteredCall()
                 call?.processAction(TelecomCallAction.Disconnect(DisconnectCause(DisconnectCause.REMOTE)))
                 onCallFinished()
@@ -252,7 +252,7 @@ private fun CallInfoSection(
         } else {
             // For incoming or outgoing before active
             Text(
-                text = "State: ${telnyxCallState.name}",
+                text = "State: ${telnyxCallState.value}",
                 style = MaterialTheme.typography.titleSmall
             )
         }

--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/MainActivity.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/MainActivity.kt
@@ -164,7 +164,7 @@ class MainActivity : AppCompatActivity(), DefaultLifecycleObserver {
         }
     }
 
-    fun updateCallState(uiState: TelnyxSocketEvent) {
+    private fun updateCallState(uiState: TelnyxSocketEvent) {
         val iconDrawable = when (uiState) {
             is TelnyxSocketEvent.OnIncomingCall -> R.drawable.incoming_indicator
             is TelnyxSocketEvent.OnCallEnded -> R.drawable.done_indicator
@@ -177,11 +177,11 @@ class MainActivity : AppCompatActivity(), DefaultLifecycleObserver {
         val callStateName = when (uiState) {
             is TelnyxSocketEvent.InitState -> getString(R.string.call_state_connecting)
             is TelnyxSocketEvent.OnIncomingCall -> getString(R.string.call_state_incoming)
-            is TelnyxSocketEvent.OnCallEnded -> getString(R.string.call_state_ended)
             is TelnyxSocketEvent.OnRinging -> getString(R.string.call_state_ringing)
             is TelnyxSocketEvent.OnCallDropped -> getString(R.string.call_state_dropped)
             is TelnyxSocketEvent.OnCallReconnecting -> getString(R.string.call_state_reconnecting)
-            else -> getString(R.string.call_state_active)
+            is TelnyxSocketEvent.OnCallAnswered -> getString(R.string.call_state_active)
+            else -> getString(R.string.call_state_ended)
         }
         binding.callStateIcon.setBackgroundResource(iconDrawable)
         binding.callStateInfo.text = callStateName

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxCommon.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxCommon.kt
@@ -245,8 +245,6 @@ class TelnyxCommon private constructor() {
             if (call.onCallQualityChange == null) {
                 call.onCallQualityChange = { metrics: CallQualityMetrics ->
                     _callQualityMetrics.value = metrics
-                    // Reduced log frequency might be needed in production
-                    Timber.v("TelnyxCommon received CallQualityMetrics: MOS=${String.format(Locale.US, "%.2f", metrics.mos)}, Quality=${metrics.quality}")
                 }
                 Timber.d("Set up call quality callback for current call: ${call.callId}")
             }

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -37,7 +37,7 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import com.telnyx.webrtc.common.util.toCredentialConfig
 import com.telnyx.webrtc.common.util.toTokenConfig
-import com.telnyx.webrtc.sdk.TelnyxClient
+import com.telnyx.webrtc.sdk.model.CallNetworkChangeReason
 import com.telnyx.webrtc.sdk.model.CallState
 import com.telnyx.webrtc.sdk.model.TxServerConfiguration
 import com.telnyx.webrtc.sdk.stats.CallQualityMetrics
@@ -58,8 +58,8 @@ sealed class TelnyxSocketEvent {
     data class OnRinging(val message: RingingResponse) : TelnyxSocketEvent()
     data object OnMedia : TelnyxSocketEvent()
     data object InitState : TelnyxSocketEvent()
-    data object OnCallDropped : TelnyxSocketEvent()
-    data object OnCallReconnecting : TelnyxSocketEvent()
+    data class OnCallDropped(val reason: CallNetworkChangeReason) : TelnyxSocketEvent()
+    data class OnCallReconnecting(val reason: CallNetworkChangeReason) : TelnyxSocketEvent()
 }
 
 sealed class TelnyxSessionState {
@@ -120,7 +120,7 @@ class TelnyxViewModel : ViewModel() {
      * Flag indicating whether the server configuration is in development environment.
      */
     var serverConfigurationIsDev = false
-    private set
+        private set
 
     /**
      * State flow for the list of user profiles.
@@ -602,9 +602,7 @@ class TelnyxViewModel : ViewModel() {
 
             _uiState.value = currentCall?.let {
                 TelnyxSocketEvent.OnCallAnswered(it.callId)
-            } ?: TelnyxSocketEvent.OnCallEnded(byeResponse).also {
-                // TelnyxCommon will clear metrics if no calls left via setCurrentCall(null)
-            }
+            } ?: TelnyxSocketEvent.OnCallEnded(byeResponse)
         }
     }
 
@@ -640,19 +638,30 @@ class TelnyxViewModel : ViewModel() {
 
     private fun handleCallState(callState: CallState) {
         when (callState) {
-            CallState.ACTIVE  -> {
-                _uiState.value = TelnyxSocketEvent.OnCallAnswered(currentCall?.callId ?: UUID.randomUUID())
+            is CallState.ACTIVE -> {
+                _uiState.value =
+                    TelnyxSocketEvent.OnCallAnswered(currentCall?.callId ?: UUID.randomUUID())
             }
-            CallState.DROPPED -> {
-                _uiState.value = TelnyxSocketEvent.OnCallDropped
+
+            is CallState.DROPPED -> {
+                _uiState.value = TelnyxSocketEvent.OnCallDropped(callState.callNetworkChangeReason)
             }
-            CallState.RECONNECTING -> {
-                _uiState.value = TelnyxSocketEvent.OnCallReconnecting
+
+            is CallState.RECONNECTING -> {
+                _uiState.value = TelnyxSocketEvent.OnCallReconnecting(callState.callNetworkChangeReason)
             }
-            CallState.ERROR -> {
+
+            is CallState.DONE -> {
                 _uiState.value = TelnyxSocketEvent.OnCallEnded(null)
             }
-            else -> {}
+
+            is CallState.ERROR -> {
+                _uiState.value = TelnyxSocketEvent.OnCallEnded(null)
+            }
+
+            CallState.NEW, CallState.CONNECTING, CallState.RINGING, CallState.HELD -> {
+                Timber.d("Call state updated to: %s", callState.javaClass.simpleName)
+            }
         }
     }
 

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/AnswerIncomingPushCall.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/AnswerIncomingPushCall.kt
@@ -55,7 +55,7 @@ class AnswerIncomingPushCall(private val context: Context) {
             val fcmToken = lastProfile.fcmToken ?: ""
 
             // Use TokenConfig when sipToken is not null, otherwise use CredentialConfig
-            if (lastProfile.sipToken != null) {
+            if (!lastProfile.sipToken.isNullOrEmpty()) {
                 telnyxClient.connect(
                     TxServerConfiguration(),
                     lastProfile.toTokenConfig(fcmToken),
@@ -63,6 +63,7 @@ class AnswerIncomingPushCall(private val context: Context) {
                     true
                 )
             } else {
+
                 telnyxClient.connect(
                     TxServerConfiguration(),
                     lastProfile.toCredentialConfig(fcmToken),

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/RejectIncomingPushCall.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/RejectIncomingPushCall.kt
@@ -49,7 +49,7 @@ class RejectIncomingPushCall(private val context: Context) {
             val fcmToken = lastProfile.fcmToken ?: ""
 
             // Use TokenConfig when sipToken is not null, otherwise use CredentialConfig
-            if (lastProfile.sipToken != null) {
+            if (!lastProfile.sipToken.isNullOrEmpty()) {
                 telnyxClient.connect(
                     TxServerConfiguration(),
                     lastProfile.toTokenConfig(fcmToken),

--- a/telnyx_rtc/build.gradle
+++ b/telnyx_rtc/build.gradle
@@ -217,7 +217,7 @@ dependencies {
     testImplementation('org.robolectric:robolectric:4.8.1') {
         exclude group: 'com.google.protobuf'
     }
-    testImplementation "io.mockk:mockk:1.12.5"
+    testImplementation deps.mockk.core
     testImplementation "com.squareup.okhttp3:mockwebserver:4.10.0"
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
 
@@ -252,7 +252,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:truth:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.work:work-testing:2.7.1'
-    androidTestImplementation "io.mockk:mockk-android:1.12.5"
+    androidTestImplementation deps.mockk.android
     debugImplementation 'androidx.fragment:fragment-testing:1.5.2'
     debugImplementation 'androidx.test:core-ktx:1.6.1'
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -390,7 +390,7 @@ data class Call(
      * Sets the call state to RECONNECTING when a call is being recovered
      */
     fun setCallRecovering() {
-        mutableCallStateFlow.value  = CallState.RECONNECTING
+        mutableCallStateFlow.value = CallState.RECONNECTING(Reason.NETWORK_SWITCH)
     }
     
     /**

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -16,6 +16,7 @@ import com.telnyx.webrtc.lib.SessionDescription
 import com.telnyx.webrtc.lib.MediaStream
 import com.telnyx.webrtc.sdk.TelnyxClient.Companion.TIMEOUT_DIVISOR
 import com.telnyx.webrtc.sdk.model.CallState
+import com.telnyx.webrtc.sdk.model.Reason
 import com.telnyx.webrtc.sdk.model.SocketMethod
 import com.telnyx.webrtc.sdk.peer.Peer
 import com.telnyx.webrtc.sdk.socket.TxSocket

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -13,10 +13,9 @@ import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonSyntaxException
 import com.telnyx.webrtc.lib.SessionDescription
-import com.telnyx.webrtc.lib.MediaStream
 import com.telnyx.webrtc.sdk.TelnyxClient.Companion.TIMEOUT_DIVISOR
 import com.telnyx.webrtc.sdk.model.CallState
-import com.telnyx.webrtc.sdk.model.Reason
+import com.telnyx.webrtc.sdk.model.CallNetworkChangeReason
 import com.telnyx.webrtc.sdk.model.SocketMethod
 import com.telnyx.webrtc.sdk.peer.Peer
 import com.telnyx.webrtc.sdk.socket.TxSocket
@@ -56,7 +55,7 @@ data class Call(
     val audioManager: AudioManager,
     val providedTurn: String = Config.DEFAULT_TURN,
     val providedStun: String = Config.DEFAULT_STUN,
-    internal val mutableCallStateFlow: MutableStateFlow<CallState> = MutableStateFlow(CallState.DONE),
+    internal val mutableCallStateFlow: MutableStateFlow<CallState> = MutableStateFlow(CallState.DONE()),
 ) {
     
     /**
@@ -391,7 +390,7 @@ data class Call(
      * Sets the call state to RECONNECTING when a call is being recovered
      */
     fun setCallRecovering() {
-        mutableCallStateFlow.value = CallState.RECONNECTING(Reason.NETWORK_SWITCH)
+        mutableCallStateFlow.value = CallState.RECONNECTING(CallNetworkChangeReason.NETWORK_SWITCH)
     }
     
     /**

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1465,7 +1465,7 @@ class TelnyxClient(
             val callIdString = params?.get("callID")?.asString
 
             if (callIdString == null) {
-                Logger.e(message = "Received BYE without callID in params: $jsonObject")
+                Logger.e("Received BYE without callID in params: $jsonObject")
                 return
             }
             val callId = UUID.fromString(callIdString)
@@ -1485,8 +1485,8 @@ class TelnyxClient(
                 )
                 updateCallState(CallState.DONE(terminationReason))
 
-                // Create the rich ByeResponse
-                val byeResponseWithDetails = ByeResponse(
+                // Create the rich ByeResponse to be sent to the UI/ViewModel
+                val byeResponseForUi = com.telnyx.webrtc.sdk.verto.receive.ByeResponse(
                     callId = callId,
                     cause = cause,
                     causeCode = causeCode,
@@ -1498,7 +1498,7 @@ class TelnyxClient(
                     SocketResponse.messageReceived(
                         ReceivedMessageBody(
                             SocketMethod.BYE.methodName,
-                            byeResponseWithDetails
+                            byeResponseForUi
                         )
                     )
                 )
@@ -1515,10 +1515,10 @@ class TelnyxClient(
                 answerResponse = null
                 inviteResponse = null
             } ?: run {
-                Logger.w(message = "Received BYE for a callId not found in active calls: $callId")
+                Logger.w("Received BYE for a callId not found in active calls: $callId")
             }
         } catch (e: Exception) {
-            Logger.e(message = "Error processing onByeReceived: ${e.message}")
+            Logger.e("Error processing onByeReceived: ${e.message}", e)
         }
     }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -483,7 +483,7 @@ class TelnyxClient(
             Handler(Looper.getMainLooper()).postDelayed(Runnable {
                 if (!ConnectivityHelper.isNetworkEnabled(context)) {
                     getActiveCalls().forEach { (_, call) ->
-                        call.updateCallState(CallState.DROPPED)
+                        call.updateCallState(CallState.DROPPED(Reason.NETWORK_LOST))
                     }
                     socketResponseLiveData.postValue(SocketResponse.error("No Network Connection"))
                 } else {
@@ -507,7 +507,7 @@ class TelnyxClient(
         getActiveCalls().forEach { (_, call) ->
             webRTCReporter?.pauseStats()
             call.peerConnection?.disconnect()
-            call.updateCallState(CallState.RECONNECTING)
+            call.updateCallState(CallState.RECONNECTING(Reason.NETWORK_SWITCH))
         }
 
         //Delay for network to be properly established

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1465,7 +1465,7 @@ class TelnyxClient(
             val callIdString = params?.get("callID")?.asString
 
             if (callIdString == null) {
-                Logger.e("Received BYE without callID in params: $jsonObject")
+                Logger.e(message = "Received BYE without callID in params: $jsonObject")
                 return
             }
             val callId = UUID.fromString(callIdString)
@@ -1515,10 +1515,10 @@ class TelnyxClient(
                 answerResponse = null
                 inviteResponse = null
             } ?: run {
-                Logger.w("Received BYE for a callId not found in active calls: $callId")
+                Logger.w(message = "Received BYE for a callId not found in active calls: $callId")
             }
         } catch (e: Exception) {
-            Logger.e("Error processing onByeReceived: ${e.message}", e)
+            Logger.e(message = "Error processing onByeReceived: ${e.message}")
         }
     }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -405,17 +405,15 @@ class TelnyxClient(
                 uuid, SocketMethod.BYE.methodName,
                 ByeParams(
                     sessionId,
-                    causeCode, // Use the defined causeCode
-                    causeName, // Use the defined causeName
+                    causeCode,
+                    causeName,
                     ByeDialogParams(
                         callId
                     )
                 )
             )
-            // The ByeResponse sent to UI. For local termination, we might not have SIP codes.
-            // If ByeResponse is to reflect what's in CallState.DONE, it should align.
-            // For now, the ticket focuses on CallState, so this part is secondary.
-            val byeResponseForUi = com.telnyx.webrtc.sdk.verto.receive.ByeResponse(
+
+            val byeResponseForUi = ByeResponse(
                 callId = callId,
                 cause = causeName,
                 causeCode = causeCode
@@ -437,6 +435,7 @@ class TelnyxClient(
             webRTCReporter = null // Clear the reporter instance
             client.removeFromCalls(callId)
             client.callNotOngoing()
+            socket.send(byeMessageBody)
             resetCallOptions()
             client.stopMediaPlayer()
             peerConnection?.release()

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -354,6 +354,7 @@ class TelnyxClient(
             providedStun = providedStun!!
         ).apply {
             callId = inviteCallId
+            updateCallState(CallState.RINGING)
 
             peerConnection = Peer(context, client, providedTurn, providedStun, inviteCallId) { candidate ->
                 addIceCandidateInternal(candidate)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/CallState.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/CallState.kt
@@ -7,11 +7,27 @@ package com.telnyx.webrtc.sdk.model
 /**
  * Enum to represent reasons for reconnection or call drop.
  */
-enum class Reason(val description: String) {
+enum class CallNetworkChangeReason(val description: String) {
     NETWORK_SWITCH("Network switched"),
     NETWORK_LOST("Network lost"),
     SERVER_ERROR("Server error")
 }
+
+/**
+ * Data class to hold detailed reasons for call termination.
+ * All fields are optional as they may not always be available.
+ *
+ * @param cause General cause description (e.g., "CALL_REJECTED").
+ * @param causeCode Numerical code for the cause (e.g., 21).
+ * @param sipCode SIP response code (e.g., 403).
+ * @param sipReason SIP reason phrase (e.g., "Dialed number is not included in whitelisted countries").
+ */
+data class CallTerminationReason(
+    val cause: String? = null,
+    val causeCode: Int? = null,
+    val sipCode: Int? = null,
+    val sipReason: String? = null
+)
 
 /**
  *
@@ -30,13 +46,13 @@ sealed class CallState {
     /** The user has put the call on hold. */
     object HELD : CallState()
     /** The call is finished - either party has ended the call. */
-    object DONE : CallState()
+    data class DONE(val reason: CallTerminationReason? = null) : CallState()
     /** There was an issue creating the call. */
     object ERROR : CallState()
     /** The call was dropped as a result of network issues. */
-    data class DROPPED(val reason: Reason) : CallState()
+    data class DROPPED(val callNetworkChangeReason: CallNetworkChangeReason) : CallState()
     /** The call is being reconnected after a network issue. */
-    data class RECONNECTING(val reason: Reason) : CallState()
+    data class RECONNECTING(val callNetworkChangeReason: CallNetworkChangeReason) : CallState()
 
     /**
      * Helper function to get the reason for the state (if applicable).
@@ -44,8 +60,8 @@ sealed class CallState {
      */
     fun getReason(): String? {
         return when (this) {
-            is RECONNECTING -> this.reason.description
-            is DROPPED -> this.reason.description
+            is RECONNECTING -> this.callNetworkChangeReason.description
+            is DROPPED -> this.callNetworkChangeReason.description
             else -> null
         }
     }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/CallState.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/CallState.kt
@@ -5,27 +5,55 @@
 package com.telnyx.webrtc.sdk.model
 
 /**
- *
- * Enum class to represent the different Call States that a call can be in.
- *
- * @property NEW the call has been created
- * @property CONNECTING the call is being connected to the remote client
- * @property RINGING the call invitation has been extended, we are waiting for an answer.
- * @property ACTIVE the call is active and the two clients are fully connected.
- * @property HELD the user has put the call on hold.
- * @property DONE the call is finished - either party has ended the call.
- * @property ERROR there was an issue creating the call.
- * @property DROPPED the call was dropped as a result of network issues.
- * @property RECONNECTING the call is being reconnected after a network issue.
+ * Enum to represent reasons for reconnection or call drop.
  */
-enum class CallState {
-    NEW,
-    CONNECTING,
-    RECONNECTING,
-    RINGING,
-    ACTIVE,
-    HELD,
-    DONE,
-    ERROR,
-    DROPPED
+enum class Reason(val description: String) {
+    NETWORK_SWITCH("Network switched"),
+    NETWORK_LOST("Network lost"),
+    SERVER_ERROR("Server error")
+}
+
+/**
+ *
+ * Sealed class to represent the different Call States that a call can be in.
+ *
+ */
+sealed class CallState {
+    /** The call has been created. */
+    object NEW : CallState()
+    /** The call is being connected to the remote client. */
+    object CONNECTING : CallState()
+    /** The call invitation has been extended, we are waiting for an answer. */
+    object RINGING : CallState()
+    /** The call is active and the two clients are fully connected. */
+    object ACTIVE : CallState()
+    /** The user has put the call on hold. */
+    object HELD : CallState()
+    /** The call is finished - either party has ended the call. */
+    object DONE : CallState()
+    /** There was an issue creating the call. */
+    object ERROR : CallState()
+    /** The call was dropped as a result of network issues. */
+    data class DROPPED(val reason: Reason) : CallState()
+    /** The call is being reconnected after a network issue. */
+    data class RECONNECTING(val reason: Reason) : CallState()
+
+    /**
+     * Helper function to get the reason for the state (if applicable).
+     * @return The reason description string or null if not applicable.
+     */
+    fun getReason(): String? {
+        return when (this) {
+            is RECONNECTING -> this.reason.description
+            is DROPPED -> this.reason.description
+            else -> null
+        }
+    }
+
+    /**
+     * Returns the string representation of the class name.
+     * @return The simple name of the class.
+     */
+    val value: String
+        get() = this.javaClass.simpleName
 }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SocketError.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SocketError.kt
@@ -13,9 +13,13 @@ package com.telnyx.webrtc.sdk.model
  * @property TOKEN_ERROR there was an issue with a token - either invalid or expired
  * @property CREDENTIAL_ERROR there was an issue with the credentials used - likely invalid.
  * @property CODEC_ERROR there was an issue with the SDP handshake, likely due to codec issues.
+ * @property GATEWAY_TIMEOUT_ERROR Gateway registration timed out.
+ * @property GATEWAY_FAILURE_ERROR Gateway registration failed after multiple retries.
  */
 enum class SocketError(var errorCode: Int) {
     TOKEN_ERROR(-32000),
     CREDENTIAL_ERROR(-32001),
-    CODEC_ERROR(-32002)
+    CODEC_ERROR(-32002),
+    GATEWAY_TIMEOUT_ERROR(-32003),
+    GATEWAY_FAILURE_ERROR(-32004)
 }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -203,11 +203,7 @@ class TxSocket(
                                 }
 
                                 BYE.methodName -> {
-                                    val params =
-                                        jsonObject.getAsJsonObject("params")
-                                    val callId =
-                                        UUID.fromString(params.get("callID").asString)
-                                    listener.onByeReceived(callId)
+                                    listener.onByeReceived(jsonObject)
                                 }
 
                                 INVITE.methodName -> {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -147,15 +147,6 @@ class TxSocket(
                         params = jsonObject.get("params").asJsonObject
                     }
 
-                    if (jsonObject.get("error") != null) {
-                        // Handle Generic Error without Result and Code
-                        Logger.v(
-                            message = "Generic Error Received"
-                        )
-                        listener.onErrorReceived(jsonObject, null)
-                        return
-                    }
-
                     when {
                         jsonObject.has("result") -> {
                             if (jsonObject.get("result").asJsonObject.has("params")) {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -146,6 +146,16 @@ class TxSocket(
                     if (jsonObject.has("params")) {
                         params = jsonObject.get("params").asJsonObject
                     }
+
+                    if (jsonObject.get("error") != null) {
+                        // Handle Generic Error without Result and Code
+                        Logger.v(
+                            message = "Generic Error Received"
+                        )
+                        listener.onErrorReceived(jsonObject, null)
+                        return
+                    }
+
                     when {
                         jsonObject.has("result") -> {
                             if (jsonObject.get("result").asJsonObject.has("params")) {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -230,27 +230,19 @@ class TxSocket(
                                 val errorCode =
                                     jsonObject.get("error").asJsonObject.get("code").asInt
                                 Logger.v(
-                                    message = Logger.formatMessage("[%s] Received Error From Telnyx [%s]",
+                                    message = Logger.formatMessage("[%s] Received Error From Telnyx [%s] with code [%d]",
+                                    this@TxSocket.javaClass.simpleName,
+                                    jsonObject.get("error").asJsonObject.get("message").toString(),
+                                    errorCode)
+                                )
+                                listener.onErrorReceived(jsonObject, errorCode)
+                            } else {
+                                Logger.v(
+                                    message = Logger.formatMessage("[%s] Received Error From Telnyx [%s] (no code provided)",
                                     this@TxSocket.javaClass.simpleName,
                                     jsonObject.get("error").asJsonObject.get("message").toString())
                                 )
-                                when (errorCode) {
-                                    CREDENTIAL_ERROR.errorCode -> {
-                                        listener.onErrorReceived(jsonObject)
-                                    }
-
-                                    TOKEN_ERROR.errorCode -> {
-                                        listener.onErrorReceived(jsonObject)
-                                    }
-
-                                    SocketError.CODEC_ERROR.errorCode -> {
-                                        listener.onErrorReceived(jsonObject)
-                                    }
-
-                                    else -> {
-                                        listener.onErrorReceived(jsonObject)
-                                    }
-                                }
+                                listener.onErrorReceived(jsonObject, null)
                             }
                         }
                     }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
@@ -43,10 +43,10 @@ interface TxSocketListener {
 
     /**
      * Fires when the TxSocket has received an indication the a call has ended or been rejected
-     * @param callId, UUID of the call that has ended or been rejected
+     * @param jsonObject, the socket response in a jsonObject format
      * @see [TxSocket]
      */
-    fun onByeReceived(callId: UUID)
+    fun onByeReceived(jsonObject: JsonObject)
 
     /**
      * Fires when a user has provided an answer to a call attempt

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
@@ -37,9 +37,10 @@ interface TxSocketListener {
     /**
      * Fires when an error has occurred with the TxSocket
      * @param jsonObject, the socket response in a jsonObject format
+     * @param errorCode, the integer error code if available
      * @see [TxSocket]
      */
-    fun onErrorReceived(jsonObject: JsonObject)
+    fun onErrorReceived(jsonObject: JsonObject, errorCode: Int?)
 
     /**
      * Fires when the TxSocket has received an indication the a call has ended or been rejected

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/WebRTCReporter.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/WebRTCReporter.kt
@@ -180,11 +180,9 @@ internal class WebRTCReporter(
     }
 
     internal suspend fun startTimer() {
-
         CoroutineScope(Dispatchers.IO).launch {
             while (isActive) {
                 peer.peerConnection?.getStats {
-                    Logger.d(tag = "stats", "Stats: ${it.statsMap}")
                     val statsData = JsonObject()
                     val data = JsonObject()
                     val audio = JsonObject()

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/receive/ReceivedResult.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/receive/ReceivedResult.kt
@@ -40,8 +40,16 @@ data class LoginResponse(
 
 
 data class ByeResponse(
-    @SerializedName("sessid")
-    val callId : UUID
+    @SerializedName("callID")
+    val callId : UUID,
+    @SerializedName("cause")
+    val cause: String? = null,
+    @SerializedName("causeCode")
+    val causeCode: Int? = null,
+    @SerializedName("sipCode")
+    val sipCode: Int? = null,
+    @SerializedName("sipReason")
+    val sipReason: String? = null
 ) : ReceivedResult()
 
 /**

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/receive/SocketResponse.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/receive/SocketResponse.kt
@@ -6,11 +6,17 @@ package com.telnyx.webrtc.sdk.verto.receive
 
 import com.telnyx.webrtc.sdk.model.SocketStatus
 
-data class SocketResponse<out T>(var status: SocketStatus, val data: T?, val errorMessage: String?) {
+data class SocketResponse<out T>(
+    var status: SocketStatus,
+    val data: T?,
+    val errorMessage: String?,
+    val errorCode: Int? = null
+) {
     companion object {
         fun <T> established(): SocketResponse<T> {
             return SocketResponse(
                 SocketStatus.ESTABLISHED,
+                null,
                 null,
                 null
             )
@@ -20,6 +26,7 @@ data class SocketResponse<out T>(var status: SocketStatus, val data: T?, val err
             return SocketResponse(
                 SocketStatus.ESTABLISHED,
                 null,
+                null,
                 null
             )
         }
@@ -28,20 +35,22 @@ data class SocketResponse<out T>(var status: SocketStatus, val data: T?, val err
             return SocketResponse(
                 SocketStatus.MESSAGERECEIVED,
                 data,
+                null,
                 null
             )
         }
 
-        fun <T> error(msg: String): SocketResponse<T> {
-            return SocketResponse(SocketStatus.ERROR, null, msg)
+        fun <T> error(msg: String, errorCode: Int? = null): SocketResponse<T> {
+            return SocketResponse(SocketStatus.ERROR, null, msg, errorCode)
         }
         fun <T> disconnect(): SocketResponse<T> {
-            return SocketResponse(SocketStatus.DISCONNECT, null, null)
+            return SocketResponse(SocketStatus.DISCONNECT, null, null, null)
         }
 
         fun <T> loading(): SocketResponse<T> {
             return SocketResponse(
                 SocketStatus.LOADING,
+                null,
                 null,
                 null
             )

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
@@ -286,7 +286,7 @@ class CallTest : BaseTest() {
             //write a way to test this
             //
 
-            call.client.onErrorReceived(jsonObject)
+            call.client.onErrorReceived(jsonObject, 0)
         }
     }
 }

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -15,6 +15,7 @@ import com.google.gson.JsonObject
 import com.telnyx.webrtc.sdk.model.AudioDevice
 import com.telnyx.webrtc.sdk.model.GatewayState
 import com.telnyx.webrtc.sdk.model.LogLevel
+import com.telnyx.webrtc.sdk.model.SocketError
 import com.telnyx.webrtc.sdk.socket.TxSocket
 import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
 import com.telnyx.webrtc.sdk.testhelpers.*
@@ -384,7 +385,7 @@ class TelnyxClientTest : BaseTest() {
         Thread.sleep(1000)
         assertEquals(
             client.socketResponseLiveData.getOrAwaitValue(),
-            SocketResponse.error("Login Incorrect")
+            SocketResponse.error("Login Incorrect", SocketError.CREDENTIAL_ERROR.errorCode)
         )
     }
 
@@ -408,7 +409,7 @@ class TelnyxClientTest : BaseTest() {
         client.onGatewayStateReceived(GatewayState.NOREG.state, sessid)
         assertEquals(
             client.socketResponseLiveData.getOrAwaitValue(),
-            SocketResponse.error("Gateway registration has timed out")
+            SocketResponse.error("Gateway registration has timed out", SocketError.GATEWAY_TIMEOUT_ERROR.errorCode)
         )
     }
 

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -385,7 +385,7 @@ class TelnyxClientTest : BaseTest() {
         Thread.sleep(1000)
         assertEquals(
             client.socketResponseLiveData.getOrAwaitValue(),
-            SocketResponse.error("Login Incorrect", SocketError.CREDENTIAL_ERROR.errorCode)
+            SocketResponse.error("Login Incorrect", null)
         )
     }
 
@@ -487,8 +487,9 @@ class TelnyxClientTest : BaseTest() {
 
     @Test
     fun `Test onErrorReceived posts LiveData to socketResponseLiveData`() {
-        client = Mockito.spy(TelnyxClient(mockContext))
+        client = spyk(TelnyxClient(mockContext))
         val errorJson = JsonObject()
+        errorJson.addProperty("id", "test-error-id")
         val errorMessageBody = JsonObject()
         errorMessageBody.addProperty("message", "my error message")
         errorJson.add("error", errorMessageBody)

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -385,7 +385,7 @@ class TelnyxClientTest : BaseTest() {
         Thread.sleep(1000)
         assertEquals(
             client.socketResponseLiveData.getOrAwaitValue(),
-            SocketResponse.error("Login Incorrect", null)
+            SocketResponse.error("Login Incorrect", -32001)
         )
     }
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -22,6 +22,7 @@ versions.googleservices = "4.3.8"
 versions.firebasebom = "28.2.1"
 versions.hilt = "2.48"
 versions.dialpad = "3.0.0"
+versions.mockk = "1.13.10"
 
 
 ext.versions = versions
@@ -75,6 +76,11 @@ hilt.plugin = "com.google.dagger:hilt-android-gradle-plugin:$versions.hilt"
 hilt.android = "com.google.dagger:hilt-android:$versions.hilt"
 hilt.compiler = "com.google.dagger:hilt-android-compiler:$versions.hilt"
 deps.hilt = hilt
+
+def mockk = [:]
+mockk.core = "io.mockk:mockk:${versions.mockk}"
+mockk.android = "io.mockk:mockk-android:${versions.mockk}"
+deps.mockk = mockk
 
 
 ext.deps = deps


### PR DESCRIPTION
## [WebRTC-2701 - Enhance Call State and Termination Reason Reporting in SDK](https://telnyx.atlassian.net/browse/WEBRTC-2701)

---
This pull request introduces significant enhancements to call state reporting and error handling within the Android WebRTC SDK. The primary goal is to provide developers with more granular information about call lifecycle events, particularly for call drops, reconnections, and terminations, including specific error codes. This allows for more informative UI/UX in client applications and better diagnostic capabilities.

Key changes include:
-   Refactoring `CallState` to a `sealed class` to allow states to carry associated data.
-   Introducing `CallNetworkChangeReason` to specify reasons for `DROPPED` and `RECONNECTING` states (e.g., network loss, network switch).
-   Introducing `CallTerminationReason` to provide detailed cause, SIP codes, and reasons when a call transitions to the `DONE` state.
-   Modifying the `ByeResponse` object and the `TxSocketListener.onByeReceived` method to parse and propagate these richer termination details from incoming `bye` messages.
-   Enhancing `SocketResponse` to include an optional `errorCode: Int?` field for error events.
-   Updating `TxSocketListener.onErrorReceived` to include `errorCode: Int?`.
-   Updating `TelnyxClient` to propagate `errorCode` from server errors and to use newly defined `SocketError` enum values for specific internally generated errors (e.g., gateway timeouts/failures).
-   Expanding the `SocketError` enum to include `GATEWAY_TIMEOUT_ERROR` (-32003) and `GATEWAY_FAILURE_ERROR` (-32004).
-   Updating relevant documentation (`ErrorHandling.md`, `Call.md`, `TelnyxClient.md`, `ReceivedMessageBody.md`, `Quickstart.md`) to reflect these new capabilities and guide developers on their usage.
-   Addressing linter errors and making necessary adjustments in the sample app and common module (`TelnyxViewModel.kt`, `HomeScreen.kt`, `TelecomCallManager.kt`, `TelecomCallScreen.kt`) to correctly handle the new `CallState` structure and other SDK changes.

## :older_man: :baby: Behaviors
### Before changes
*   `CallState` was an enum, limiting the ability to associate specific reasons with states like `DROPPED`, `RECONNECTING`, or `DONE`.
*   When a call ended (`DONE` state), there was no structured way to access detailed termination reasons (like SIP codes or specific cause from the network/remote party).
*   `DROPPED` and `RECONNECTING` states did not provide specific context about the network event (e.g., total loss vs. network switch).
*   The `onByeReceived` listener method in `TxSocketListener` only provided the `callId`, making it difficult to get detailed termination information directly from the `bye` event.
*   Error messages propagated via `SocketResponse` (e.g., from `onErrorReceived`) only contained a string message, without a structured error code.
*   Internally generated error messages (like gateway timeouts) did not have associated, easily referenceable error codes.
*   Error handling documentation was more of a general guide and lacked a quick reference for specific error states and codes.

### After changes
*   `CallState` is a `sealed class`.
    *   `CallState.DROPPED` now includes a `callNetworkChangeReason: CallNetworkChangeReason` (e.g., `NETWORK_LOST`, `NETWORK_SWITCH`).
    *   `CallState.RECONNECTING` now includes a `callNetworkChangeReason: CallNetworkChangeReason` (e.g., `NETWORK_SWITCH`).
    *   `CallState.DONE` now includes an optional `reason: CallTerminationReason?`, which contains `cause`, `causeCode`, `sipCode`, and `sipReason`.
*   The `TxSocketListener.onByeReceived` method now accepts a `JsonObject` payload. The `TelnyxClient` implementation parses this to extract detailed termination reasons and updates the `CallState.DONE` with these details.
*   The `com.telnyx.webrtc.sdk.verto.receive.ByeResponse` object (exposed via `socketResponseLiveData`) is now enriched with `cause`, `causeCode`, `sipCode`, and `sipReason`.
*   `SocketResponse` for errors now includes an optional `errorCode: Int?`.
*   `TxSocketListener.onErrorReceived` now includes `errorCode: Int?` in its signature.
*   `TelnyxClient` passes `errorCode` from server errors and uses specific `SocketError` enum values (e.g., `SocketError.GATEWAY_TIMEOUT_ERROR.errorCode`) for certain internally generated errors.
*   The `SocketError` enum has been expanded with `GATEWAY_TIMEOUT_ERROR` and `GATEWAY_FAILURE_ERROR`.
*   Client applications can now observe `call.callStateFlow` and, for `DONE`, `DROPPED`, and `RECONNECTING` states, access specific reasons. They can also check `SocketResponse.errorCode` for more detailed error handling.
*   The `ErrorHandling.md` documentation has been restructured and significantly updated to cover these new states, reasons, error codes, and the enriched `ByeResponse`. Other relevant SDK documentation has also been updated.
*   Sample apps and the common module have been updated to correctly use the new `CallState` structure and handle potential type mismatches arising from these changes.

## ✋ Manual testing
1.  **Outgoing Call - Normal Hangup (Local)**:
    *   Initiate an outgoing call from the SDK.
    *   End the call locally using `telnyxClient.endCall(callId)`.
    *   **Verify**: The `Call.callStateFlow` transitions to `CallState.DONE`. The `reason` in `CallState.DONE` should reflect a local hangup (e.g., cause "USER_BUSY", causeCode 17, with null SIP details as it was a local action).
2.  **Outgoing Call - Remote Hangup**:
    *   Initiate an outgoing call from the SDK to a device that can hang up.
    *   Have the remote party hang up the call.
    *   **Verify**: The `TelnyxClient.socketResponseLiveData` emits a `BYE` message. The `ByeResponse` object should contain `cause`, `causeCode`, `sipCode`, and `sipReason` as sent by the server.
    *   **Verify**: The corresponding `Call.callStateFlow` transitions to `CallState.DONE`, and its `reason: CallTerminationReason` should be populated with the details from the `BYE` message.
3.  **Incoming Call - Accept and Remote Hangup**:
    *   Initiate an incoming call to the SDK.
    *   Accept the call in the SDK.
    *   Have the remote party (caller) hang up the call.
    *   **Verify**: Similar to step 2, check `socketResponseLiveData` for the `BYE` message details and the `Call.callStateFlow` for `CallState.DONE` with the correct populated `CallTerminationReason`.
4.  **Incoming Call - Reject**:
    *   Initiate an incoming call to the SDK.
    *   Reject the call locally using `telnyxClient.endCall(callId)` (or a specific reject method if applicable).
    *   **Verify**: The `Call.callStateFlow` transitions to `CallState.DONE`. The `reason` should reflect a local rejection.
5.  **Network Drop Scenario**:
    *   Initiate a call.
    *   Simulate a network loss on the device running the SDK (e.g., turn off Wi-Fi and mobile data).
    *   **Verify**: The `Call.callStateFlow` transitions to `CallState.DROPPED` with `callNetworkChangeReason = CallNetworkChangeReason.NETWORK_LOST`.
    *   **Verify**: `socketResponseLiveData` should emit an error "No Network Connection" with `errorCode = null` if the drop happens during connection attempts or as a general network unavailability.
6.  **Gateway Timeout/Failure Simulation** (This may require specific test conditions or manual simulation if direct triggering is hard):
    *   Simulate conditions leading to gateway registration timeout.
    *   **Verify**: `TelnyxClient.socketResponseLiveData` emits an error with `errorMessage` "Gateway registration has timed out" and `errorCode = SocketError.GATEWAY_TIMEOUT_ERROR.errorCode` (-32003).
    *   Simulate conditions leading to gateway registration failure.
    *   **Verify**: `TelnyxClient.socketResponseLiveData` emits an error with `errorMessage` "Gateway registration has failed" and `errorCode = SocketError.GATEWAY_FAILURE_ERROR.errorCode` (-32004).
7.  **Server-Side Error (e.g., Invalid Credentials)**:
    *   Attempt to login with incorrect credentials.
    *   **Verify**: `TelnyxClient.socketResponseLiveData` emits an error. The `errorMessage` should be "Login Incorrect" (or similar from server) and `errorCode` should be `SocketError.CREDENTIAL_ERROR.errorCode` (-32001).
8.  **Call Termination with SIP Error (e.g., Invalid Number, Forbidden)**:
    *   Attempt to call an invalid number or a number that would result in a specific SIP error (e.g., 404 Not Found, 403 Forbidden).
    *   **Verify**: The call should fail, `CallState.DONE` should be reached with `CallTerminationReason` populated with the appropriate `sipCode`, `sipReason`, `cause`, and `causeCode`. The `ByeResponse` via `socketResponseLiveData` should also reflect these details.
9.  **Documentation Review**:
    *   Check `docs-markdown/error-handling/ErrorHandling.md` for accuracy regarding `SocketResponse.errorCode`, `SocketError` enum usage, and the updated reference table.
    *   Review `docs-markdown/classes/Call.md`, `TelnyxClient.md`, `socket/ReceivedMessageBody.md`, and `quickstart/Quickstart.md` for correctness regarding the new call state details and error code handling.

---