### PR TITLE
WEBRTC-2710: Add Precall Diagnosis

### DIFF
--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
@@ -98,6 +98,7 @@ fun HomeScreen(navController: NavHostController, telnyxViewModel: TelnyxViewMode
     val scope = rememberCoroutineScope()
     var showLoginBottomSheet by remember { mutableStateOf(false) }
     var showEnvironmentBottomSheet by remember { mutableStateOf(false) }
+    var showPreCallDiagnosisBottomSheet by remember { mutableStateOf(false) }
     val currentConfig by telnyxViewModel.currentProfile.collectAsState()
     var editableUserProfile by remember { mutableStateOf<Profile?>(null) }
     var selectedUserProfile by remember { mutableStateOf<Profile?>(null) }
@@ -209,7 +210,196 @@ fun HomeScreen(navController: NavHostController, telnyxViewModel: TelnyxViewMode
         }
 
         //BottomSheet
-        if (showLoginBottomSheet) {
+        // Pre-call diagnosis bottom sheet
+    if (showPreCallDiagnosisBottomSheet) {
+        ModalBottomSheet(
+            modifier = Modifier.fillMaxSize(),
+            onDismissRequest = {
+                showPreCallDiagnosisBottomSheet = false
+            },
+            containerColor = Color.White,
+            sheetState = sheetState
+        ) {
+            Column(
+                modifier = Modifier.padding(Dimens.mediumSpacing),
+                verticalArrangement = Arrangement.spacedBy(Dimens.mediumSpacing)
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    MediumTextBold(
+                        text = "Pre-call Diagnosis",
+                        modifier = Modifier.fillMaxWidth(fraction = 0.9f)
+                    )
+                    IconButton(onClick = {
+                        scope.launch {
+                            sheetState.hide()
+                        }.invokeOnCompletion {
+                            if (!sheetState.isVisible) {
+                                showPreCallDiagnosisBottomSheet = false
+                            }
+                        }
+                    }) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_close),
+                            contentDescription = stringResource(id = R.string.close_button_dessc)
+                        )
+                    }
+                }
+                
+                var diagnosisStatus by remember { mutableStateOf("Running diagnosis...") }
+                var showResults by remember { mutableStateOf(false) }
+                var mosValue by remember { mutableStateOf("--") }
+                var rttValue by remember { mutableStateOf("--") }
+                var jitterValue by remember { mutableStateOf("--") }
+                var packetLossValue by remember { mutableStateOf("--") }
+                
+                RegularText(
+                    text = diagnosisStatus,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center
+                )
+                
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        color = telnyxGreen,
+                        modifier = Modifier.padding(Dimens.mediumSpacing)
+                    )
+                }
+                
+                AnimatedVisibility(visible = showResults) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(Dimens.smallSpacing)
+                    ) {
+                        MediumTextBold(text = "Call Quality Metrics:")
+                        
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            RegularText(text = "MOS:")
+                            RegularText(text = mosValue)
+                        }
+                        
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            RegularText(text = "RTT:")
+                            RegularText(text = rttValue)
+                        }
+                        
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            RegularText(text = "Jitter:")
+                            RegularText(text = jitterValue)
+                        }
+                        
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            RegularText(text = "Packet Loss:")
+                            RegularText(text = packetLossValue)
+                        }
+                    }
+                }
+                
+                // Start the diagnosis call
+                LaunchedEffect(Unit) {
+                    try {
+                        // Get texml_number from local.properties
+                        val properties = java.util.Properties()
+                        val localPropertiesFile = java.io.File(context.filesDir.parentFile?.parentFile?.parentFile?.parentFile, "local.properties")
+                        if (localPropertiesFile.exists()) {
+                            properties.load(java.io.FileInputStream(localPropertiesFile))
+                            val texmlNumber = properties.getProperty("texml_number", "+15551234567")
+                            
+                            // Make a call to the texml_number
+                            telnyxViewModel.sendInvite(context, texmlNumber, true)
+                            
+                            // Wait for call to connect and collect metrics
+                            var callConnected = false
+                            var metricsCollected = false
+                            var callEndedManually = false
+                            
+                            // Collect call state
+                            val callStateJob = launch {
+                                telnyxViewModel.currentCall?.callStateFlow?.collect { callState ->
+                                    when (callState) {
+                                        CallState.ACTIVE -> {
+                                            callConnected = true
+                                            diagnosisStatus = "Call connected. Collecting metrics..."
+                                            
+                                            // Wait a bit to collect metrics
+                                            delay(5000)
+                                            
+                                            // End the call after collecting metrics
+                                            if (!callEndedManually) {
+                                                callEndedManually = true
+                                                telnyxViewModel.currentCall?.hangup()
+                                            }
+                                        }
+                                        CallState.DONE, CallState.ERROR -> {
+                                            if (callConnected && !metricsCollected) {
+                                                metricsCollected = true
+                                                diagnosisStatus = "Diagnosis completed"
+                                                showResults = true
+                                            } else if (!callConnected) {
+                                                diagnosisStatus = "Diagnosis failed. Could not establish call."
+                                            }
+                                        }
+                                        else -> {
+                                            // Other call states
+                                        }
+                                    }
+                                }
+                            }
+                            
+                            // Collect metrics
+                            val metricsJob = launch {
+                                telnyxViewModel.callQualityMetrics.collect { metrics ->
+                                    metrics?.let {
+                                        mosValue = String.format("%.2f", metrics.mos)
+                                        rttValue = String.format("%.2f ms", metrics.rtt)
+                                        jitterValue = String.format("%.2f ms", metrics.jitter)
+                                        packetLossValue = String.format("%.2f%%", metrics.packetLoss * 100)
+                                    }
+                                }
+                            }
+                            
+                            // Set a timeout for the diagnosis
+                            delay(30000) // 30 seconds timeout
+                            
+                            // If call is still active, end it
+                            if (telnyxViewModel.currentCall?.callStateFlow?.value == CallState.ACTIVE && !callEndedManually) {
+                                callEndedManually = true
+                                telnyxViewModel.currentCall?.hangup()
+                            }
+                            
+                            // Cancel the jobs
+                            callStateJob.cancel()
+                            metricsJob.cancel()
+                            
+                        } else {
+                            diagnosisStatus = "Error: Could not find local.properties file"
+                        }
+                    } catch (e: Exception) {
+                        diagnosisStatus = "Error: ${e.message}"
+                    }
+                }
+            }
+        }
+    }
+
+    if (showLoginBottomSheet) {
             ModalBottomSheet(
                 modifier = Modifier.fillMaxSize(),
                 onDismissRequest = {
@@ -441,6 +631,23 @@ fun HomeScreen(navController: NavHostController, telnyxViewModel: TelnyxViewMode
                                     R.string.push_notifications_disabled,
                                     Toast.LENGTH_LONG
                                 ).show()
+                            }
+                            
+                            // Add Pre-call diagnosis button when user is logged in
+                            RoundSmallButton(
+                                modifier = Modifier.fillMaxWidth(),
+                                text = "Pre-call diagnosis",
+                                textSize = 14.sp,
+                                backgroundColor = MaterialTheme.colorScheme.secondary
+                            ) {
+                                scope.launch {
+                                    sheetState.hide()
+                                }.invokeOnCompletion {
+                                    if (!sheetState.isVisible) {
+                                        showEnvironmentBottomSheet = false
+                                        showPreCallDiagnosisBottomSheet = true
+                                    }
+                                }
                             }
                         }
 

--- a/samples/xml_app/src/main/res/layout/bottom_sheet_environment.xml
+++ b/samples/xml_app/src/main/res/layout/bottom_sheet_environment.xml
@@ -61,4 +61,13 @@
         android:text="Disable Push Notifications"
         style="@style/Widget.MaterialComponents.Button" />
 
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/preCallDiagnosisButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="Pre-call diagnosis"
+        android:visibility="gone"
+        style="@style/Widget.MaterialComponents.Button" />
+
 </LinearLayout>

--- a/samples/xml_app/src/main/res/layout/bottom_sheet_precall_diagnosis.xml
+++ b/samples/xml_app/src/main/res/layout/bottom_sheet_precall_diagnosis.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Pre-call Diagnosis"
+            style="@style/HeaderText" />
+
+        <ImageButton
+            android:id="@+id/closeButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_close"
+            android:contentDescription="@string/close_button_dessc" />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/diagnosisStatusText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Running diagnosis..."
+        android:textAlignment="center" />
+
+    <ProgressBar
+        android:id="@+id/diagnosisProgressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="16dp" />
+
+    <LinearLayout
+        android:id="@+id/resultsContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_marginTop="16dp"
+        android:visibility="gone">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Call Quality Metrics:"
+            android:textStyle="bold"
+            android:layout_marginBottom="8dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="MOS:" />
+            <TextView
+                android:id="@+id/mosValue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="--" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="RTT:" />
+            <TextView
+                android:id="@+id/rttValue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="--" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Jitter:" />
+            <TextView
+                android:id="@+id/jitterValue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="--" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Packet Loss:" />
+            <TextView
+                android:id="@+id/packetLossValue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="--" />
+        </LinearLayout>
+    </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
## Description
This PR adds the 'Pre-call diagnosis' feature to both XML and Compose apps.

## Changes
- Added 'Pre-call diagnosis' option to XML app's environment bottom sheet (visible only when user is logged in)
- Added 'Pre-call diagnosis' option to Compose app's environment bottom sheet (visible only when user is logged in)
- Created bottom sheets to display diagnosis progress and results
- Implemented logic to make a call to texml_number from local.properties
- Added real-time display of call quality metrics (MOS, RTT, jitter, packet loss)

## Testing
1. Log in to the app
2. Long press on the Telnyx logo to open the environment bottom sheet
3. Click on 'Pre-call diagnosis'
4. Verify that a call is made to the texml_number and metrics are displayed

## Related Jira Ticket
[WEBRTC-2710](https://telnyx.atlassian.net/browse/WEBRTC-2710)