### PR TITLE
[WEBRTC-3038] - Reactive Circus UI tests fallback mechanism

### DIFF
--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -80,16 +80,25 @@ jobs:
           echo "compose_status=success" >> $GITHUB_OUTPUT
 
       # Reactive Circus fallback mechanism - runs only when both Firebase tests fail
+      - name: Enable KVM group perms (Reactive Circus)
+        if: always() && steps.xml_tests.outcome == 'failure' && steps.compose_tests.outcome == 'failure'
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Run XML App Tests with Reactive Circus (Fallback)
         id: xml_fallback_tests
         if: always() && steps.xml_tests.outcome == 'failure' && steps.compose_tests.outcome == 'failure'
         continue-on-error: true
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 29
-          target: default
+          api-level: 34
+          target: google_apis
           arch: x86_64
-          profile: Nexus 6
+          profile: pixel_6
+          disable-animations: true
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: |
             echo "Running XML app instrumentation tests as fallback..."
             ./gradlew :samples:xml_app:connectedDebugAndroidTest --stacktrace
@@ -106,10 +115,12 @@ jobs:
         continue-on-error: true
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 29
-          target: default
+          api-level: 34
+          target: google_apis
           arch: x86_64
-          profile: Nexus 6
+          profile: pixel_6
+          disable-animations: true
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: |
             echo "Running Compose app instrumentation tests as fallback..."
             ./gradlew :samples:compose_app:connectedDebugAndroidTest --stacktrace


### PR DESCRIPTION
[WEBRTC-3038 - Reactive Circus UI tests fallback mechanism](https://telnyx.atlassian.net/browse/WEBRTC-3038)

---

This PR implements a fallback mechanism for UI tests using Reactive Circus when Firebase Test Lab fails. The fallback runs directly on the Linux runner using an Android emulator to ensure test reliability.

## :older_man: :baby: Behaviors
### Before changes
- UI tests only ran on Firebase Test Lab
- If Firebase tests failed, the entire workflow would fail
- No fallback mechanism for test execution

### After changes
- Firebase Test Lab remains the primary testing method
- When both Firebase test suites fail, Reactive Circus fallback is triggered
- Fallback runs instrumentation tests using android-emulator-runner on API 29
- Proper environment variable configuration for test credentials
- Enhanced result checking logic considers both Firebase and fallback outcomes

## ✋ Manual testing
1. Trigger the UI tests workflow
2. Verify Firebase tests run first as expected
3. In case of Firebase failures, confirm fallback mechanism activates
4. Validate that fallback tests run with proper emulator configuration
5. Check that final workflow status reflects combined results from both test methods

**Key Features:**
- ✅ Maintains existing Firebase test behavior
- ✅ Only runs fallback when both Firebase suites fail
- ✅ Uses same test credentials and configuration
- ✅ Proper error handling and result aggregation
- ✅ Clear logging for debugging test execution paths