### PR TITLE
[WEBRTC-2961]: Android SDK - Ice Trickle Support

### DIFF
--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/LoginBottomSheet.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/LoginBottomSheet.kt
@@ -62,6 +62,7 @@ fun CredentialTokenView(
     var callerIdName by remember { mutableStateOf(profile?.callerIdName ?: "") }
     var callerIdNumber by remember { mutableStateOf(profile?.callerIdNumber ?: "") }
     var forceRelayCandidate by remember { mutableStateOf(profile?.forceRelayCandidate ?: false) }
+    var useTrickleIce by remember { mutableStateOf(profile?.useTrickleIce ?: false) }
 
 
     Column(
@@ -152,6 +153,24 @@ fun CredentialTokenView(
             )
         }
 
+        // Trickle ICE Switch
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = Dimens.spacing8dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Use Trickle ICE",
+                fontWeight = FontWeight.Medium
+            )
+            Switch(
+                checked = useTrickleIce,
+                onCheckedChange = { useTrickleIce = it }
+            )
+        }
+
         Spacer(modifier = Modifier.height(Dimens.spacing8dp))
 
         Box(modifier = Modifier.fillMaxWidth()) {
@@ -173,7 +192,8 @@ fun CredentialTokenView(
                                 callerIdName = callerIdName.trim(),
                                 callerIdNumber = callerIdNumber.trim(),
                                 isUserLoggedIn = true,
-                                forceRelayCandidate = forceRelayCandidate
+                                forceRelayCandidate = forceRelayCandidate,
+                                useTrickleIce = useTrickleIce
                             ),
                         )
                     } else {
@@ -188,7 +208,8 @@ fun CredentialTokenView(
                                 callerIdName = callerIdName.trim(),
                                 callerIdNumber = callerIdNumber.trim(),
                                 isUserLoggedIn = true,
-                                forceRelayCandidate = forceRelayCandidate
+                                forceRelayCandidate = forceRelayCandidate,
+                                useTrickleIce = useTrickleIce
                             )
                         )
                     }

--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/login/LoginBottomSheetFragment.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/login/LoginBottomSheetFragment.kt
@@ -79,6 +79,7 @@ class LoginBottomSheetFragment : BottomSheetDialogFragment() {
             val sipCallerIdName = callerIdNameTextField.text.toString()
             val sipCallerIdNumber = callerIdNumberTextField.text.toString()
             val forceRelayCandidate = forceRelaySwitch.isChecked
+            val useTrickleIce = trickleIceSwitch.isChecked
 
             if (!validateProfile()) return
 
@@ -88,7 +89,8 @@ class LoginBottomSheetFragment : BottomSheetDialogFragment() {
                 sipPass = sipPass,
                 callerIdName = sipCallerIdName,
                 callerIdNumber = sipCallerIdNumber,
-                forceRelayCandidate = forceRelayCandidate
+                forceRelayCandidate = forceRelayCandidate,
+                useTrickleIce = useTrickleIce
             )
             telnyxViewModel.addProfile(this@LoginBottomSheetFragment.requireContext(), newProfile)
             lifecycleScope.launch {
@@ -156,6 +158,7 @@ class LoginBottomSheetFragment : BottomSheetDialogFragment() {
                         callerIdNameTextField.setText(profile.callerIdName)
                         callerIdNumberTextField.setText(profile.callerIdNumber)
                         forceRelaySwitch.isChecked = profile.forceRelayCandidate
+                        trickleIceSwitch.isChecked = profile.useTrickleIce
                     }
                 }
                 ProfileAction.SELECT_PROFILE -> {

--- a/samples/xml_app/src/main/res/layout/credentials_layout.xml
+++ b/samples/xml_app/src/main/res/layout/credentials_layout.xml
@@ -251,6 +251,32 @@
 
         </LinearLayout>
 
+        <LinearLayout
+            android:id="@+id/trickleIceLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginTop="@dimen/spacing_normal"
+            android:gravity="center_vertical"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/forceRelayLayout">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Use Trickle ICE"
+                android:textSize="14sp"
+                android:textColor="@color/black" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/trickleIceSwitch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="false" />
+
+        </LinearLayout>
+
         <Button
             android:id="@+id/confirmButton"
             android:layout_width="wrap_content"
@@ -262,7 +288,7 @@
             android:textStyle="bold"
             style="@style/CustomPrimaryButton"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/forceRelayLayout"
+            app:layout_constraintTop_toBottomOf="@+id/trickleIceLayout"
             />
 
         <Button
@@ -276,7 +302,7 @@
             android:textSize="12sp"
             style="@style/CustomOutlinedButton"
             app:layout_constraintStart_toEndOf="@+id/confirmButton"
-            app:layout_constraintTop_toBottomOf="@+id/forceRelayLayout" />
+            app:layout_constraintTop_toBottomOf="@+id/trickleIceLayout" />
 
         <View
             android:layout_width="match_parent"

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/model/Profile.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/model/Profile.kt
@@ -17,6 +17,7 @@ import com.telnyx.webrtc.sdk.model.Region
  * When this option is on it allows the SDK to collect WebRTC debug information.
  * That information is stored in the Telnyx customer portal
  * @param forceRelayCandidate True to force TURN relay for peer connections to prevent local network access permission popup.
+ * @param useTrickleIce True to enable trickle ICE for faster call establishment, false otherwise.
  */
 data class Profile(
     val sipUsername: String? = null,
@@ -28,7 +29,8 @@ data class Profile(
     var isDev: Boolean = false,
     var fcmToken: String? = null,
     var region: Region = Region.AUTO,
-    var forceRelayCandidate: Boolean = false
+    var forceRelayCandidate: Boolean = false,
+    var useTrickleIce: Boolean = false
 ) {
     fun isToken(): Boolean {
         return sipToken?.trim()?.isNotEmpty() ?: false

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/util/Utils.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/util/Utils.kt
@@ -20,7 +20,8 @@ fun Profile.toCredentialConfig(fcmToken: String, isDebug: Boolean = false): Cred
         ringBackTone = R.raw.ringback_tone,
         autoReconnect = true,
         region = this.region,
-        forceRelayCandidate = this.forceRelayCandidate
+        forceRelayCandidate = this.forceRelayCandidate,
+        useTrickleIce = this.useTrickleIce
     )
 }
 
@@ -37,6 +38,7 @@ fun Profile.toTokenConfig(fcmToken: String, isDebug: Boolean = false): TokenConf
         ringBackTone = R.raw.ringback_tone,
         autoReconnect = true,
         region = this.region,
-        forceRelayCandidate = this.forceRelayCandidate
+        forceRelayCandidate = this.forceRelayCandidate,
+        useTrickleIce = this.useTrickleIce
     )
 }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxConfig.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxConfig.kt
@@ -39,6 +39,7 @@ sealed class TelnyxConfig
  * @property region the region to use for the connection
  * @property fallbackOnRegionFailure whether or not connect to default region if the select region is not reachable
  * @property forceRelayCandidate whether to force TURN relay for peer connections. Note that this may cause issues with some networks that do not allow TURN connections. Enabling this may affect the quality of calls when devices are on the same local network, as all media will be relayed through TURN servers.
+ * @property useTrickleIce whether to use trickle ICE for peer connections. When enabled, ICE candidates are sent individually as they are discovered rather than waiting for all candidates to be gathered before sending the offer/answer.
  */
 data class CredentialConfig(
     val sipUser: String,
@@ -55,7 +56,8 @@ data class CredentialConfig(
     val reconnectionTimeout: Long = 60000,
     val region: Region = Region.AUTO,
     val fallbackOnRegionFailure: Boolean = true,
-    val forceRelayCandidate: Boolean = false
+    val forceRelayCandidate: Boolean = false,
+    val useTrickleIce: Boolean = false
 ) : TelnyxConfig() {
     companion object {
         const val DEFAULT_DEBUG = false
@@ -79,6 +81,7 @@ data class CredentialConfig(
  * @property region the region to use for the connection
  * @property fallbackOnRegionFailure whether or not connect to default region if the select region is not reachable
  * @property forceRelayCandidate whether to force TURN relay for peer connections. Note that this may cause issues with some networks that do not allow TURN connections. Enabling this may affect the quality of calls when devices are on the same local network, as all media will be relayed through TURN servers.
+ * @property useTrickleIce whether to use trickle ICE for peer connections. When enabled, ICE candidates are sent individually as they are discovered rather than waiting for all candidates to be gathered before sending the offer/answer.
  */
 data class TokenConfig(
     val sipToken: String,
@@ -94,7 +97,8 @@ data class TokenConfig(
     val reconnectionTimeout: Long = 60000,
     val region: Region = Region.AUTO,
     val fallbackOnRegionFailure: Boolean = true,
-    val forceRelayCandidate: Boolean = false
+    val forceRelayCandidate: Boolean = false,
+    val useTrickleIce: Boolean = false
 ) : TelnyxConfig() {
     companion object {
         const val DEFAULT_DEBUG = false

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SocketMethod.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SocketMethod.kt
@@ -33,6 +33,8 @@ enum class SocketMethod(var methodName: String) {
     GATEWAY_STATE("telnyx_rtc.gatewayState"),
     DISABLE_PUSH("telnyx_rtc.disable_push_notification"),
     ATTACH_CALL("telnyx_rtc.attachCalls"),
+    CANDIDATE("telnyx_rtc.candidate"),
+    END_OF_CANDIDATES("telnyx_rtc.endOfCandidates"),
     LOGIN("login"),
     ANONYMOUS_LOGIN("anonymous_login"),
     AI_CONVERSATION("ai_conversation")

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -219,6 +219,12 @@ class TxSocket(
                                 AI_CONVERSATION.methodName -> {
                                     listener.onAiConversationReceived(jsonObject)
                                 }
+                                CANDIDATE.methodName -> {
+                                    listener.onCandidateReceived(jsonObject)
+                                }
+                                END_OF_CANDIDATES.methodName -> {
+                                    listener.onEndOfCandidatesReceived(jsonObject)
+                                }
                                 PINGPONG.methodName -> {
                                     isPing = true
                                     webSocket.send(text)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocketListener.kt
@@ -119,4 +119,18 @@ interface TxSocketListener {
      * @see [TxSocket]
      */
     fun onAiConversationReceived(jsonObject: JsonObject)
+
+    /**
+     * Fires when an ICE candidate is received via trickle ICE
+     * @param jsonObject, the socket response in a jsonObject format
+     * @see [TxSocket]
+     */
+    fun onCandidateReceived(jsonObject: JsonObject)
+
+    /**
+     * Fires when end-of-candidates is received via trickle ICE
+     * @param jsonObject, the socket response in a jsonObject format
+     * @see [TxSocket]
+     */
+    fun onEndOfCandidatesReceived(jsonObject: JsonObject)
 }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/ParamRequest.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/ParamRequest.kt
@@ -112,3 +112,16 @@ data class InfoParams(
 ) : ParamRequest()
 
 data class StateParams(val state: String?) : ParamRequest()
+
+data class CandidateParams(
+    val sessid: String,
+    val candidate: String,
+    val sdpMid: String?,
+    val sdpMLineIndex: Int,
+    val dialogParams: CallDialogParams
+) : ParamRequest()
+
+data class EndOfCandidatesParams(
+    val sessid: String,
+    val dialogParams: CallDialogParams
+) : ParamRequest()


### PR DESCRIPTION
## Summary

This PR implements trickle ICE support for the Android WebRTC SDK as requested in WEBRTC-2961.

## Changes Made

### Core Implementation
- **TelnyxConfig**: Added  parameter to both  and  (defaulted to )
- **SocketMethods**: Added new socket methods for  and 
- **Peer.kt**: Modified signaling process to support trickle ICE:
  - Send ICE candidates via signaling when trickle ICE is enabled
  - Add candidates locally when trickle ICE is disabled
  - Send end-of-candidates signal when ICE gathering completes
- **TelnyxClient.kt**: Updated with trickle ICE configuration and message handling
- **ParamRequest.kt**: Added  and  classes for ICE candidate signaling
- **TxSocket.kt**: Added handling for  and  socket methods
- **TxSocketListener.kt**: Added  and  interface methods

### Common Module Updates
- **Profile.kt**: Added  parameter to Profile model
- **Utils.kt**: Updated Profile to TelnyxConfig conversion functions to include trickle ICE parameter

### Sample App Updates
- **compose_app**: Added trickle ICE checkbox to LoginBottomSheet.kt
- **xml_app**: Added trickle ICE switch to credentials_layout.xml and LoginBottomSheetFragment.kt
- Both sample apps now allow users to toggle trickle ICE on/off during login configuration

## Technical Details

When trickle ICE is enabled:
1. ICE candidates are sent via signaling as they are discovered using  messages
2. An  message is sent when ICE gathering completes
3. This allows for faster call establishment by starting the connection process before all candidates are gathered

When trickle ICE is disabled (default):
1. ICE candidates are added locally to the peer connection
2. Traditional ICE gathering behavior is maintained for backward compatibility

## Testing

- ✅ Core trickle ICE implementation complete
- ✅ Socket message handling implemented
- ✅ Sample apps updated with UI controls
- ✅ Backward compatibility maintained (default: disabled)

## Related

- Jira Ticket: [WEBRTC-2961](https://telnyx.atlassian.net/browse/WEBRTC-2961)
- Implements trickle ICE support as requested in the ticket requirements