### PR TITLE
[WEBRTC-3147] - Add answered_device_token parameter for push notification call answering

### DIFF
--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/call/AcceptCall.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/call/AcceptCall.kt
@@ -27,6 +27,7 @@ class AcceptCall(private val context: Context) {
      * @param useTrickleIce When true, enables trickle ICE for faster call setup.
      * @param audioConstraints Optional audio processing constraints for the call.
      * @param mutedMicOnStart When true, starts the call with the microphone muted.
+     * @param answeredDeviceToken Optional device token to identify which device answered a push call.
      * @param onCallQualityChange Optional callback for receiving real-time call quality metrics.
      * @param onCallHistoryAdd Optional callback for adding call to history.
      * @return The accepted incoming call.
@@ -39,11 +40,12 @@ class AcceptCall(private val context: Context) {
         useTrickleIce: Boolean = false,
         audioConstraints: AudioConstraints? = null,
         mutedMicOnStart: Boolean = false,
+        answeredDeviceToken: String? = null,
         onCallQualityChange: ((CallQualityMetrics) -> Unit)? = null,
         onCallHistoryAdd: (suspend (String) -> Unit)? = null
     ): Call {
         val telnyxCommon = TelnyxCommon.getInstance()
-        val incomingCall = telnyxCommon.getTelnyxClient(context).acceptCall(callId, callerIdNumber, customHeaders, debug, useTrickleIce, audioConstraints, mutedMicOnStart)
+        val incomingCall = telnyxCommon.getTelnyxClient(context).acceptCall(callId, callerIdNumber, customHeaders, debug, useTrickleIce, audioConstraints, mutedMicOnStart, answeredDeviceToken)
         
         // Set the call quality change callback if provided
         if (debug && onCallQualityChange != null) {

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/AnswerIncomingPushCall.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/AnswerIncomingPushCall.kt
@@ -40,6 +40,9 @@ class AnswerIncomingPushCall(private val context: Context) {
     // Indicates whether trickle ICE should be enabled for the call.
     private var useTrickleIce: Boolean = false
 
+    // The FCM token to identify which device answered the push call.
+    private var fcmToken: String? = null
+
     // Observer for incoming call responses.
     private val incomingCallObserver = Observer<SocketResponse<ReceivedMessageBody>> { response ->
         handleSocketResponse(response)
@@ -74,13 +77,14 @@ class AnswerIncomingPushCall(private val context: Context) {
         val socketFlow = telnyxClient.socketResponseFlow
 
         ProfileManager.getProfilesList(context).lastOrNull()?.let { lastProfile ->
-            val fcmToken = lastProfile.fcmToken ?: ""
+            val token = lastProfile.fcmToken ?: ""
+            this.fcmToken = token
 
             // Use TokenConfig when sipToken is not null, otherwise use CredentialConfig
             if (!lastProfile.sipToken.isNullOrEmpty()) {
                 telnyxClient.connect(
                     TxServerConfiguration(),
-                    lastProfile.toTokenConfig(fcmToken),
+                    lastProfile.toTokenConfig(token),
                     txPushMetaData,
                     true
                 )
@@ -88,7 +92,7 @@ class AnswerIncomingPushCall(private val context: Context) {
 
                 telnyxClient.connect(
                     TxServerConfiguration(),
-                    lastProfile.toCredentialConfig(fcmToken),
+                    lastProfile.toCredentialConfig(token),
                     txPushMetaData,
                     true
                 )
@@ -132,13 +136,14 @@ class AnswerIncomingPushCall(private val context: Context) {
 
         val telnyxClient = TelnyxCommon.getInstance().getTelnyxClient(context)
         ProfileManager.getProfilesList(context).lastOrNull()?.let { lastProfile ->
-            val fcmToken = lastProfile.fcmToken ?: ""
+            val token = lastProfile.fcmToken ?: ""
+            this.fcmToken = token
 
             // Use TokenConfig when sipToken is not null, otherwise use CredentialConfig
             if (!lastProfile.sipToken.isNullOrEmpty()) {
                 telnyxClient.connect(
                     TxServerConfiguration(),
-                    lastProfile.toTokenConfig(fcmToken),
+                    lastProfile.toTokenConfig(token),
                     txPushMetaData,
                     true
                 )
@@ -146,7 +151,7 @@ class AnswerIncomingPushCall(private val context: Context) {
 
                 telnyxClient.connect(
                     TxServerConfiguration(),
-                    lastProfile.toCredentialConfig(fcmToken),
+                    lastProfile.toCredentialConfig(token),
                     txPushMetaData,
                     true
                 )
@@ -174,6 +179,7 @@ class AnswerIncomingPushCall(private val context: Context) {
                         debug,
                         useTrickleIce,
                         audioConstraints = null,  // Use defaults for push calls
+                        answeredDeviceToken = fcmToken,
                         onCallQualityChange = onCallQualityChange
                     )
                     cleanUp(answeredCall)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -379,7 +379,8 @@ class TelnyxClient(
         debug: Boolean = false,
         useTrickleIce: Boolean = false,
         audioConstraints: AudioConstraints? = null,
-        mutedMicOnStart: Boolean = false
+        mutedMicOnStart: Boolean = false,
+        answeredDeviceToken: String? = null
     ): Call {
         val callDebug = debug
         val socketPortalDebug = isSocketDebug
@@ -447,6 +448,7 @@ class TelnyxClient(
                         CallParams(
                             sessid = sessionId,
                             sdp = finalAnswerSdp,
+                            answeredDeviceToken = answeredDeviceToken,
                             dialogParams = CallDialogParams(
                                 callId = callId,
                                 destinationNumber = destinationNumber,
@@ -546,6 +548,7 @@ class TelnyxClient(
                                     CallParams(
                                         sessid = sessionId,
                                         sdp = finalAnswerSdp,
+                                        answeredDeviceToken = answeredDeviceToken,
                                         dialogParams = CallDialogParams(
                                             callId = callId,
                                             destinationNumber = destinationNumber,

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/ParamRequest.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/ParamRequest.kt
@@ -54,6 +54,8 @@ data class CallParams(
     val sdp: String,
     @SerializedName("User-Agent")
     val userAgent: String = "Android-" + BuildConfig.SDK_VERSION,
+    @SerializedName("answered_device_token")
+    val answeredDeviceToken: String? = null,
     val dialogParams: CallDialogParams,
     val trickle: Boolean? = null
 ) : ParamRequest()


### PR DESCRIPTION
## Summary
This PR adds an optional `answered_device_token` parameter to the call answering flow, allowing the backend to identify which device answered a push notification call.

## Jira Ticket
[WEBRTC-3147](https://telnyx.atlassian.net/browse/WEBRTC-3147)

## Changes
- **DialogParams.kt**: Added `answered_device_token` field to `CallDialogParams` data class with `@SerializedName` annotation
- **TelnyxClient.kt**: Updated `acceptCall()` method to accept and pass the optional `answeredDeviceToken` parameter
- **AcceptCall.kt**: Updated wrapper class to propagate the `answeredDeviceToken` parameter
- **AnswerIncomingPushCall.kt**: Modified to automatically pass the FCM token as `answered_device_token` when answering push notification calls

## Implementation Details
- The `answered_device_token` parameter is optional (nullable) and only included in the answer message when provided
- For push notification calls, the FCM token is automatically extracted from the profile and passed as the device token
- For regular calls (not from push notifications), the parameter can be omitted or set to null

## Testing
- Detekt checks passed
- The parameter is only serialized when non-null, maintaining backward compatibility

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated (KDoc comments added)
- [x] Detekt checks passed

[WEBRTC-3147]: https://telnyx.atlassian.net/browse/WEBRTC-3147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ