### PR TITLE
Fix: flakey UI tests on compose

### DIFF
--- a/samples/compose_app/src/androidTest/java/org/telnyx/webrtc/compose_app/MainActivityTest.kt
+++ b/samples/compose_app/src/androidTest/java/org/telnyx/webrtc/compose_app/MainActivityTest.kt
@@ -98,6 +98,7 @@ class MainActivityTest {
     private fun addSipCredentials() {
         assertNotNull(navController.graph)
 
+        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText(context.getString(R.string.missing_profile)).assertIsDisplayed()
         composeTestRule.onNodeWithText(context.getString(R.string.switch_profile)).assertIsDisplayed()
         composeTestRule.onNodeWithText(context.getString(R.string.switch_profile)).performClick()
@@ -115,9 +116,13 @@ class MainActivityTest {
         composeTestRule.onNodeWithTag("callerIDNumber").performScrollTo().assertIsDisplayed()
         composeTestRule.onNodeWithTag("callerIDNumber").performTextInput(BuildConfig.TEST_SIP_CALLER_NUMBER)
         composeTestRule.onNodeWithTag("credentialsForm").performClick()
-        composeTestRule.onNodeWithText(context.getString(R.string.confirm)).performClick()
+        composeTestRule.onNodeWithText(context.getString(R.string.save)).performClick()
 
         composeTestRule.waitForIdle()
+        composeTestRule.waitUntil(40000) {
+            composeTestRule.onNodeWithTag("profileList").isDisplayed()
+        }
+
         composeTestRule.onNodeWithTag("profileList").onChildAt(0).performClick()
         composeTestRule.onNodeWithText(context.getString(R.string.confirm)).performClick()
     }

--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
@@ -556,13 +556,13 @@ fun PosNegButton(
             horizontalArrangement = Arrangement.spacedBy(Dimens.extraSmallSpacing),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            RoundedOutlinedButton(modifier = Modifier.height(Dimens.size32dp),
+            RoundedOutlinedButton(modifier = Modifier.height(Dimens.size32dp).testTag("negativeButton"),
                 text = negativeText,
                 contentColor = MaterialTheme.colorScheme.primary,
                 backgroundColor = Color.White) {
                 onNegativeClick()
             }
-            RoundedOutlinedButton(modifier = Modifier.height(Dimens.size32dp), text = positiveText) {
+            RoundedOutlinedButton(modifier = Modifier.height(Dimens.size32dp).testTag("positiveButton"), text = positiveText) {
                 onPositiveClick()
             }
 

--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/LoginBottomSheet.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/LoginBottomSheet.kt
@@ -141,7 +141,7 @@ fun CredentialTokenView(
 
         Box(modifier = Modifier.fillMaxWidth()) {
             PosNegButton(
-                positiveText = stringResource(id = R.string.confirm),
+                positiveText = stringResource(id = R.string.save),
                 negativeText = stringResource(id = R.string.Cancel),
                 contentAlignment = Alignment.BottomStart,
                 onPositiveClick = {


### PR DESCRIPTION
[WebRTC-2722 - flakey UI tests on compose.](https://telnyx.atlassian.net/browse/WEBRTC-2722)

---

## :older_man: :baby: Behaviors
### Before changes
- UI tests failing both locally and remotely 

### After changes
Adjust UI tests in MainActivityTest.kt so that assertion failures do not occur

## ✋ Manual testing
1. Run tests locally and ensure they pass
2. Ideally they pass on this PR as well (Remote via Firebase Test Labs)
