### PR TITLE
Fix broken Client Side Push handling

### DIFF
--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/CallScreen.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/CallScreen.kt
@@ -111,7 +111,12 @@ fun CallScreen(telnyxViewModel: TelnyxViewModel) {
 
     LaunchedEffect(uiState) {
         callUIState = when (uiState) {
-            is TelnyxSocketEvent.OnClientReady -> CallUIState.IDLE
+            is TelnyxSocketEvent.OnClientReady -> {
+                if (telnyxViewModel.currentCall != null)
+                    CallUIState.ACTIVE
+                else
+                    CallUIState.IDLE
+            }
             is TelnyxSocketEvent.OnIncomingCall -> {
                 CallUIState.INCOMING
             }

--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/home/HomeCallFragment.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/home/HomeCallFragment.kt
@@ -137,7 +137,11 @@ class HomeCallFragment : Fragment() {
             telnyxViewModel.uiState.collect { uiState ->
                 when (uiState) {
                     is TelnyxSocketEvent.OnClientReady -> {
-                        onIdle()
+                        if (telnyxViewModel.currentCall != null) {
+                            onCallActive()
+                            registerObservers() // Register observers when call is answered
+                        } else
+                            onIdle()
                     }
 
                     is TelnyxSocketEvent.OnIncomingCall -> {

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -295,7 +295,7 @@ class TelnyxViewModel : ViewModel() {
                 autoLogin
             ).asFlow().collectLatest { response ->
                 Timber.d("Auth Response: $response")
-                handleSocketResponse(response, false)
+                handleSocketResponse(response)
             }
         }
     }
@@ -324,7 +324,7 @@ class TelnyxViewModel : ViewModel() {
                 }
                 .asFlow().collectLatest { response ->
                     Timber.d("Answering income push response: $response")
-                    handleSocketResponse(response, true)
+                    handleSocketResponse(response)
                 }
         }
 
@@ -352,7 +352,7 @@ class TelnyxViewModel : ViewModel() {
                 }
                 .asFlow().collectLatest { response ->
                     Timber.d("Rejecting income push response: $response")
-                    handleSocketResponse(response, true)
+                    handleSocketResponse(response)
                 }
         }
     }
@@ -452,7 +452,7 @@ class TelnyxViewModel : ViewModel() {
                 autoLogin
             ).asFlow().collectLatest { response ->
                 Timber.d("Auth Response: $response")
-                handleSocketResponse(response, false)
+                handleSocketResponse(response)
             }
         }
     }
@@ -521,15 +521,14 @@ class TelnyxViewModel : ViewModel() {
     }
 
     private fun handleSocketResponse(
-        response: SocketResponse<ReceivedMessageBody>,
-        isPushConnection: Boolean
+        response: SocketResponse<ReceivedMessageBody>
     ) {
         if (handlingResponses) {
             return
         }
         when (response.status) {
             SocketStatus.ESTABLISHED -> handleEstablished()
-            SocketStatus.MESSAGERECEIVED -> handleMessageReceived(response, isPushConnection)
+            SocketStatus.MESSAGERECEIVED -> handleMessageReceived(response)
             SocketStatus.LOADING -> handleLoading()
             SocketStatus.ERROR -> handleError(response)
             SocketStatus.DISCONNECT -> handleDisconnect()
@@ -541,13 +540,12 @@ class TelnyxViewModel : ViewModel() {
     }
 
     private fun handleMessageReceived(
-        response: SocketResponse<ReceivedMessageBody>,
-        isPushConnection: Boolean
+        response: SocketResponse<ReceivedMessageBody>
     ) {
         val data = response.data
         when (data?.method) {
             SocketMethod.CLIENT_READY.methodName -> handleClientReady()
-            SocketMethod.LOGIN.methodName -> handleLogin(data, isPushConnection)
+            SocketMethod.LOGIN.methodName -> handleLogin(data)
             SocketMethod.INVITE.methodName -> handleInvite(data)
             SocketMethod.ANSWER.methodName -> handleAnswer(data)
             SocketMethod.RINGING.methodName -> handleRinging(data)
@@ -562,13 +560,13 @@ class TelnyxViewModel : ViewModel() {
         _uiState.value = TelnyxSocketEvent.OnClientReady
     }
 
-    private fun handleLogin(data: ReceivedMessageBody, isPushConnection: Boolean) {
+    private fun handleLogin(data: ReceivedMessageBody) {
         val sessionId = (data.result as LoginResponse).sessid
         sessionId.let {
             Timber.d("Session ID: $sessionId")
         }
         _sessionsState.value = TelnyxSessionState.ClientLoggedIn(data.result as LoginResponse)
-        _isLoading.value = isPushConnection
+        _isLoading.value = false
     }
 
     private fun handleInvite(data: ReceivedMessageBody) {


### PR DESCRIPTION
[WebRTC-2770 - Fix broken Client Side Push handling.](https://telnyx.atlassian.net/browse/WEBRTC-2770)

---
In case of push call the order of incoming messages had been changed. This lead to the situation in which client app, after answering or rejecting incoming push call, stuck in 'loading' state.

Now incoming push call will properly shown in compose and xml demo apps.
