### PR TITLE
WEBRTC-3089 Use close instead of cancel to prevent onError callback

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -384,7 +384,7 @@ class TxSocket(
         cleanPingIntervals()
 
         if (this::webSocket.isInitialized) {
-            webSocket.close(1000, "Websocket connection closed")
+            webSocket.close(WEBSOCKET_NORMAL_CLOSURE, "Websocket connection closed")
         }
         job.cancel("Socket was destroyed, cancelling attached job")
     }
@@ -490,6 +490,9 @@ class TxSocket(
 
     companion object {
         const val STATE_ATTACHED = "ATTACHED"
+
+        // WebSocket constants
+        private const val WEBSOCKET_NORMAL_CLOSURE = 1000
 
         // Ping tracking constants
         private const val MAX_PING_HISTORY_SIZE_VALUE = 30


### PR DESCRIPTION
[WEBRTC-3089 - Use close instead of cancel to prevent onError callback.](https://telnyx.atlassian.net/browse/WEBRTC-3089)

---
<!-- Describe your changes here -->

## :older_man: :baby: Behaviors
### Before changes
Use webSocket.cancel() which terminates the socket connection "violently"

### After changes
Use webSocket.close() which prevents an error message from being emitted

## ✋ Manual testing
1. Launch app
2. Connect and disconnect repeatedly, notice there is no error emitted

