### PR TITLE
[WEBRTC-2802] - Update documentation around Region for Config

### DIFF
--- a/docs-markdown/config/TelnyxConfig.md
+++ b/docs-markdown/config/TelnyxConfig.md
@@ -8,20 +8,34 @@ sealed class TelnyxConfig
 ### Credential Config
 
 Represents a SIP user for login - Credential based
- * sipUser The SIP username of the user logging in
- * sipPassword The SIP password of the user logging in
- * sipCallerIDName The user's chosen Caller ID Name
- * sipCallerIDNumber The user's Caller ID Number
- * fcmToken The user's Firebase Cloud Messaging device ID
- * ringtone The integer raw value or uri of the audio file to use as a ringtone. Supports only raw file or uri
- * ringBackTone The integer raw value of the audio file to use as a ringback tone
- * logLevel The log level that the SDK should use - default value is none.
- * customLogger Optional custom logger implementation to handle SDK logs
- * autoReconnect whether or not to reattempt (3 times) the login in the instance of a failure to connect and register to the gateway with valid credentials
- * debug whether or not to send client debug reports
- * reconnectionTimeout how long the app should try to reconnect to the socket server before giving up
- * region the region to use for the connection
- * fallbackOnRegionFailure whether or not connect to default region if the select region is not reachable
+
+**sipUser** - The SIP username of the user logging in
+
+**sipPassword** - The SIP password of the user logging in
+
+**sipCallerIDName** - The user's chosen Caller ID Name (optional)
+
+**sipCallerIDNumber** - The user's Caller ID Number (optional)
+
+**fcmToken** - The user's Firebase Cloud Messaging device ID (optional)
+
+**ringtone** - The integer raw value or uri of the audio file to use as a ringtone. Supports only raw file or uri (optional)
+
+**ringBackTone** - The integer raw value of the audio file to use as a ringback tone (optional)
+
+**logLevel** - The log level that the SDK should use. Default value is `LogLevel.NONE`
+
+**customLogger** - Optional custom logger implementation to handle SDK logs
+
+**autoReconnect** - Whether or not to reattempt (3 times) the login in the instance of a failure to connect and register to the gateway with valid credentials. Default is `false`
+
+**debug** - Whether or not to send client debug reports. Default is `false`
+
+**reconnectionTimeout** - How long the app should try to reconnect to the socket server before giving up (in milliseconds). Default is `60000`
+
+**region** - The region to use for the connection. Default is `Region.AUTO`. See [Available Regions](#available-regions) for options
+
+**fallbackOnRegionFailure** - Whether or not to connect to default region if the selected region is not reachable. Default is `true`
 
 ```kotlin
 data class CredentialConfig(
@@ -45,19 +59,32 @@ data class CredentialConfig(
 ### Token Config
 
 Represents a SIP user for login - Token based
- * sipToken The JWT token for the SIP user.
- * sipCallerIDName The user's chosen Caller ID Name
- * sipCallerIDNumber The user's Caller ID Number
- * fcmToken The user's Firebase Cloud Messaging device ID
- * ringtone The integer raw value or uri of the audio file to use as a ringtone. Supports only raw file or uri
- * ringBackTone The integer raw value of the audio file to use as a ringback tone
- * logLevel The log level that the SDK should use - default value is none.
- * customLogger Optional custom logger implementation to handle SDK logs
- * autoReconnect whether or not to reattempt (3 times) the login in the instance of a failure to connect and register to the gateway with a valid token
- * debug whether or not to send client debug reports
- * reconnectionTimeout how long the app should try to reconnect to the socket server before giving up
- * region the region to use for the connection
- * fallbackOnRegionFailure whether or not connect to default region if the select region is not reachable
+
+**sipToken** - The JWT token for the SIP user
+
+**sipCallerIDName** - The user's chosen Caller ID Name (optional)
+
+**sipCallerIDNumber** - The user's Caller ID Number (optional)
+
+**fcmToken** - The user's Firebase Cloud Messaging device ID (optional)
+
+**ringtone** - The integer raw value or uri of the audio file to use as a ringtone. Supports only raw file or uri (optional)
+
+**ringBackTone** - The integer raw value of the audio file to use as a ringback tone (optional)
+
+**logLevel** - The log level that the SDK should use. Default value is `LogLevel.NONE`
+
+**customLogger** - Optional custom logger implementation to handle SDK logs
+
+**autoReconnect** - Whether or not to reattempt (3 times) the login in the instance of a failure to connect and register to the gateway with valid token. Default is `true`
+
+**debug** - Whether or not to send client debug reports. Default is `false`
+
+**reconnectionTimeout** - How long the app should try to reconnect to the socket server before giving up (in milliseconds). Default is `60000`
+
+**region** - The region to use for the connection. Default is `Region.AUTO`. See [Available Regions](#available-regions) for options
+
+**fallbackOnRegionFailure** - Whether or not to connect to default region if the selected region is not reachable. Default is `true`
 
 ```kotlin
 data class TokenConfig(
@@ -76,3 +103,49 @@ data class TokenConfig(
     val fallbackOnRegionFailure: Boolean = true
 ) : TelnyxConfig()
 ```
+
+## Available Regions
+
+The `region` parameter accepts a `Region` enum value that determines which Telnyx data center region to connect to. This can help optimize connection quality and latency based on your geographic location.
+
+### Region Options
+
+**Region.AUTO** - Automatically selects the best region based on network conditions (default)
+
+**Region.EU** - European region for users in Europe
+
+**Region.US_CENTRAL** - US Central region for users in central United States
+
+**Region.US_EAST** - US East region for users in eastern United States
+
+**Region.US_WEST** - US West region for users in western United States
+
+**Region.CA_CENTRAL** - Canada Central region for users in central Canada
+
+**Region.APAC** - Asia-Pacific region for users in Asia-Pacific areas
+
+### Usage Example
+
+```kotlin
+// Using a specific region
+val credentialConfig = CredentialConfig(
+    sipUser = "your_sip_user",
+    sipPassword = "your_sip_password",
+    sipCallerIDName = "Your Name",
+    sipCallerIDNumber = "1234567890",
+    region = Region.US_EAST,
+    fallbackOnRegionFailure = true
+)
+
+// Using automatic region selection (default)
+val tokenConfig = TokenConfig(
+    sipToken = "your_jwt_token",
+    sipCallerIDName = "Your Name",
+    sipCallerIDNumber = "1234567890",
+    region = Region.AUTO
+)
+```
+
+### Region Fallback
+
+When `fallbackOnRegionFailure` is set to `true` (default), the SDK will automatically fall back to the default region if the selected region is unreachable. This ensures better connection reliability while still attempting to use your preferred region first.


### PR DESCRIPTION
[WEBRTC-2802 - Update documentation around Region for Config.](https://telnyx.atlassian.net/browse/WEBRTC-2802)

---

This PR updates the TelnyxConfig.md documentation to reflect the current parameters in the TelnyxConfig.kt file. The documentation was missing proper formatting and comprehensive region information.

## :older_man: :baby: Behaviors
### Before changes
- TelnyxConfig.md documentation had unformatted parameter descriptions (not bolded)
- Missing detailed information about available regions
- No usage examples showing how to use different regions
- Parameter descriptions lacked type information and default values
- No documentation about region fallback behavior

### After changes
- All parameters are now properly formatted with bold markdown for better readability
- Added comprehensive documentation for all TelnyxConfig parameters with types and defaults
- Included detailed region documentation with all 7 available options (AUTO, EU, US-CENTRAL, US-EAST, US-WEST, CA-CENTRAL, APAC)
- Added practical usage examples for both CredentialConfig and TokenConfig
- Documented region fallback behavior and how it improves connection reliability
- Added clear explanations of optional vs required parameters

## ✋ Manual testing
1. Review the updated TelnyxConfig.md file to ensure all parameters are documented
2. Verify that the parameter descriptions match the actual implementation in TelnyxConfig.kt
3. Check that all Region enum options are correctly documented with clear descriptions
4. Confirm that the usage examples are accurate and helpful for developers