### PR TITLE
[WEBRTC-3346] Add ICE data to Call Stats

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/DebugDataCollector.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/DebugDataCollector.kt
@@ -587,6 +587,7 @@ class DebugDataCollector(private val context: Context) {
             if (interval.inboundBitrateAvg > 0) {
                 addProperty("bitrateAvg", interval.inboundBitrateAvg)
             }
+            addProperty("audioLevelAvg", interval.inboundAudioLevelAvg)
         }
         audio.add("inbound", audioInbound)
 
@@ -596,6 +597,7 @@ class DebugDataCollector(private val context: Context) {
             if (interval.outboundBitrateAvg > 0) {
                 addProperty("bitrateAvg", interval.outboundBitrateAvg)
             }
+            addProperty("audioLevelAvg", interval.outboundAudioLevelAvg)
         }
         audio.add("outbound", audioOutbound)
 
@@ -1516,10 +1518,12 @@ data class IntervalStats(
     val inboundConcealmentEvents: Long = 0,
     val inboundTotalSamplesReceived: Long = 0,
     val inboundBitrateAvg: Double = 0.0,
+    val inboundAudioLevelAvg: Double = 0.0,
     // Audio outbound
     val outboundBytesSent: Long = 0,
     val outboundPacketsSent: Long = 0,
     val outboundBitrateAvg: Double = 0.0,
+    val outboundAudioLevelAvg: Double = 0.0,
     // Connection
     val connectionBytesReceived: Long = 0,
     val connectionBytesSent: Long = 0,

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/WebRTCReporter.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/WebRTCReporter.kt
@@ -425,10 +425,12 @@ internal class WebRTCReporter(
                                 inboundConcealmentEvents = concealmentEvents,
                                 inboundTotalSamplesReceived = totalSamplesReceived,
                                 inboundBitrateAvg = inboundBitrateAvg,
+                                inboundAudioLevelAvg = inboundAudioLevel.toDouble(),
                                 // Audio outbound
                                 outboundBytesSent = mediaStats.outboundBytesSent,
                                 outboundPacketsSent = mediaStats.outboundPacketsSent,
                                 outboundBitrateAvg = outboundBitrateAvg,
+                                outboundAudioLevelAvg = outboundAudioLevel.toDouble(),
                                 // Connection
                                 connectionBytesReceived = connectionBytesReceived,
                                 connectionBytesSent = connectionBytesSent,


### PR DESCRIPTION
## Summary

Add detailed ICE candidate pair statistics to the Call Stats output for better connection diagnostics.

## Jira Ticket
https://telnyx.atlassian.net/browse/WEBRTC-3346

## Changes

### CandidateDetails
- Added `networkType` field for local candidates (e.g., "wifi", "cellular")

### CandidatePairInfo
- Added `id` - unique identifier for the candidate pair
- Added `nominated` - whether this pair is nominated
- Added `state` - connection state (e.g., "succeeded")
- Added `requestsSent` - number of connectivity check requests sent
- Added `responsesReceived` - number of responses received
- Added `writable` - whether the pair is writable

### JSON Output Structure
```json
"selectedPair": {
  "id": "CPg/czgYmv_RWGwnW/e",
  "local": {
    "address": "178.224.33.154",
    "candidateType": "srflx",
    "networkType": "wifi",
    "port": 51607,
    "protocol": "udp"
  },
  "nominated": true,
  "remote": {
    "address": "50.114.144.6",
    "candidateType": "host",
    "port": 19804,
    "protocol": "udp"
  },
  "requestsSent": 7,
  "responsesReceived": 7,
  "state": "succeeded",
  "writable": true
}
```

## Testing
- Build compiles successfully
- Stats are populated from WebRTC candidate-pair statistics
