### PR TITLE
[WEBRTC-2904] Implement preferred codec functionality for Android WebRTC SDK

### DIFF
--- a/.llm-repo-instructions
+++ b/.llm-repo-instructions
@@ -34,3 +34,5 @@ Use meaningful variable and function names that make the code self-documenting.
 Never modify ProGuard rules without explicit instruction, as they are critical for WebRTC functionality.
 When adding new public APIs, ensure they are properly documented with KDoc comments.
 Maintain backward compatibility when possible, especially for public SDK interfaces.
+
+Files need to end with a new line!

--- a/samples/connection_service_app/src/main/java/com/telnyx/webrtc/sdk/utility/telecom/call/TelecomCallManager.kt
+++ b/samples/connection_service_app/src/main/java/com/telnyx/webrtc/sdk/utility/telecom/call/TelecomCallManager.kt
@@ -122,12 +122,17 @@ class TelecomCallManager @Inject constructor(
         callerNumber: String,
         destinationNumber: String
     ) {
+        // Example: Get supported codecs and prefer Opus if available
+        val supportedCodecs = telnyxClient.getSupportedAudioCodecs()
+        val preferredCodecs = supportedCodecs.filter { it.mimeType.contains("opus", ignoreCase = true) }
+        
         val newCall = telnyxClient.newInvite(
             callerName,
             callerNumber,
             destinationNumber,
             clientState = "Sample Client State",
-            customHeaders = mapOf("X-test" to "123456")
+            customHeaders = mapOf("X-test" to "123456"),
+            preferredCodecs = preferredCodecs.ifEmpty { null }
         )
         currentCall = newCall
         listenToCallState(newCall)

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxCommon.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxCommon.kt
@@ -3,10 +3,10 @@ package com.telnyx.webrtc.common
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.lifecycle.Observer
-import com.telnyx.webrtc.common.model.AudioCodec
 import com.telnyx.webrtc.common.service.CallForegroundService
 import com.telnyx.webrtc.sdk.Call
 import com.telnyx.webrtc.sdk.TelnyxClient
+import com.telnyx.webrtc.sdk.model.AudioCodec
 import com.telnyx.webrtc.sdk.model.PushMetaData
 import com.telnyx.webrtc.sdk.stats.CallQualityMetrics
 import com.telnyx.webrtc.sdk.stats.ICECandidate

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxCommon.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxCommon.kt
@@ -3,6 +3,7 @@ package com.telnyx.webrtc.common
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.lifecycle.Observer
+import com.telnyx.webrtc.common.model.AudioCodec
 import com.telnyx.webrtc.common.service.CallForegroundService
 import com.telnyx.webrtc.sdk.Call
 import com.telnyx.webrtc.sdk.TelnyxClient
@@ -250,6 +251,17 @@ class TelnyxCommon private constructor() {
                 Timber.d("Set up call quality callback for current call: ${call.callId}")
             }
         }
+    }
+
+    /**
+     * Returns a list of supported audio codecs available on the device.
+     * This is a convenience method that delegates to the TelnyxClient.
+     *
+     * @param context The application context
+     * @return List of [AudioCodec] objects representing the supported audio codecs
+     */
+    fun getSupportedAudioCodecs(context: Context): List<AudioCodec> {
+        return getTelnyxClient(context).getSupportedAudioCodecs()
     }
 
 }

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -17,7 +17,6 @@ import com.telnyx.webrtc.common.domain.call.HoldUnholdCall
 import com.telnyx.webrtc.common.domain.call.OnByeReceived
 import com.telnyx.webrtc.common.domain.call.RejectCall
 import com.telnyx.webrtc.common.domain.call.SendInvite
-import com.telnyx.webrtc.common.model.AudioCodec
 import com.telnyx.webrtc.common.model.Profile
 import com.telnyx.webrtc.sdk.model.Region
 import com.telnyx.webrtc.common.data.CallHistoryRepository
@@ -50,6 +49,7 @@ import com.telnyx.webrtc.sdk.stats.CallQualityMetrics
 import com.telnyx.webrtc.common.model.MetricSummary
 import com.telnyx.webrtc.common.model.PreCallDiagnosis
 import com.telnyx.webrtc.sdk.CredentialConfig
+import com.telnyx.webrtc.sdk.model.AudioCodec
 import com.telnyx.webrtc.sdk.model.SocketError
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -17,6 +17,7 @@ import com.telnyx.webrtc.common.domain.call.HoldUnholdCall
 import com.telnyx.webrtc.common.domain.call.OnByeReceived
 import com.telnyx.webrtc.common.domain.call.RejectCall
 import com.telnyx.webrtc.common.domain.call.SendInvite
+import com.telnyx.webrtc.common.model.AudioCodec
 import com.telnyx.webrtc.common.model.Profile
 import com.telnyx.webrtc.sdk.model.Region
 import com.telnyx.webrtc.common.data.CallHistoryRepository
@@ -832,11 +833,13 @@ class TelnyxViewModel : ViewModel() {
      * @param viewContext The application context.
      * @param destinationNumber The phone number to call.
      * @param debug Whether to enable debug mode for call quality metrics.
+     * @param preferredCodecs Optional list of preferred audio codecs for the call.
      */
     fun sendInvite(
         viewContext: Context,
         destinationNumber: String,
-        debug: Boolean
+        debug: Boolean,
+        preferredCodecs: List<AudioCodec>? = null
     ) {
 
         callStateJob?.cancel()
@@ -852,6 +855,7 @@ class TelnyxViewModel : ViewModel() {
                     "",
                     mapOf(Pair("X-test", "123456")),
                     debug,
+                    preferredCodecs,
                     onCallHistoryAdd = { number ->
                         addCallToHistory(CallType.OUTBOUND, number)
                     }
@@ -864,6 +868,16 @@ class TelnyxViewModel : ViewModel() {
         if (debug) {
             collectAudioLevels()
         }
+    }
+
+    /**
+     * Returns a list of supported audio codecs available on the device.
+     *
+     * @param viewContext The application context.
+     * @return List of [AudioCodec] objects representing the supported audio codecs.
+     */
+    fun getSupportedAudioCodecs(viewContext: Context): List<AudioCodec> {
+        return TelnyxCommon.getInstance().getSupportedAudioCodecs(viewContext)
     }
 
     /**

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/call/SendInvite.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/call/SendInvite.kt
@@ -2,8 +2,8 @@ package com.telnyx.webrtc.common.domain.call
 
 import android.content.Context
 import com.telnyx.webrtc.common.TelnyxCommon
-import com.telnyx.webrtc.common.model.AudioCodec
 import com.telnyx.webrtc.sdk.Call
+import com.telnyx.webrtc.sdk.model.AudioCodec
 import com.telnyx.webrtc.sdk.stats.CallQualityMetrics
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/call/SendInvite.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/call/SendInvite.kt
@@ -2,6 +2,7 @@ package com.telnyx.webrtc.common.domain.call
 
 import android.content.Context
 import com.telnyx.webrtc.common.TelnyxCommon
+import com.telnyx.webrtc.common.model.AudioCodec
 import com.telnyx.webrtc.sdk.Call
 import com.telnyx.webrtc.sdk.stats.CallQualityMetrics
 import kotlinx.coroutines.CoroutineScope
@@ -24,6 +25,7 @@ class SendInvite(private val context: Context) {
      * @param clientState The client state to send the invite.
      * @param customHeaders The custom headers to send the invite.
      * @param debug When true, enables real-time call quality metrics.
+     * @param preferredCodecs Optional list of preferred audio codecs for the call.
      * @param onCallQualityChange Optional callback for receiving real-time call quality metrics.
      * @param onCallHistoryAdd Optional callback for adding call to history.
      * @return The created outgoing call.
@@ -35,13 +37,14 @@ class SendInvite(private val context: Context) {
         clientState: String,
         customHeaders: Map<String, String>? = null,
         debug: Boolean = false,
+        preferredCodecs: List<AudioCodec>? = null,
         onCallQualityChange: ((CallQualityMetrics) -> Unit)? = null,
         onCallHistoryAdd: (suspend (String) -> Unit)? = null
     ): Call {
         val telnyxCommon = TelnyxCommon.getInstance()
         val telnyxClient = telnyxCommon.getTelnyxClient(context)
 
-        val outgoingCall = telnyxClient.newInvite(callerName, callerNumber, destinationNumber, clientState, customHeaders, debug)
+        val outgoingCall = telnyxClient.newInvite(callerName, callerNumber, destinationNumber, clientState, customHeaders, debug, preferredCodecs)
         
         // Set the call quality change callback if provided
         if (debug && onCallQualityChange != null) {

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/model/AudioCodec.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/model/AudioCodec.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2025 Telnyx LLC. All rights reserved.
+ */
+
+package com.telnyx.webrtc.common.model
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Represents an audio codec with its properties.
+ *
+ * @property channels Number of audio channels (e.g., 1 for mono, 2 for stereo)
+ * @property clockRate Sample rate in Hz (e.g., 48000, 8000)
+ * @property mimeType MIME type of the codec (e.g., "audio/opus", "audio/PCMA")
+ * @property sdpFmtpLine SDP format parameters line (optional)
+ */
+data class AudioCodec(
+    val channels: Int,
+    @SerializedName("clockRate")
+    val clockRate: Int,
+    val mimeType: String,
+    val sdpFmtpLine: String? = null
+)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -14,13 +14,13 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonSyntaxException
 import com.telnyx.webrtc.lib.SessionDescription
 import com.telnyx.webrtc.sdk.TelnyxClient.Companion.TIMEOUT_DIVISOR
+import com.telnyx.webrtc.sdk.model.AudioCodec
 import com.telnyx.webrtc.sdk.model.CallState
 import com.telnyx.webrtc.sdk.model.CallNetworkChangeReason
 import com.telnyx.webrtc.sdk.model.SocketMethod
 import com.telnyx.webrtc.sdk.peer.Peer
 import com.telnyx.webrtc.sdk.socket.TxSocket
 import com.telnyx.webrtc.sdk.stats.CallQualityMetrics
-import com.telnyx.webrtc.sdk.stats.ICECandidate
 import com.telnyx.webrtc.sdk.utilities.Logger
 import com.telnyx.webrtc.sdk.utilities.encodeBase64
 import com.telnyx.webrtc.sdk.verto.receive.*
@@ -424,7 +424,7 @@ data class Call(
         destinationNumber: String,
         clientState: String,
         customHeaders: Map<String, String>?,
-        preferredCodecs: List<com.telnyx.webrtc.common.model.AudioCodec>? = null
+        preferredCodecs: List<AudioCodec>? = null
     ) {
         // Ensure peerConnection is initialized for this Call instance before proceeding
         if (peerConnection == null) {
@@ -443,7 +443,8 @@ data class Call(
                     callerNumber,
                     destinationNumber,
                     clientState,
-                    customHeaders
+                    customHeaders,
+                    preferredCodecs
                 )
             }
 
@@ -462,7 +463,8 @@ data class Call(
         callerNumber: String,
         destinationNumber: String,
         clientState: String,
-        customHeaders: Map<String, String>?
+        customHeaders: Map<String, String>?,
+        preferredCodecs: List<AudioCodec>?
     ) {
         resetIceCandidateTimer() // Ensure any previous timer is cancelled
         iceCandidateTimer = Timer("call-${this.callId}-iceTimer") // Name the timer thread

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -423,7 +423,8 @@ data class Call(
         callerNumber: String,
         destinationNumber: String,
         clientState: String,
-        customHeaders: Map<String, String>?
+        customHeaders: Map<String, String>?,
+        preferredCodecs: List<com.telnyx.webrtc.common.model.AudioCodec>? = null
     ) {
         // Ensure peerConnection is initialized for this Call instance before proceeding
         if (peerConnection == null) {
@@ -484,7 +485,8 @@ data class Call(
                                     clientState = clientState.encodeBase64(),
                                     callId = callId, // Use the specific call ID assigned to this Call instance
                                     destinationNumber = destinationNumber,
-                                    customHeaders = customHeaders?.toCustomHeaders() ?: arrayListOf()
+                                    customHeaders = customHeaders?.toCustomHeaders() ?: arrayListOf(),
+                                    preferredCodecs = preferredCodecs
                                 )
                             )
                         )

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -23,7 +23,6 @@ import com.telnyx.webrtc.sdk.TelnyxClient.SpeakerMode.EARPIECE
 import com.telnyx.webrtc.sdk.TelnyxClient.SpeakerMode.SPEAKER
 import com.telnyx.webrtc.sdk.TelnyxClient.SpeakerMode.UNASSIGNED
 import com.telnyx.webrtc.sdk.model.*
-import com.telnyx.webrtc.common.model.AudioCodec
 import com.telnyx.webrtc.sdk.peer.Peer
 import com.telnyx.webrtc.sdk.socket.TxSocket
 import com.telnyx.webrtc.sdk.socket.TxSocketListener
@@ -2356,58 +2355,11 @@ class TelnyxClient(
                     continue
                 }
 
-                val types = codecInfo.supportedTypes
-                for (type in types) {
+                for (type in codecInfo.supportedTypes) {
                     if (type.startsWith("audio/")) {
                         Logger.d(message = "Supported audio codec: ${codecInfo.name}, type: $type")
                         
-                        // Map common codec types to standard formats
-                        val audioCodec = when {
-                            type.contains("opus", ignoreCase = true) -> {
-                                AudioCodec(
-                                    channels = 2,
-                                    clockRate = 48000,
-                                    mimeType = "audio/opus",
-                                    sdpFmtpLine = "minptime=10;useinbandfec=1"
-                                )
-                            }
-                            type.contains("pcma", ignoreCase = true) || type.contains("g711a", ignoreCase = true) -> {
-                                AudioCodec(
-                                    channels = 1,
-                                    clockRate = 8000,
-                                    mimeType = "audio/PCMA"
-                                )
-                            }
-                            type.contains("pcmu", ignoreCase = true) || type.contains("g711u", ignoreCase = true) -> {
-                                AudioCodec(
-                                    channels = 1,
-                                    clockRate = 8000,
-                                    mimeType = "audio/PCMU"
-                                )
-                            }
-                            type.contains("g722", ignoreCase = true) -> {
-                                AudioCodec(
-                                    channels = 1,
-                                    clockRate = 16000,
-                                    mimeType = "audio/G722"
-                                )
-                            }
-                            type.contains("g729", ignoreCase = true) -> {
-                                AudioCodec(
-                                    channels = 1,
-                                    clockRate = 8000,
-                                    mimeType = "audio/G729"
-                                )
-                            }
-                            else -> {
-                                // Generic codec mapping
-                                AudioCodec(
-                                    channels = 1,
-                                    clockRate = 8000,
-                                    mimeType = type
-                                )
-                            }
-                        }
+                        val audioCodec = mapTypeToAudioCodec(type)
                         
                         // Avoid duplicates
                         if (!supportedCodecs.any { it.mimeType == audioCodec.mimeType }) {
@@ -2421,6 +2373,60 @@ class TelnyxClient(
         }
         
         return supportedCodecs
+    }
+
+    /**
+     * Maps a codec type string to an AudioCodec object with appropriate settings.
+     * 
+     * @param type The codec type string (e.g., "audio/opus")
+     * @return AudioCodec object configured for the given type
+     */
+    private fun mapTypeToAudioCodec(type: String): AudioCodec {
+        return when {
+            type.contains("opus", ignoreCase = true) -> {
+                AudioCodec(
+                    channels = 2,
+                    clockRate = 48000,
+                    mimeType = "audio/opus",
+                    sdpFmtpLine = "minptime=10;useinbandfec=1"
+                )
+            }
+            type.contains("pcma", ignoreCase = true) || type.contains("g711a", ignoreCase = true) -> {
+                AudioCodec(
+                    channels = 1,
+                    clockRate = 8000,
+                    mimeType = "audio/PCMA"
+                )
+            }
+            type.contains("pcmu", ignoreCase = true) || type.contains("g711u", ignoreCase = true) -> {
+                AudioCodec(
+                    channels = 1,
+                    clockRate = 8000,
+                    mimeType = "audio/PCMU"
+                )
+            }
+            type.contains("g722", ignoreCase = true) -> {
+                AudioCodec(
+                    channels = 1,
+                    clockRate = 16000,
+                    mimeType = "audio/G722"
+                )
+            }
+            type.contains("g729", ignoreCase = true) -> {
+                AudioCodec(
+                    channels = 1,
+                    clockRate = 8000,
+                    mimeType = "audio/G729"
+                )
+            }
+            else -> {
+                AudioCodec(
+                    channels = 1,
+                    clockRate = 8000,
+                    mimeType = type
+                )
+            }
+        }
     }
 
     /**

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -6,6 +6,7 @@ package com.telnyx.webrtc.sdk
 
 import android.content.Context
 import android.media.AudioManager
+import android.media.MediaCodecList
 import android.media.MediaPlayer
 import android.net.ConnectivityManager
 import android.net.Uri
@@ -22,6 +23,7 @@ import com.telnyx.webrtc.sdk.TelnyxClient.SpeakerMode.EARPIECE
 import com.telnyx.webrtc.sdk.TelnyxClient.SpeakerMode.SPEAKER
 import com.telnyx.webrtc.sdk.TelnyxClient.SpeakerMode.UNASSIGNED
 import com.telnyx.webrtc.sdk.model.*
+import com.telnyx.webrtc.common.model.AudioCodec
 import com.telnyx.webrtc.sdk.peer.Peer
 import com.telnyx.webrtc.sdk.socket.TxSocket
 import com.telnyx.webrtc.sdk.socket.TxSocketListener
@@ -395,6 +397,7 @@ class TelnyxClient(
      * @param clientState Additional state information to pass with the call
      * @param customHeaders Optional custom SIP headers to include with the call
      * @param debug When true, enables real-time call quality metrics
+     * @param preferredCodecs Optional list of preferred audio codecs for the call
      * @return A new [Call] instance representing the outgoing call
      */
     fun newInvite(
@@ -403,7 +406,8 @@ class TelnyxClient(
         destinationNumber: String,
         clientState: String,
         customHeaders: Map<String, String>? = null,
-        debug: Boolean = false
+        debug: Boolean = false,
+        preferredCodecs: List<AudioCodec>? = null
     ): Call {
         var callDebug = debug
         var socketPortalDebug = isSocketDebug
@@ -461,7 +465,8 @@ class TelnyxClient(
                 callerNumber = callerNumber,
                 destinationNumber = destinationNumber,
                 clientState = clientState,
-                customHeaders = customHeaders
+                customHeaders = customHeaders,
+                preferredCodecs = preferredCodecs
             )
 
             client.callOngoing()
@@ -2332,6 +2337,90 @@ class TelnyxClient(
         return credentialSessionConfig?.forceRelayCandidate 
             ?: tokenSessionConfig?.forceRelayCandidate 
             ?: false
+    }
+
+    /**
+     * Returns a list of supported audio codecs available on the device.
+     * This method queries the device's MediaCodecList to find all available audio encoders
+     * and returns them in a format compatible with the preferred_codecs parameter.
+     *
+     * @return List of [AudioCodec] objects representing the supported audio codecs
+     */
+    fun getSupportedAudioCodecs(): List<AudioCodec> {
+        val supportedCodecs = mutableListOf<AudioCodec>()
+        
+        try {
+            val codecList = MediaCodecList(MediaCodecList.ALL_CODECS)
+            for (codecInfo in codecList.codecInfos) {
+                if (!codecInfo.isEncoder) {
+                    continue
+                }
+
+                val types = codecInfo.supportedTypes
+                for (type in types) {
+                    if (type.startsWith("audio/")) {
+                        Logger.d(message = "Supported audio codec: ${codecInfo.name}, type: $type")
+                        
+                        // Map common codec types to standard formats
+                        val audioCodec = when {
+                            type.contains("opus", ignoreCase = true) -> {
+                                AudioCodec(
+                                    channels = 2,
+                                    clockRate = 48000,
+                                    mimeType = "audio/opus",
+                                    sdpFmtpLine = "minptime=10;useinbandfec=1"
+                                )
+                            }
+                            type.contains("pcma", ignoreCase = true) || type.contains("g711a", ignoreCase = true) -> {
+                                AudioCodec(
+                                    channels = 1,
+                                    clockRate = 8000,
+                                    mimeType = "audio/PCMA"
+                                )
+                            }
+                            type.contains("pcmu", ignoreCase = true) || type.contains("g711u", ignoreCase = true) -> {
+                                AudioCodec(
+                                    channels = 1,
+                                    clockRate = 8000,
+                                    mimeType = "audio/PCMU"
+                                )
+                            }
+                            type.contains("g722", ignoreCase = true) -> {
+                                AudioCodec(
+                                    channels = 1,
+                                    clockRate = 16000,
+                                    mimeType = "audio/G722"
+                                )
+                            }
+                            type.contains("g729", ignoreCase = true) -> {
+                                AudioCodec(
+                                    channels = 1,
+                                    clockRate = 8000,
+                                    mimeType = "audio/G729"
+                                )
+                            }
+                            else -> {
+                                // Generic codec mapping
+                                AudioCodec(
+                                    channels = 1,
+                                    clockRate = 8000,
+                                    mimeType = type
+                                )
+                            }
+                        }
+                        
+                        // Avoid duplicates
+                        if (!supportedCodecs.any { it.mimeType == audioCodec.mimeType }) {
+                            supportedCodecs.add(audioCodec)
+                        }
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Logger.e(message = "Error retrieving supported audio codecs: ${e.message}")
+        }
+        
+        return supportedCodecs
     }
 
     /**

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/AudioCodec.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/AudioCodec.kt
@@ -2,8 +2,7 @@
  * Copyright © 2025 Telnyx LLC. All rights reserved.
  */
 
-package com.telnyx.webrtc.common.model
-
+package com.telnyx.webrtc.sdk.model
 import com.google.gson.annotations.SerializedName
 
 /**

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/DialogParams.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/DialogParams.kt
@@ -6,6 +6,7 @@ package com.telnyx.webrtc.sdk.verto.send
 
 import com.google.gson.annotations.SerializedName
 import com.telnyx.webrtc.sdk.CustomHeaders
+import com.telnyx.webrtc.common.model.AudioCodec
 import java.util.*
 import kotlin.collections.ArrayList
 
@@ -34,4 +35,6 @@ data class CallDialogParams(
     val destinationNumber: String = "",
     @SerializedName("custom_headers")
     val customHeaders: ArrayList<CustomHeaders> = arrayListOf(),
+    @SerializedName("preferred_codecs")
+    val preferredCodecs: List<AudioCodec>? = null
     )

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/DialogParams.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/DialogParams.kt
@@ -6,7 +6,7 @@ package com.telnyx.webrtc.sdk.verto.send
 
 import com.google.gson.annotations.SerializedName
 import com.telnyx.webrtc.sdk.CustomHeaders
-import com.telnyx.webrtc.common.model.AudioCodec
+import com.telnyx.webrtc.sdk.model.AudioCodec
 import java.util.*
 import kotlin.collections.ArrayList
 


### PR DESCRIPTION
## Summary

This PR implements preferred codec functionality for the Android WebRTC SDK as requested in [WEBRTC-2904](https://telnyx.atlassian.net/browse/WEBRTC-2904).

## Changes Made

### Core Implementation
- **AudioCodec Data Class**: Added new AudioCodec model in telnyx_common module with fields for channels, clockRate, mimeType, and sdpFmtpLine
- **getSupportedAudioCodecs() Method**: Implemented in TelnyxClient using Android's MediaCodecList to detect device audio codec capabilities
- **CallDialogParams Update**: Added preferredCodecs field with proper JSON serialization support
- **newInvite() Method Enhancement**: Updated method signature to accept optional preferredCodecs parameter

### Integration Updates
- **SendInvite Class**: Updated to support preferred codecs parameter
- **TelnyxCommon**: Added convenience method for getting supported codecs
- **TelnyxViewModel**: Updated sendInvite() method to accept and pass preferred codecs
- **Call.kt**: Modified startOutgoingCallInternal() to handle preferred codecs in dialog parameters

### Documentation
- Added comprehensive KDoc documentation for all new methods and parameters
- Updated method signatures with proper parameter descriptions

## Technical Details

The implementation follows the existing codebase patterns and maintains backward compatibility. The preferredCodecs parameter is optional in all methods, ensuring existing code continues to work without modification.

### Supported Codecs Detection
The getSupportedAudioCodecs() method maps Android's MediaCodec capabilities to standard audio codec formats:
- Opus (audio/opus)
- PCMA (audio/PCMA) 
- PCMU (audio/PCMU)
- G722 (audio/G722)
- G729 (audio/G729)

## Testing

- ✅ Code compiles successfully
- ✅ Detekt checks pass
- ✅ Maintains backward compatibility
- ✅ All existing functionality preserved

## Related Issues

- Jira: [WEBRTC-2904](https://telnyx.atlassian.net/browse/WEBRTC-2904)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] Backward compatibility maintained
- [x] Draft PR created for review

[WEBRTC-2904]: https://telnyx.atlassian.net/browse/WEBRTC-2904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBRTC-2904]: https://telnyx.atlassian.net/browse/WEBRTC-2904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ