### PR TITLE
[WEBRTC-2954] - Connection State Exposure Enhancement

### DIFF
--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/MainActivity.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/MainActivity.kt
@@ -38,6 +38,7 @@ import com.telnyx.webrtc.common.model.Profile
 import com.telnyx.webrtc.common.notification.MyFirebaseMessagingService
 import com.telnyx.webrtc.common.notification.LegacyCallNotificationService
 import com.telnyx.webrtc.sdk.TelnyxClient
+import com.telnyx.webrtc.sdk.model.ConnectionStatus
 import kotlinx.coroutines.launch
 import org.telnyx.webrtc.xmlapp.BuildConfig
 import org.telnyx.webrtc.xmlapp.R
@@ -361,6 +362,13 @@ class MainActivity : AppCompatActivity(), DefaultLifecycleObserver {
             }
         }
 
+        // Listen for connection status changes
+        lifecycleScope.launch {
+            telnyxViewModel.connectionStatus?.collect { connectionStatus ->
+                updateConnectionStatus(connectionStatus)
+            }
+        }
+
         // Listen for call state changes:
         lifecycleScope.launch {
             telnyxViewModel.uiState.collect { uiState ->
@@ -403,6 +411,19 @@ class MainActivity : AppCompatActivity(), DefaultLifecycleObserver {
         }
         binding.callStateIcon.setBackgroundResource(iconDrawable)
         binding.callStateInfo.text = callStateName
+    }
+
+    private fun updateConnectionStatus(connectionStatus: ConnectionStatus) {
+        val statusText = when (connectionStatus) {
+            ConnectionStatus.DISCONNECTED -> getString(R.string.disconnected)
+            ConnectionStatus.CONNECTED -> getString(R.string.connected)
+            ConnectionStatus.RECONNECTING -> "Reconnecting"
+            ConnectionStatus.CLIENT_READY -> getString(R.string.client_ready)
+        }
+        
+        val isConnected = connectionStatus != ConnectionStatus.DISCONNECTED
+        binding.socketStatusIcon.isEnabled = isConnected
+        binding.socketStatusInfo.text = statusText
     }
 
     fun highlightButton(button: MaterialButton) {

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -237,6 +237,12 @@ class TelnyxViewModel : ViewModel() {
     val transcriptMessages: SharedFlow<List<TranscriptItem>>?
         get() = TelnyxCommon.getInstance().telnyxClient?.transcriptUpdateFlow
 
+    /**
+     * Shared flow for connection status from TelnyxClient.
+     * Observe this flow to display connection state in the UI.
+     */
+    val connectionStatus: SharedFlow<com.telnyx.webrtc.sdk.model.ConnectionStatus>?
+        get() = TelnyxCommon.getInstance().telnyxClient?.connectionStatusFlow
 
     /**
      * Job for collecting audio levels.

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/ConnectionStatus.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/ConnectionStatus.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2021 Telnyx LLC. All rights reserved.
+ */
+
+package com.telnyx.webrtc.sdk.model
+
+/**
+ * Represents the different connection states of the Telnyx client
+ */
+enum class ConnectionStatus {
+    /**
+     * Client is disconnected from the server
+     */
+    DISCONNECTED,
+
+    /**
+     * Client is connected to the server but not registered
+     */
+    CONNECTED,
+
+    /**
+     * Client is attempting to reconnect to the server
+     */
+    RECONNECTING,
+
+    /**
+     * Client is connected and registered, ready to make calls
+     */
+    CLIENT_READY
+}


### PR DESCRIPTION
## Summary

This PR implements the Android Connection State Exposure Enhancement as requested in WEBRTC-2954. It adds a new `connectionStatusFlow` to the TelnyxClient that exposes four distinct connection states to help developers better understand and react to connection state changes.

## Changes Made

### Core Implementation
- **ConnectionStatus.kt**: New enum with four states:
  - `DISCONNECTED`: Initial state and when disconnected
  - `CONNECTED`: When WebSocket connection is established
  - `RECONNECTING`: During reconnection attempts
  - `CLIENT_READY`: When gateway is registered and client is fully ready

- **TelnyxClient.kt**: Added `connectionStatusFlow` SharedFlow with state transitions at key connection points:
  - Initialization → DISCONNECTED
  - Connection established → CONNECTED
  - Gateway registered → CLIENT_READY
  - Reconnection attempts → RECONNECTING
  - Disconnection → DISCONNECTED

- **TelnyxViewModel.kt**: Exposed `connectionStatus` flow for UI consumption

### Sample App Updates
- **Compose App**: Enhanced ConnectionState component to display all four states with color-coded indicators:
  - 🟢 Green for CONNECTED and CLIENT_READY
  - 🟡 Yellow for RECONNECTING
  - 🔴 Red for DISCONNECTED

- **XML App**: Added connection status collection and UI updates in MainActivity

## Implementation Details

The implementation follows the existing TelnyxViewModel `_sessionState` pattern and is based on the Flutter SDK changes. The `connectionStatusFlow` uses `MutableSharedFlow` with replay=1 and extraBufferCapacity=64 to ensure reliable state delivery.

State transitions are strategically placed at:
- `init` block
- `onConnectionEstablished()`
- `onGatewayStateReceived()` (when registered)
- `reconnectToSocket()`
- `onDisconnect()`

## Testing

Both sample applications demonstrate the new functionality:
- Real-time connection status updates
- Visual indicators for each state
- Backward compatibility with existing session state handling

## Related

- Jira: WEBRTC-2954
- Based on Flutter SDK connection status implementation
- Maintains compatibility with existing TelnyxSessionState usage