### PR TITLE
WEBRTC-3143: Fixing Developer Doc Github MD file issues

### DIFF
--- a/docs-markdown/classes/TelnyxClient.md
+++ b/docs-markdown/classes/TelnyxClient.md
@@ -125,7 +125,7 @@ NOTE:
 Remember to add and handle INTERNET, RECORD_AUDIO and ACCESS_NETWORK_STATE permissions
 
    <p align="center">
-               <img align="center" src="https://user-images.githubusercontent.com/9112652/117322479-f4731c00-ae85-11eb-9259-6333fc20b629.png">
+               <img align="center" src="https://user-images.githubusercontent.com/9112652/117322479-f4731c00-ae85-11eb-9259-6333fc20b629.png" />
             </p>
 
 ### Initialize


### PR DESCRIPTION
[WebRTC-3143 - Fixing Developer Doc Github MD file issues](https://telnyx.atlassian.net/browse/WEBRTC-3143)

Fix MDX syntax in TelnyxClient.md for Mintlify compatibility

Fixed invalid MDX syntax that prevented Mintlify from parsing the documentation correctly.

Changes

- Made <img> tag self-closing in docs-markdown/classes/TelnyxClient.md (line 128)
- Changed <img ... > to <img ... /> to comply with MDX/JSX syntax requirements

