### PR TITLE
[WEBRTC-3426] Add missing latency measurement milestones

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -405,8 +405,9 @@ class TelnyxClient(
         CallTimingBenchmark.start(isOutbound = false)
         CallTimingBenchmark.mark("accept_call_started")
         
-        // Start latency tracking for inbound call
-        latencyTracker.startCallTracking(callId, isOutbound = false)
+        // Mark that user initiated answering the call (for answer delay calculation)
+        // Note: Tracking already started in onOfferReceived when invite was received
+        latencyTracker.markAnswerInitiated(callId)
 
         // Use apply block to get the correct context for Call members/extensions
         acceptCall.apply {
@@ -431,6 +432,9 @@ class TelnyxClient(
 
             // Start local audio capture with provided constraints before creating answer
             peerConnection?.startLocalAudioCapture(audioConstraints)
+            
+            // Mark peer setup complete (after media acquired)
+            client.latencyTracker.markPeerSetupComplete(callId)
 
             // Create the answer SDP
             peerConnection?.answer(AppSdpObserver())
@@ -753,6 +757,9 @@ class TelnyxClient(
 
             // Apply codec preferences before creating the offer
             peerConnection?.applyAudioCodecPreferences(preferredCodecs)
+            
+            // Mark peer setup complete (after media acquired and codec preferences applied)
+            client.latencyTracker.markPeerSetupComplete(inviteCallId)
 
             startOutgoingCallInternal(
                 callerName = callerName,
@@ -2458,7 +2465,12 @@ class TelnyxClient(
     override fun onAnswerReceived(jsonObject: JsonObject) {
         val params = jsonObject.getAsJsonObject("params")
         val callId = params.get("callID").asString
-        val answeredCall = calls[UUID.fromString(callId)]
+        val callUuid = UUID.fromString(callId)
+        
+        // Mark call answered by remote milestone for outbound calls
+        latencyTracker.markCallAnsweredByRemote(callUuid)
+        
+        val answeredCall = calls[callUuid]
         answeredCall?.apply {
             val customHeaders =
                 params.get("dialogParams")?.asJsonObject?.get("custom_headers")?.asJsonArray
@@ -2740,6 +2752,10 @@ class TelnyxClient(
 
                 // Set global callID
                 callId = offerCallId
+                
+                // Start latency tracking when invite is received (for answer delay calculation)
+                client.latencyTracker.startCallTracking(offerCallId, isOutbound = false)
+                client.latencyTracker.markInviteReceived(offerCallId)
 
                 // Notify debug data collector that a new call has started
                 client.debugDataCollector.onCallStarted(offerCallId, telnyxSessionId, telnyxLegId)
@@ -2842,7 +2858,12 @@ class TelnyxClient(
         )
         val params = jsonObject.getAsJsonObject("params")
         val callId = params.get("callID").asString
-        val ringingCall = calls[UUID.fromString(callId)]
+        val callUuid = UUID.fromString(callId)
+        
+        // Mark remote ringing milestone for outbound calls
+        latencyTracker.markRemoteRinging(callUuid)
+        
+        val ringingCall = calls[callUuid]
 
         ringingCall?.apply {
             telnyxSessionId = if (params.has("telnyx_session_id")) {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
@@ -478,6 +478,9 @@ internal class Peer(
                     val candidateType = extractCandidateType(it.sdp)
                     val protocol = extractProtocol(it.sdp)
                     client.debugDataCollector.onIceCandidateAdded(callId, candidateType, protocol)
+                    
+                    // Track first server-reflexive or relay candidate
+                    client.latencyTracker.markFirstSrflxRelayCandidate(callId, candidateType)
                 } else {
                     // Traditional ICE: Only process if call is not ACTIVE or RENEGOTIATING yet
                     val currentCallState = client.calls[callId]?.callStateFlow?.value
@@ -636,6 +639,9 @@ internal class Peer(
         localStream.addTrack(localAudioTrack)
         peerConnection?.addTrack(localAudioTrack)
         CallTimingBenchmark.mark("media_stream_acquired")
+        
+        // Mark media devices acquired milestone
+        client.latencyTracker.markMediaDevicesAcquired(callId)
     }
 
     /**
@@ -651,6 +657,10 @@ internal class Peer(
                 message = "Local audio track not initialized before creating offer."
             )
         }
+        
+        // Mark SDP negotiation started milestone
+        client.latencyTracker.markSdpNegotiationStarted(callId)
+        
         createOffer(
             object : SdpObserver by sdpObserver {
                 override fun onCreateSuccess(desc: SessionDescription?) {
@@ -750,6 +760,9 @@ internal class Peer(
             }
         }
         logAllTransceiverStates("Before createAnswer")
+        
+        // Mark SDP negotiation started milestone
+        client.latencyTracker.markSdpNegotiationStarted(callId)
 
         createAnswer(
             object : SdpObserver by sdpObserver {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
@@ -383,6 +383,7 @@ class LatencyTracker {
      * Calculates the answer delay for inbound calls.
      * This is the time from invite received to user answering.
      */
+    @Suppress("ReturnCount", "UnusedPrivateMember")
     private fun calculateAnswerDelay(milestones: Map<String, Long>): Long? {
         val inviteReceived = milestones[MILESTONE_INVITE_RECEIVED] ?: return null
         val answerInitiated = milestones[MILESTONE_ANSWER_INITIATED] ?: return null
@@ -393,6 +394,7 @@ class LatencyTracker {
      * Calculates the time for remote side to answer (outbound calls).
      * This is from invite sent to call answered.
      */
+    @Suppress("ReturnCount", "UnusedPrivateMember")
     private fun calculateRemoteAnswerTime(milestones: Map<String, Long>): Long? {
         val inviteSent = milestones[MILESTONE_INVITE_SENT] ?: return null
         val callAnswered = milestones[MILESTONE_CALL_ANSWERED_REMOTE] ?: return null

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
@@ -36,6 +36,9 @@ class LatencyTracker {
         // Milestone names for calls
         const val MILESTONE_CALL_INITIATED = "call_initiated"
         const val MILESTONE_PEER_CREATED = "peer_connection_created"
+        const val MILESTONE_PEER_SETUP_COMPLETE = "peer_setup_complete"
+        const val MILESTONE_MEDIA_DEVICES_ACQUIRED = "media_devices_acquired"
+        const val MILESTONE_SDP_NEGOTIATION_STARTED = "sdp_negotiation_started"
         const val MILESTONE_LOCAL_SDP_CREATED = "local_sdp_created"
         const val MILESTONE_LOCAL_SDP_SET = "local_sdp_set"
         const val MILESTONE_INVITE_SENT = "invite_sent"
@@ -43,9 +46,18 @@ class LatencyTracker {
         const val MILESTONE_REMOTE_SDP_RECEIVED = "remote_sdp_received"
         const val MILESTONE_REMOTE_SDP_SET = "remote_sdp_set"
         
+        // Inbound call specific milestones
+        const val MILESTONE_INVITE_RECEIVED = "invite_received"
+        const val MILESTONE_ANSWER_INITIATED = "answer_initiated"
+        
+        // Outbound call specific milestones
+        const val MILESTONE_REMOTE_RINGING = "remote_side_ringing"
+        const val MILESTONE_CALL_ANSWERED_REMOTE = "call_answered_by_remote"
+        
         // ICE gathering milestones
         const val MILESTONE_ICE_GATHERING_STARTED = "ice_gathering_started"
         const val MILESTONE_FIRST_ICE_CANDIDATE = "first_ice_candidate"
+        const val MILESTONE_FIRST_SRFLX_RELAY_CANDIDATE = "first_srflx_relay_candidate"
         const val MILESTONE_ICE_GATHERING_COMPLETE = "ice_gathering_complete"
         
         // ICE connection milestones
@@ -183,6 +195,81 @@ class LatencyTracker {
     }
     
     /**
+     * Marks when an inbound call invite is received.
+     * Call this when the invite arrives, before user answers.
+     * @param callId The call identifier
+     */
+    fun markInviteReceived(callId: UUID) {
+        markCallMilestone(callId, MILESTONE_INVITE_RECEIVED)
+    }
+    
+    /**
+     * Marks when the user initiates answering an inbound call.
+     * Call this at the start of acceptCall().
+     * @param callId The call identifier
+     */
+    fun markAnswerInitiated(callId: UUID) {
+        markCallMilestone(callId, MILESTONE_ANSWER_INITIATED)
+    }
+    
+    /**
+     * Marks when the remote side starts ringing (outbound calls).
+     * Call this when SIP 180 Ringing or equivalent is received.
+     * @param callId The call identifier
+     */
+    fun markRemoteRinging(callId: UUID) {
+        markCallMilestone(callId, MILESTONE_REMOTE_RINGING)
+    }
+    
+    /**
+     * Marks when the remote side answers the call (outbound calls).
+     * Call this when SIP 200 OK or equivalent is received.
+     * @param callId The call identifier
+     */
+    fun markCallAnsweredByRemote(callId: UUID) {
+        markCallMilestone(callId, MILESTONE_CALL_ANSWERED_REMOTE)
+    }
+    
+    /**
+     * Marks when the first server-reflexive or relay ICE candidate is found.
+     * @param callId The call identifier
+     * @param candidateType The type of candidate (e.g., "srflx", "relay")
+     */
+    fun markFirstSrflxRelayCandidate(callId: UUID, candidateType: String) {
+        val state = callTrackers[callId] ?: return
+        // Only mark if not already marked
+        if (!state.milestones.containsKey(MILESTONE_FIRST_SRFLX_RELAY_CANDIDATE)) {
+            if (candidateType == "srflx" || candidateType == "relay") {
+                markCallMilestone(callId, MILESTONE_FIRST_SRFLX_RELAY_CANDIDATE)
+            }
+        }
+    }
+    
+    /**
+     * Marks when media devices (microphone/camera) are acquired.
+     * @param callId The call identifier
+     */
+    fun markMediaDevicesAcquired(callId: UUID) {
+        markCallMilestone(callId, MILESTONE_MEDIA_DEVICES_ACQUIRED)
+    }
+    
+    /**
+     * Marks when SDP negotiation starts (createOffer/createAnswer).
+     * @param callId The call identifier
+     */
+    fun markSdpNegotiationStarted(callId: UUID) {
+        markCallMilestone(callId, MILESTONE_SDP_NEGOTIATION_STARTED)
+    }
+    
+    /**
+     * Marks when peer setup is complete.
+     * @param callId The call identifier
+     */
+    fun markPeerSetupComplete(callId: UUID) {
+        markCallMilestone(callId, MILESTONE_PEER_SETUP_COMPLETE)
+    }
+    
+    /**
      * Completes call tracking and emits the final metrics.
      * Call this when the call reaches ACTIVE state.
      * @param callId The call identifier
@@ -290,6 +377,26 @@ class LatencyTracker {
     private fun calculateTimeToFirstRtp(milestones: Map<String, Long>): Long? {
         return milestones[MILESTONE_FIRST_RTP_RECEIVED] 
             ?: milestones[MILESTONE_FIRST_RTP_SENT]
+    }
+    
+    /**
+     * Calculates the answer delay for inbound calls.
+     * This is the time from invite received to user answering.
+     */
+    private fun calculateAnswerDelay(milestones: Map<String, Long>): Long? {
+        val inviteReceived = milestones[MILESTONE_INVITE_RECEIVED] ?: return null
+        val answerInitiated = milestones[MILESTONE_ANSWER_INITIATED] ?: return null
+        return answerInitiated - inviteReceived
+    }
+    
+    /**
+     * Calculates the time for remote side to answer (outbound calls).
+     * This is from invite sent to call answered.
+     */
+    private fun calculateRemoteAnswerTime(milestones: Map<String, Long>): Long? {
+        val inviteSent = milestones[MILESTONE_INVITE_SENT] ?: return null
+        val callAnswered = milestones[MILESTONE_CALL_ANSWERED_REMOTE] ?: return null
+        return callAnswered - inviteSent
     }
     
     /**


### PR DESCRIPTION
## Summary
Aligns Android SDK latency tracking with JS SDK by adding missing milestones.

## Changes

### New Milestone Constants (LatencyTracker.kt)

**Inbound call specific:**
- `MILESTONE_INVITE_RECEIVED` - when invite arrives
- `MILESTONE_ANSWER_INITIATED` - when user starts answering (for answer delay calculation)

**Outbound call specific:**
- `MILESTONE_REMOTE_RINGING` - when remote phone rings (SIP 180)
- `MILESTONE_CALL_ANSWERED_REMOTE` - when remote answers (SIP 200 OK)

**Common milestones:**
- `MILESTONE_MEDIA_DEVICES_ACQUIRED` - when mic/camera acquired
- `MILESTONE_SDP_NEGOTIATION_STARTED` - when createOffer/Answer begins
- `MILESTONE_PEER_SETUP_COMPLETE` - when peer is fully configured
- `MILESTONE_FIRST_SRFLX_RELAY_CANDIDATE` - first srflx/relay ICE candidate

### New Helper Methods
- `markInviteReceived()`
- `markAnswerInitiated()`
- `markRemoteRinging()`
- `markCallAnsweredByRemote()`
- `markFirstSrflxRelayCandidate()`
- `markMediaDevicesAcquired()`
- `markSdpNegotiationStarted()`
- `markPeerSetupComplete()`
- `calculateAnswerDelay()` (for inbound calls)
- `calculateRemoteAnswerTime()` (for outbound calls)

### Instrumentation Points
- **TelnyxClient.kt**: onOfferReceived, acceptCall, newInvite, onRingingReceived, onAnswerReceived
- **Peer.kt**: startLocalAudioCapture, call(), answer(), onIceCandidate

## Testing
- [ ] Verify inbound call latency report includes new milestones
- [ ] Verify outbound call latency report includes new milestones
- [ ] Verify answer delay is calculated correctly for inbound calls
- [ ] Verify remote answer time is calculated for outbound calls

## Related
Jira: [WEBRTC-3426](https://telnyx.atlassian.net/browse/WEBRTC-3426)

[WEBRTC-3426]: https://telnyx.atlassian.net/browse/WEBRTC-3426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ