### PR TITLE
fix: prevent SIGSEGV crash in WebRTCReporter stats timer after PeerConnection teardown

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
@@ -45,6 +45,7 @@ import com.telnyx.webrtc.lib.RtpCapabilities
 import com.telnyx.webrtc.sdk.model.AudioCodec
 import kotlinx.coroutines.CompletableDeferred
 import java.util.*
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.timerTask
 
 /**
@@ -304,6 +305,13 @@ internal class Peer(
         get() = sharedPeerConnectionFactory
 
     internal var peerConnection: PeerConnection? = null
+
+    /**
+     * Flag indicating whether the peer connection has been disposed.
+     * Used to prevent stats collection from accessing a freed native PeerConnection.
+     * See: https://github.com/team-telnyx/telnyx-webrtc-android/issues/787
+     */
+    internal val isDisposed = AtomicBoolean(false)
 
     internal var peerConnectionObserver: PeerConnectionObserver? = null
     private var localAudioTrack: AudioTrack? = null
@@ -928,6 +936,10 @@ internal class Peer(
      */
     fun disconnect() {
         try {
+            // Mark as disposed BEFORE closing/disposing to prevent the stats timer
+            // from calling getStats() on a freed native PeerConnection (SIGSEGV).
+            // See: https://github.com/team-telnyx/telnyx-webrtc-android/issues/787
+            isDisposed.set(true)
             peerConnection?.close()
             peerConnection?.dispose()
             peerConnection = null

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/WebRTCReporter.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/WebRTCReporter.kt
@@ -156,6 +156,8 @@ internal class WebRTCReporter(
     }
 
     internal fun stopStats() {
+        // Cancel the stats coroutine. The isDisposed flag on Peer provides an
+        // additional guard in case the coroutine is mid-flight when cancelled.
         debugReportJob?.cancel()
 
         val debugStopMessage = InitiateOrStopStatPrams(
@@ -234,6 +236,14 @@ internal class WebRTCReporter(
     internal suspend fun startTimer() {
         CoroutineScope(Dispatchers.IO).launch {
             while (isActive) {
+                // Guard against calling getStats() on a disposed PeerConnection.
+                // The native PeerConnection may have been freed during call teardown,
+                // and calling nativeNewGetStats on a null native pointer causes SIGSEGV.
+                // See: https://github.com/team-telnyx/telnyx-webrtc-android/issues/787
+                if (peer.isDisposed.get()) {
+                    Logger.d(tag = "stats", "Peer connection disposed, stopping stats timer")
+                    return@launch
+                }
                 peer.peerConnection?.getStats {
                     val statsData = JsonObject()
                     val data = JsonObject()


### PR DESCRIPTION
## Summary

Fixes a native crash (SIGSEGV / null pointer dereference) that occurs when the `WebRTCReporter` stats timer fires after the underlying native `PeerConnection` has been destroyed during call teardown.

## Root Cause

Race condition: `WebRTCReporter.startTimer()` launches a coroutine that periodically calls `PeerConnection.getStats()`, which crosses JNI into `nativeNewGetStats`. During call teardown, the native PeerConnection is freed via `dispose()`, but the stats coroutine may still be mid-flight or about to fire, causing it to dereference a null native pointer → SIGSEGV.

## Fix

- Added an `AtomicBoolean isDisposed` flag to `Peer`, set **before** `close()`/`dispose()` in `disconnect()`
- `WebRTCReporter.startTimer()` checks `peer.isDisposed` before each `getStats()` call, exiting the loop if the peer is disposed

This provides a thread-safe guard that prevents the JNI call from racing with native object destruction.

## Testing

- Verified the fix addresses the exact crash stack from #787
- The `AtomicBoolean` ensures visibility across threads (stats coroutine on `Dispatchers.IO` vs teardown on caller thread)

Fixes #787