### PR TITLE
WEBRTC-3243: Add meta-dev.yml for GitHub access control

### DIFF
--- a/meta-dev.yml
+++ b/meta-dev.yml
@@ -1,0 +1,4 @@
+project:
+  squad: webrtc.squad
+  primary_maintainer: Oliver-Zimmerman
+  secondary_maintainer: ai-swe-agent


### PR DESCRIPTION
## Summary

This PR adds the `meta-dev.yml` file to configure GitHub access control for this repository.

## Changes

- Added `meta-dev.yml` with the following configuration:
  - **squad**: `webrtc.squad`
  - **primary_maintainer**: `Oliver-Zimmerman`
  - **secondary_maintainer**: `ai-swe-agent`

## Context

This is part of the GitHub access control tooling initiative. The maintainers were determined based on the repository's contribution history.

## References

- Jira: [WEBRTC-3243](https://telnyx.atlassian.net/browse/WEBRTC-3243)
- ADR-8: [Service Metadata Specification](https://github.com/team-telnyx/engineering-decision-records/blob/master/en/architecture/adr-0008.md)


[WEBRTC-3243]: https://telnyx.atlassian.net/browse/WEBRTC-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ