### PR TITLE
[WEBRTC-3319] Add conversation_id parameter to anonymous login methods

### DIFF
--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/assistant/AssistantLoginBottomSheet.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/assistant/AssistantLoginBottomSheet.kt
@@ -24,6 +24,7 @@ fun AssistantLoginBottomSheet(
 ) {
     val context = LocalContext.current
     var targetId by remember { mutableStateOf("") }
+    var conversationId by remember { mutableStateOf("") }
     val isLoading by telnyxViewModel.isLoading.collectAsState()
 
     ModalBottomSheet(
@@ -59,6 +60,20 @@ fun AssistantLoginBottomSheet(
                     .padding(bottom = 16.dp),
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Text,
+                    imeAction = ImeAction.Next
+                ),
+                enabled = !isLoading
+            )
+
+            OutlinedTextField(
+                value = conversationId,
+                onValueChange = { conversationId = it },
+                label = { Text(stringResource(R.string.assistant_conversation_id)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Text,
                     imeAction = ImeAction.Done
                 ),
                 keyboardActions = KeyboardActions(
@@ -66,7 +81,8 @@ fun AssistantLoginBottomSheet(
                         if (targetId.isNotBlank()) {
                             telnyxViewModel.anonymousLogin(
                                 viewContext = context,
-                                targetId = targetId.trim()
+                                targetId = targetId.trim(),
+                                conversationId = conversationId.trim().ifBlank { null }
                             )
                             onDismiss()
                         }
@@ -92,7 +108,8 @@ fun AssistantLoginBottomSheet(
                         if (targetId.isNotBlank()) {
                             telnyxViewModel.anonymousLogin(
                                 viewContext = context,
-                                targetId = targetId.trim()
+                                targetId = targetId.trim(),
+                                conversationId = conversationId.trim().ifBlank { null }
                             )
                             onDismiss()
                         }

--- a/samples/compose_app/src/main/res/values/strings.xml
+++ b/samples/compose_app/src/main/res/values/strings.xml
@@ -164,6 +164,7 @@
     <string name="assistant_login">Assistant Login</string>
     <string name="assistant_target_id">Target ID</string>
     <string name="assistant_target_id_hint">Enter assistant target ID</string>
+    <string name="assistant_conversation_id">Conversation ID (Optional)</string>
     <string name="assistant_login_button">Login</string>
     <string name="assistant_transcript">Assistant Transcript</string>
     <string name="assistant_message_hint">Type your message...</string>

--- a/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/assistant/AssistantLoginDialogFragment.kt
+++ b/samples/xml_app/src/main/java/org/telnyx/webrtc/xml_app/assistant/AssistantLoginDialogFragment.kt
@@ -14,23 +14,25 @@ import kotlinx.coroutines.launch
 import org.telnyx.webrtc.xmlapp.R
 
 class AssistantLoginDialogFragment : DialogFragment() {
-    
+
     private val telnyxViewModel: TelnyxViewModel by activityViewModels()
-    
+
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val view = layoutInflater.inflate(R.layout.dialog_assistant_login, null)
-        
+
         val etTargetId = view.findViewById<TextInputEditText>(R.id.etTargetId)
+        val etConversationId = view.findViewById<TextInputEditText>(R.id.etConversationId)
         val btnLogin = view.findViewById<MaterialButton>(R.id.btnLogin)
         val btnCancel = view.findViewById<MaterialButton>(R.id.btnCancel)
-        
+
         val dialog = AlertDialog.Builder(requireContext())
             .setView(view)
             .create()
-        
+
         btnLogin.setOnClickListener {
             val targetId = etTargetId.text?.toString()?.trim()
-            
+            val conversationId = etConversationId.text?.toString()?.trim()?.ifBlank { null }
+
             if (targetId.isNullOrEmpty()) {
                 Toast.makeText(
                     requireContext(),
@@ -39,11 +41,14 @@ class AssistantLoginDialogFragment : DialogFragment() {
                 ).show()
                 return@setOnClickListener
             }
-            
-            // Perform anonymous login for assistant
+
             lifecycleScope.launch {
                 try {
-                    telnyxViewModel.anonymousLogin(requireContext(), targetId)
+                    telnyxViewModel.anonymousLogin(
+                        viewContext = requireContext(),
+                        targetId = targetId,
+                        conversationId = conversationId
+                    )
                     Toast.makeText(
                         requireContext(),
                         getString(R.string.assistant_connected),
@@ -59,17 +64,17 @@ class AssistantLoginDialogFragment : DialogFragment() {
                 }
             }
         }
-        
+
         btnCancel.setOnClickListener {
             dialog.dismiss()
         }
-        
+
         return dialog
     }
-    
+
     companion object {
         const val TAG = "AssistantLoginDialog"
-        
+
         fun newInstance(): AssistantLoginDialogFragment {
             return AssistantLoginDialogFragment()
         }

--- a/samples/xml_app/src/main/res/layout/dialog_assistant_login.xml
+++ b/samples/xml_app/src/main/res/layout/dialog_assistant_login.xml
@@ -18,7 +18,7 @@
     <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="24dp"
+        android:layout_marginBottom="16dp"
         app:boxStrokeColor="@color/black"
         app:hintTextColor="@color/black">
 
@@ -27,6 +27,23 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/assistant_target_id_hint"
+            android:inputType="text"
+            android:maxLines="1" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="24dp"
+        app:boxStrokeColor="@color/black"
+        app:hintTextColor="@color/black">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etConversationId"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/assistant_conversation_id_hint"
             android:inputType="text"
             android:maxLines="1" />
 

--- a/samples/xml_app/src/main/res/values/strings.xml
+++ b/samples/xml_app/src/main/res/values/strings.xml
@@ -163,6 +163,7 @@
     <string name="assistant_login_dialog_title">Assistant Login</string>
     <string name="assistant_target_id">Target ID</string>
     <string name="assistant_target_id_hint">Enter Assistant Target ID</string>
+    <string name="assistant_conversation_id_hint">Conversation ID (Optional)</string>
     <string name="assistant_login_button">Login</string>
     <string name="assistant_cancel_button">Cancel</string>
     <string name="assistant_dial_button">Dial the connected Assistant</string>

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -693,6 +693,7 @@ class TelnyxViewModel : ViewModel() {
      * @param targetId The unique identifier of the target AI assistant.
      * @param targetType The type of target (defaults to "ai_assistant").
      * @param targetVersionId Optional version ID of the target.
+     * @param conversationId Optional conversation ID to join an existing conversation.
      * @param userVariables Optional user variables to include.
      */
     fun anonymousLogin(
@@ -700,6 +701,7 @@ class TelnyxViewModel : ViewModel() {
         targetId: String,
         targetType: String = "ai_assistant",
         targetVersionId: String? = null,
+        conversationId: String? = null,
         userVariables: Map<String, Any>? = null
     ) {
         _isLoading.value = true
@@ -715,6 +717,7 @@ class TelnyxViewModel : ViewModel() {
                 targetId = targetId,
                 targetType = targetType,
                 targetVersionId = targetVersionId,
+                conversationId = conversationId,
                 userVariables = userVariables,
                 reconnection = false,
                 logLevel = LogLevel.ALL

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/authentication/AuthenticateAnonymously.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/domain/authentication/AuthenticateAnonymously.kt
@@ -22,6 +22,7 @@ class AuthenticateAnonymously(private val context: Context) {
      * @param targetId The unique identifier of the target AI assistant.
      * @param targetType The type of target (defaults to "ai_assistant").
      * @param targetVersionId Optional version ID of the target.
+     * @param conversationId Optional conversation ID to join an existing conversation.
      * @param userVariables Optional user variables to include.
      * @param reconnection Whether this is a reconnection attempt (defaults to false).
      * @param logLevel The log level for the operation (defaults to LogLevel.NONE).
@@ -33,6 +34,7 @@ class AuthenticateAnonymously(private val context: Context) {
         targetId: String,
         targetType: String = "ai_assistant",
         targetVersionId: String? = null,
+        conversationId: String? = null,
         userVariables: Map<String, Any>? = null,
         reconnection: Boolean = false,
         logLevel: LogLevel = LogLevel.NONE
@@ -45,6 +47,7 @@ class AuthenticateAnonymously(private val context: Context) {
             targetId = targetId,
             targetType = targetType,
             targetVersionId = targetVersionId,
+            conversationId = conversationId,
             userVariables = userVariables,
             reconnection = reconnection,
             logLevel = logLevel

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1251,6 +1251,7 @@ class TelnyxClient(
      * @param targetId The unique identifier of the target AI assistant
      * @param targetType The type of target (defaults to "ai_assistant")
      * @param targetVersionId Optional version ID of the target
+     * @param conversationId Optional conversation ID to join an existing conversation
      * @param userVariables Optional user variables to include
      * @param reconnection Whether this is a reconnection attempt (defaults to false)
      */
@@ -1259,6 +1260,7 @@ class TelnyxClient(
         targetId: String,
         targetType: String = "ai_assistant",
         targetVersionId: String? = null,
+        conversationId: String? = null,
         userVariables: Map<String, Any>? = null,
         reconnection: Boolean = false,
         logLevel: LogLevel = LogLevel.NONE,
@@ -1291,6 +1293,7 @@ class TelnyxClient(
                         targetId = targetId,
                         targetType = targetType,
                         targetVersionId = targetVersionId,
+                        conversationId = conversationId,
                         userVariables = userVariables,
                         reconnection = reconnection,
                     )
@@ -1627,6 +1630,7 @@ class TelnyxClient(
      * @param targetId the unique identifier of the target AI assistant
      * @param targetType the type of target (defaults to "ai_assistant")
      * @param targetVersionId optional version ID of the target
+     * @param conversationId optional conversation ID to join an existing conversation
      * @param userVariables optional user variables to include
      * @param reconnection whether this is a reconnection attempt (defaults to false)
      */
@@ -1634,6 +1638,7 @@ class TelnyxClient(
         targetId: String,
         targetType: String = "ai_assistant",
         targetVersionId: String? = null,
+        conversationId: String? = null,
         userVariables: Map<String, Any>? = null,
         reconnection: Boolean = false,
     ) {
@@ -1648,6 +1653,7 @@ class TelnyxClient(
             targetType = targetType,
             targetId = targetId,
             targetVersionId = targetVersionId,
+            conversationId = conversationId,
             userVariables = userVariables,
             reconnection = reconnection,
             userAgent = userAgent,

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/AnonymousLoginMessage.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/send/AnonymousLoginMessage.kt
@@ -13,6 +13,7 @@ import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
  * @param targetType the type of target (defaults to "ai_assistant")
  * @param targetId the unique identifier of the target assistant
  * @param targetVersionId optional version ID of the target
+ * @param conversationId optional conversation ID to join an existing conversation
  * @param userVariables optional user variables to include
  * @param reconnection whether this is a reconnection attempt
  * @param userAgent user agent information containing SDK version and platform data
@@ -25,6 +26,8 @@ data class AnonymousLoginParams(
     val targetId: String,
     @SerializedName("target_version_id")
     val targetVersionId: String? = null,
+    @SerializedName("conversation_id")
+    val conversationId: String? = null,
     @SerializedName("userVariables")
     val userVariables: Map<String, Any>? = null,
     @SerializedName("reconnection")


### PR DESCRIPTION
## Summary
This PR adds support for an optional `conversation_id` parameter in the anonymous login flow for AI assistant connections. This allows users to join existing conversations rather than creating new ones.

## Jira Ticket
[WEBRTC-3319](https://telnyx.atlassian.net/browse/WEBRTC-3319)

## Changes

### Core SDK (telnyx_rtc)
- **AnonymousLoginMessage.kt**: Added `conversationId` field to `AnonymousLoginParams` with `@SerializedName("conversation_id")` annotation
- **TelnyxClient.kt**: Updated `anonymousLogin()` and `connectAnonymously()` methods to accept optional `conversationId` parameter

### Common Module (telnyx_common)
- **AuthenticateAnonymously.kt**: Updated `invokeFlow()` to accept optional `conversationId` parameter
- **TelnyxViewModel.kt**: Updated `anonymousLogin()` to accept optional `conversationId` parameter

### Sample Apps
- **compose_app**: Added Conversation ID input field to `AssistantLoginBottomSheet`
- **xml_app**: Added Conversation ID input field to `AssistantLoginDialogFragment` and updated layout

## Expected JSON Structure
```json
{
  "anonymous_login": {
    "target_params": {
      "conversation_id": "<string>"
    }
  }
}
```

## Backward Compatibility
All new parameters use `String? = null` pattern, ensuring existing code without `conversationId` will continue to work without modification.

## Testing
- [ ] CI/CD pipeline will run detekt and lint checks
- [ ] Manual testing with AI assistant connections

Co-authored-by: openhands <openhands@all-hands.dev>

[WEBRTC-3319]: https://telnyx.atlassian.net/browse/WEBRTC-3319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ