### PR TITLE
fix: wrong value in isUserLoggedIn param

### DIFF
--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/login/LoginFragment.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/login/LoginFragment.kt
@@ -57,10 +57,6 @@ class LoginFragment : Fragment() {
                 telnyxViewModel.uiState.collect { uiState ->
                     when (uiState) {
                         is TelnyxSocketEvent.OnClientReady -> {
-                            telnyxViewModel.currentProfile.value?.let { profile ->
-                                profile.isUserLoggedIn = true
-                                telnyxViewModel.setCurrentConfig(requireContext(), profile)
-                            }
                             findNavController().navigate(R.id.action_loginFragment_to_homeFragment)
                             cancel()
                         }

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/ProfileManager.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/ProfileManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.telnyx.webrtc.common.model.Profile
+import timber.log.Timber
 
 /**
  * Object responsible for managing user profiles.
@@ -49,6 +50,9 @@ object ProfileManager {
         listOfProfiles.firstOrNull { it.sipToken?.isEmpty() == false && it.sipToken == profile.sipToken }?.let { existingProfile ->
             listOfProfiles.remove(existingProfile)
         }
+
+        if (profile.isUserLoggedIn)
+            listOfProfiles.forEach { it.isUserLoggedIn = false }
 
         listOfProfiles.add(profile)
 


### PR DESCRIPTION
[WebRTC-2711 - Wrong caller name send with invite](https://telnyx.atlassian.net/browse/WEBRTC-2711)

---
Description

When there is more then one profile added in the demo app, wrong profile is used during invite action. Instead of already logged one, the app is using first on the list

Environment
all

Steps to Reproduce

add 2 profiles to the app

login with one profile, disconnect, login with another profile

make a call, in sendInvite packet will be visible credentials from first profile
