### PR TITLE
[WEBRTC-2830] - Fix notification channel reference

### DIFF
--- a/samples/compose_app/src/main/AndroidManifest.xml
+++ b/samples/compose_app/src/main/AndroidManifest.xml
@@ -44,7 +44,7 @@
 
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_channel_id"
-            android:value="telnyx_channel" />
+            android:value="telnyx_call_notification_channel" />
 
         <service
             android:enabled="true"

--- a/samples/connection_service_app/src/main/AndroidManifest.xml
+++ b/samples/connection_service_app/src/main/AndroidManifest.xml
@@ -71,7 +71,7 @@
 
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_channel_id"
-            android:value="telnyx_channel" />
+            android:value="telnyx_call_notification_channel" />
 
         <service android:name=".utility.telecom.call.TelecomCallService"
             android:exported="false"/>

--- a/samples/xml_app/src/main/AndroidManifest.xml
+++ b/samples/xml_app/src/main/AndroidManifest.xml
@@ -40,7 +40,7 @@
 
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_channel_id"
-            android:value="telnyx_channel" />
+            android:value="telnyx_call_notification_channel" />
 
         <service
             android:enabled="true"


### PR DESCRIPTION
[WEBRTC-2830 - Fix notification channel reference](https://telnyx.atlassian.net/browse/WEBRTC-2830)

---

This PR fixes the notification channel reference mismatch in AndroidManifest.xml files across all sample applications.

## :older_man: :baby: Behaviors
### Before changes
- AndroidManifest.xml files referenced 'telnyx_channel' as the default notification channel ID
- CallNotificationService.kt creates channels with IDs 'telnyx_call_notification_channel' and 'telnyx_call_ongoing_channel'
- This mismatch caused the warning: 'Notification Channel set in AndroidManifest.xml has not been created by the app. Default value will be used.'

### After changes
- Updated all AndroidManifest.xml files to use 'telnyx_call_notification_channel' as the default notification channel ID
- This matches the channel ID created in CallNotificationService.kt
- The warning should no longer appear when launching sample applications

## ✋ Manual testing
1. Launch any of the sample applications (compose_app, xml_app, or connection_service_app)
2. Check the console/logcat for notification channel warnings
3. Verify that no warning about notification channel not being created appears
4. Test incoming call notifications to ensure they work properly with the correct channel