### PR TITLE
[WEBRTC-3147] Add answered_device_token parameter (conflicts resolved)

### DIFF
--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/call/AcceptCall.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/call/AcceptCall.kt
@@ -27,6 +27,7 @@ class AcceptCall(private val context: Context) {
      * @param useTrickleIce When true, enables trickle ICE for faster call setup.
      * @param audioConstraints Optional audio processing constraints for the call.
      * @param mutedMicOnStart When true, starts the call with the microphone muted.
+     * @param answeredDeviceToken Optional device token to identify which device answered a push call.
      * @param onCallQualityChange Optional callback for receiving real-time call quality metrics.
      * @param onCallHistoryAdd Optional callback for adding call to history.
      * @return The accepted incoming call.
@@ -39,11 +40,12 @@ class AcceptCall(private val context: Context) {
         useTrickleIce: Boolean = false,
         audioConstraints: AudioConstraints? = null,
         mutedMicOnStart: Boolean = false,
+        answeredDeviceToken: String? = null,
         onCallQualityChange: ((CallQualityMetrics) -> Unit)? = null,
         onCallHistoryAdd: (suspend (String) -> Unit)? = null
     ): Call {
         val telnyxCommon = TelnyxCommon.getInstance()
-        val incomingCall = telnyxCommon.getTelnyxClient(context).acceptCall(callId, callerIdNumber, customHeaders, debug, useTrickleIce, audioConstraints, mutedMicOnStart)
+        val incomingCall = telnyxCommon.getTelnyxClient(context).acceptCall(callId, callerIdNumber, customHeaders, debug, useTrickleIce, audioConstraints, mutedMicOnStart, answeredDeviceToken)
         
         // Set the call quality change callback if provided
         if (debug && onCallQualityChange != null) {

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/AnswerIncomingPushCall.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/push/AnswerIncomingPushCall.kt
@@ -40,6 +40,9 @@ class AnswerIncomingPushCall(private val context: Context) {
     // Indicates whether trickle ICE should be enabled for the call.
     private var useTrickleIce: Boolean = false
 
+    // The FCM token to identify which device answered the push call.
+    private var fcmToken: String? = null
+
     // Observer for incoming call responses.
     private val incomingCallObserver = Observer<SocketResponse<ReceivedMessageBody>> { response ->
         handleSocketResponse(response)
@@ -74,13 +77,14 @@ class AnswerIncomingPushCall(private val context: Context) {
         val socketFlow = telnyxClient.socketResponseFlow
 
         ProfileManager.getProfilesList(context).lastOrNull()?.let { lastProfile ->
-            val fcmToken = lastProfile.fcmToken ?: ""
+            val token = lastProfile.fcmToken ?: ""
+            this.fcmToken = token
 
             // Use TokenConfig when sipToken is not null, otherwise use CredentialConfig
             if (!lastProfile.sipToken.isNullOrEmpty()) {
                 telnyxClient.connect(
                     TxServerConfiguration(),
-                    lastProfile.toTokenConfig(fcmToken),
+                    lastProfile.toTokenConfig(token),
                     txPushMetaData,
                     true
                 )
@@ -88,7 +92,7 @@ class AnswerIncomingPushCall(private val context: Context) {
 
                 telnyxClient.connect(
                     TxServerConfiguration(),
-                    lastProfile.toCredentialConfig(fcmToken),
+                    lastProfile.toCredentialConfig(token),
                     txPushMetaData,
                     true
                 )
@@ -132,13 +136,14 @@ class AnswerIncomingPushCall(private val context: Context) {
 
         val telnyxClient = TelnyxCommon.getInstance().getTelnyxClient(context)
         ProfileManager.getProfilesList(context).lastOrNull()?.let { lastProfile ->
-            val fcmToken = lastProfile.fcmToken ?: ""
+            val token = lastProfile.fcmToken ?: ""
+            this.fcmToken = token
 
             // Use TokenConfig when sipToken is not null, otherwise use CredentialConfig
             if (!lastProfile.sipToken.isNullOrEmpty()) {
                 telnyxClient.connect(
                     TxServerConfiguration(),
-                    lastProfile.toTokenConfig(fcmToken),
+                    lastProfile.toTokenConfig(token),
                     txPushMetaData,
                     true
                 )
@@ -146,7 +151,7 @@ class AnswerIncomingPushCall(private val context: Context) {
 
                 telnyxClient.connect(
                     TxServerConfiguration(),
-                    lastProfile.toCredentialConfig(fcmToken),
+                    lastProfile.toCredentialConfig(token),
                     txPushMetaData,
                     true
                 )
@@ -174,6 +179,7 @@ class AnswerIncomingPushCall(private val context: Context) {
                         debug,
                         useTrickleIce,
                         audioConstraints = null,  // Use defaults for push calls
+                        answeredDeviceToken = fcmToken,
                         onCallQualityChange = onCallQualityChange
                     )
                     cleanUp(answeredCall)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -379,7 +379,8 @@ class TelnyxClient(
         debug: Boolean = false,
         useTrickleIce: Boolean = false,
         audioConstraints: AudioConstraints? = null,
-        mutedMicOnStart: Boolean = false
+        mutedMicOnStart: Boolean = false,
+        answeredDeviceToken: String? = null
     ): Call {
         val callDebug = debug
         val socketPortalDebug = isSocketDebug
@@ -447,6 +448,7 @@ class TelnyxClient(
                         CallParams(
                             sessid = sessionId,
                             sdp = finalAnswerSdp,
+                            answeredDeviceToken = answeredDeviceToken,
                             dialogParams = CallDialogParams(
                                 callId = callId,
                                 destinationNumber = destinationNumber,
@@ -546,6 +548,7 @@ class TelnyxClient(
                                     CallParams(
                                         sessid = sessionId,
                                         sdp = finalAnswerSdp,
+                                        answeredDeviceToken = answeredDeviceToken,
                                         dialogParams = CallDialogParams(
                                             callId = callId,
                                             destinationNumber = destinationNumber,

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/ParamRequest.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/ParamRequest.kt
@@ -54,6 +54,8 @@ data class CallParams(
     val sdp: String,
     @SerializedName("User-Agent")
     val userAgent: String = "Android-" + BuildConfig.SDK_VERSION,
+    @SerializedName("answered_device_token")
+    val answeredDeviceToken: String? = null,
     val dialogParams: CallDialogParams,
     val trickle: Boolean? = null
 ) : ParamRequest()


### PR DESCRIPTION
## Summary
This PR adds an optional `answered_device_token` parameter to the call answering flow, allowing the backend to identify which device answered a push notification call.

**Supersedes #744** — merged main to resolve conflicts with the trickle ICE feature that was added after #744 was opened.

## Jira Ticket
[WEBRTC-3147](https://telnyx.atlassian.net/browse/WEBRTC-3147)

## Changes
- **DialogParams.kt**: Added `answered_device_token` field to `CallDialogParams`
- **TelnyxClient.kt**: Updated `acceptCall()` to accept and pass the optional `answeredDeviceToken` parameter in both trickle ICE and traditional ICE paths
- **AcceptCall.kt**: Updated wrapper class to propagate the `answeredDeviceToken` parameter
- **AnswerIncomingPushCall.kt**: Automatically passes the FCM token as `answered_device_token` when answering push notification calls
- **ParamRequest.kt**: Added `answeredDeviceToken` to `CallParams` alongside `trickle`

## Conflict Resolution
Merged main to include the `useTrickleIce` feature. Both features now work together:
- `trickle` flag for ICE optimization
- `answered_device_token` for push notification device identification

## Testing
- Verified all conflict markers resolved
- Both code paths (trickle ICE and traditional ICE) now include `answeredDeviceToken`

Closes #744

[WEBRTC-3147]: https://telnyx.atlassian.net/browse/WEBRTC-3147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ