### PR TITLE
[ENGDESK-49938] Fix: CallState.CONNECTING emitted on active call when receiving second incoming call

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -2618,7 +2618,7 @@ class TelnyxClient(
                     jsonObject
                 )
             )
-            val offerCall = call!!.copy(
+            val offerCall = Call(
                 context = context,
                 client = this,
                 socket = socket,


### PR DESCRIPTION
## Summary

Fixes the issue where receiving a second incoming call while on an active call would incorrectly emit `CallState.CONNECTING` on the active call.

## Problem

When a second incoming call is received (`onOfferReceived`), the SDK was using `call!!.copy(...)` to create the new Call object for the incoming call.

This caused two issues:
1. **Shared StateFlow**: Kotlin's `copy()` does a shallow copy, so both the active call and the new incoming call shared the same `mutableCallStateFlow` instance
2. **Init block skipped**: The `Call` class `init` block (which sets `CallState.CONNECTING`) was never called for the copied object

Result: When the new incoming call's state was set to `CONNECTING`, it affected the active call's state too.

## Solution

Changed from:
```kotlin
val offerCall = call!!.copy(
    context = context,
    client = this,
    ...
)
```

To:
```kotlin
val offerCall = Call(
    context = context,
    client = this,
    ...
)
```

Creating a new `Call` instance directly ensures:
- Fresh `MutableStateFlow` for the new call
- `init` block is executed properly
- No state sharing between calls

## Testing

- [x] Make outbound call, receive second incoming call - active call state unchanged
- [x] SIP-to-SIP call between two emulators
