### PR TITLE
[WEBRTC-2799] - Android Decline Push Documentation Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,17 @@ If no custom logger is provided, the SDK will use its default logging implementa
 
 ### Handling Push Notifications
 In order to properly handle push notifications, we recommend using a call type (Foreground Service)[https://developer.android.com/develop/background-work/services/foreground-services] with a broadcast receiver to show push notifications. An answer or reject call intent with `telnyxPushMetaData` can then be passed to the MainActivity for processing.
+
+#### Declining Push Notifications
+The SDK now provides a simplified way to decline incoming calls from push notifications without launching the main application. The `BackgroundCallDeclineService` automatically handles the decline process by:
+
+1. Connecting to the socket with a `decline_push` parameter
+2. Sending the appropriate decline message
+3. Disconnecting automatically
+
+This eliminates the need for the complex flow of launching the app, waiting for invites, and manually sending bye messages.
+
+#### Best Practices for Push Notifications
 - Play a ringtone when a call is received from push notification using the `RingtoneManager`
 ``` kotlin
 val notification = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)

--- a/README.md
+++ b/README.md
@@ -340,13 +340,13 @@ If no custom logger is provided, the SDK will use its default logging implementa
 In order to properly handle push notifications, we recommend using a call type (Foreground Service)[https://developer.android.com/develop/background-work/services/foreground-services] with a broadcast receiver to show push notifications. An answer or reject call intent with `telnyxPushMetaData` can then be passed to the MainActivity for processing.
 
 #### Declining Push Notifications
-The SDK now provides a simplified way to decline incoming calls from push notifications without launching the main application. The `BackgroundCallDeclineService` automatically handles the decline process by:
+The SDK now provides a simplified way to decline incoming calls from push notifications using the `connectWithDeclinePush()` method. This new approach automatically handles the decline process by:
 
 1. Connecting to the socket with a `decline_push` parameter
 2. Sending the appropriate decline message
 3. Disconnecting automatically
 
-This eliminates the need for the complex flow of launching the app, waiting for invites, and manually sending bye messages.
+This eliminates the need for the complex flow of launching the app, waiting for invites, and manually sending bye messages. Use `connectWithDeclinePush()` instead of the standard `connect()` method when declining calls from push notifications.
 
 #### Best Practices for Push Notifications
 - Play a ringtone when a call is received from push notification using the `RingtoneManager`


### PR DESCRIPTION
[WEBRTC-2799 - Android Decline Push Documentation Update](https://telnyx.atlassian.net/browse/WEBRTC-2799)

---

This PR updates the Android WebRTC SDK documentation to reflect the new simplified push notification decline functionality introduced in PR #561.

## :older_man: :baby: Behaviors
### Before changes
**Complex Push Decline Flow:**
- User taps decline on notification
- App launches via PendingIntent
- App connects to socket
- App waits for invite message
- App manually sends bye message to decline
- App remains open

**Documentation Issues:**
- No documentation of the new BackgroundCallDeclineService
- Missing information about the simplified decline flow
- Outdated examples showing complex implementation

### After changes
**Simplified Push Decline Flow:**
- User taps decline on notification
- BackgroundCallDeclineService starts automatically
- Service connects to socket with decline_push parameter
- Service receives login success and disconnects
- Service stops automatically
- No app launch required

**Updated Documentation:**
- Added comprehensive BackgroundCallDeclineService documentation
- Updated README.md with new push decline section
- Enhanced app-setup.md with before/after flow comparison
- Updated quickstart.md with service documentation and migration guide
- Added benefits explanation: no app launch, reduced battery usage, improved UX

## ✋ Manual testing
1. Review updated README.md push notification section
2. Check app-setup.md for new decline functionality documentation
3. Verify quickstart.md includes BackgroundCallDeclineService information
4. Confirm migration guide is clear and helpful
5. Validate code examples are accurate and up-to-date