### PR TITLE
WEBRTC-2944 Fix: profile doesn't refresh after update

### DIFF
--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
@@ -640,6 +640,7 @@ fun HomeScreen(
                                             telnyxViewModel.addProfile(context, profile)
                                             editableUserProfile = null
                                         }
+                                        selectedUserProfile = profile
                                         isAddProfile = !isAddProfile
                                     },
                                     onDismiss = {

--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/login/LoginBottomSheetFragment.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/login/LoginBottomSheetFragment.kt
@@ -91,6 +91,12 @@ class LoginBottomSheetFragment : BottomSheetDialogFragment() {
                 forceRelayCandidate = forceRelayCandidate
             )
             telnyxViewModel.addProfile(this@LoginBottomSheetFragment.requireContext(), newProfile)
+            lifecycleScope.launch {
+                telnyxViewModel.profileList.collectLatest { profiles ->
+                    adapter.submitList(profiles) // Submit the updated list to the adapter
+                    adapter.setSelectedProfile(newProfile)
+                }
+            }
             resetFields()
             toggleCredentialLayout(false)
         }


### PR DESCRIPTION
[WebRTC-2944 - [Android] Fix: refresh user profiles list after update](https://telnyx.atlassian.net/browse/WEBRTC-2944)

---
In sample apps, when user will update some profile parameters and then use it to call, old parameters will be still taken during connection.
