### PR TITLE
WEBRTC-2941 Fix: missing caller name on push call

### DIFF
--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/CallScreen.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/CallScreen.kt
@@ -119,9 +119,10 @@ fun CallScreen(telnyxViewModel: TelnyxViewModel) {
     LaunchedEffect(uiState) {
         callUIState = when (uiState) {
             is TelnyxSocketEvent.OnClientReady -> {
-                if (telnyxViewModel.currentCall != null)
+                if (telnyxViewModel.currentCall != null) {
+                    destinationNumber = telnyxViewModel.currentCallCallerName ?: ""
                     CallUIState.ACTIVE
-                else
+                } else
                     CallUIState.IDLE
             }
             is TelnyxSocketEvent.OnIncomingCall -> {

--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/home/HomeCallFragment.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/home/HomeCallFragment.kt
@@ -164,6 +164,9 @@ class HomeCallFragment : Fragment() {
                 when (uiState) {
                     is TelnyxSocketEvent.OnClientReady -> {
                         if (telnyxViewModel.currentCall != null) {
+                            telnyxViewModel.currentCallCallerName?.let {
+                                binding.callInput.setText(it)
+                            }
                             onCallActive()
                             registerObservers() // Register observers when call is answered
                         } else

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -178,6 +178,13 @@ class TelnyxViewModel : ViewModel() {
         get() = TelnyxCommon.getInstance().currentCall
 
     /**
+     * The caller name of the current call, if any.
+     * Returns null if there is no active call.
+     */
+    val currentCallCallerName : String?
+        get() = TelnyxCommon.getInstance().currentCall?.inviteResponse?.callerIdName
+
+    /**
      * State flow for the current user profile.
      * Observe this flow to react to profile changes.
      */


### PR DESCRIPTION
[WebRTC-2941 - Fix: missing caller name on push call](https://telnyx.atlassian.net/browse/WEBRTC-2941)

---
In case of incoming push call, caller name is not visible in 'Sip Number' field, in both sample apps.

Steps to reproduce:
- make incoming push call
- answer the call
- field 'Sip Number' will be empty
