### PR TITLE
WEBRTC-3243: Add meta-dev.yml for GitHub access control

### DIFF
--- a/meta-dev.yml
+++ b/meta-dev.yml
@@ -1,0 +1,4 @@
+project:
+  squad: webrtc.squad
+  primary_maintainer: Oliver-Zimmerman
+  secondary_maintainer: wojciechowskiradek


### PR DESCRIPTION
## Summary
This PR adds the `meta-dev.yml` file to configure GitHub access control for the WebRTC squad.

## Changes
- Added `meta-dev.yml` with the following configuration:
  - Squad: `webrtc.squad`
  - Primary Maintainer: `Oliver-Zimmerman`
  - Secondary Maintainer: `wojciechowskiradek`

## Related
- Jira: [WEBRTC-3243](https://telnyx.atlassian.net/browse/WEBRTC-3243)
- ADR-8: Service Metadata Specification

## Notes
Maintainers were determined based on repository contribution history.


[WEBRTC-3243]: https://telnyx.atlassian.net/browse/WEBRTC-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ