### PR TITLE
ENGDESK-43202: [Trackimo] - Call Audio Problem - Ice Candidate Collection Change

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
@@ -175,18 +175,14 @@ internal class Peer(
                  Logger.d(tag = "Observer", message = "First ICE candidate processed, completing deferred.")
             }
 
-            Logger.d(tag = "Observer", message = "Event-IceCandidate Generated from server: $candidate")
+            Logger.d(tag = "Observer", message = "Event-IceCandidate Generated: $candidate")
             candidate?.let {
-                if (!it.serverUrl.isNullOrEmpty() && (it.serverUrl == providedStun || it.serverUrl == providedTurn)) {
-                    Logger.d(tag = "Observer", message = "Valid ICE candidate generated from server: ${it.serverUrl}")
-                    if (client.calls[callId]?.getCallState()?.value != CallState.ACTIVE) {
-                        peerConnection?.addIceCandidate(it)
-                        Logger.d(tag = "Observer", message = "ICE candidate added: $it")
-                        onIceCandidateAdd?.invoke(it.serverUrl)
-                        lastCandidateTime = System.currentTimeMillis()
-                    }
-                } else {
-                    Logger.d(tag = "Observer", message = "Ignoring local ICE candidate: $it")
+                Logger.d(tag = "Observer", message = "Processing ICE candidate: ${it.serverUrl}")
+                if (client.calls[callId]?.getCallState()?.value != CallState.ACTIVE) {
+                    peerConnection?.addIceCandidate(it)
+                    Logger.d(tag = "Observer", message = "ICE candidate added: $it")
+                    onIceCandidateAdd?.invoke(it.serverUrl)
+                    lastCandidateTime = System.currentTimeMillis()
                 }
             }
             peerConnectionObserver?.onIceCandidate(candidate)


### PR DESCRIPTION
[ENGDESK-43202 - [Trackimo] - Call Audio Problem - Ice Candidate Collection Change](https://telnyx.atlassian.net/browse/ENGDESK-43202)

---

This PR removes the ICE candidate filtering logic from the onIceCandidate method in Peer.kt to improve the WebRTC signalling process.

## :older_man: :baby: Behaviors
### Before changes
The onIceCandidate method was filtering ICE candidates based on serverUrl, only processing candidates that matched the provided STUN or TURN servers and ignoring local ICE candidates.

### After changes
All ICE candidates are now processed regardless of their serverUrl. This allows both server-generated and local candidates to be handled properly, improving the WebRTC signalling process.

## ✋ Manual testing
1. Test call establishment with the updated ICE candidate handling
2. Verify that both local and server candidates are processed
3. Confirm that call audio quality is improved with proper candidate collection
4. Test various network conditions to ensure robust connectivity