### PR TITLE
[WEBRTC-3137] - Fix profile creation screen to show dynamic environment text

### DIFF
--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/HomeScreen.kt
@@ -663,7 +663,12 @@ fun HomeScreen(
                         isAddProfile = !isAddProfile
                     }
 
-                    RegularText(stringResource(R.string.production_label))
+                    val environmentLabel = if (telnyxViewModel.serverConfigurationIsDev) {
+                        stringResource(R.string.development_label)
+                    } else {
+                        stringResource(R.string.production_label)
+                    }
+                    RegularText(environmentLabel)
 
                     val credentialConfigList by telnyxViewModel.profileList.collectAsState()
 

--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/login/LoginBottomSheetFragment.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/login/LoginBottomSheetFragment.kt
@@ -76,6 +76,16 @@ class LoginBottomSheetFragment : BottomSheetDialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         setupRecyclerView()
         setupListeners()
+        updateEnvironmentLabel()
+    }
+
+    private fun updateEnvironmentLabel() {
+        val environmentLabel = if (telnyxViewModel.serverConfigurationIsDev) {
+            getString(R.string.development_label)
+        } else {
+            getString(R.string.production_label)
+        }
+        binding.productionText.text = environmentLabel
     }
 
 


### PR DESCRIPTION
[WEBRTC-3137 - [Android] Profile creation screen shows 'production' text regardless of environment](https://telnyx.atlassian.net/browse/WEBRTC-3137)

---
This PR fixes a UI bug where the profile creation screen was showing 'production' text regardless of the selected environment.

## :older_man: :baby: Behaviors
### Before changes
The profile creation screen in both xml_app and compose_app displayed a static 'production' label regardless of whether the user had selected the development or production environment.

### After changes
The profile creation screen now dynamically displays the correct environment label ('development' or 'production') based on the `serverConfigurationIsDev` flag from the TelnyxViewModel.

## ✋ Manual testing
1. Open the app and switch to the development environment
2. Navigate to the profile creation screen (Add new profile)
3. Verify that the environment label shows 'development'
4. Switch to production environment
5. Navigate to the profile creation screen again
6. Verify that the environment label shows 'production'

## Changes
- **xml_app**: Added `updateEnvironmentLabel()` method in `LoginBottomSheetFragment.kt` to dynamically set the environment text
- **compose_app**: Updated `HomeScreen.kt` to use dynamic environment label based on `serverConfigurationIsDev`