### PR TITLE
VSDK-170: CallTimings — fix portal parsing

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -485,8 +485,7 @@ class TelnyxClient(
                     updateCallState(CallState.ACTIVE)
                     
                     // Complete call latency tracking
-                    client.debugDataCollector.addCallTimingsLogs(callId, client.latencyTracker.generateCallTimingsLogs(callId))
-                    client.latencyTracker.completeCallTracking(callId)
+                    client.debugDataCollector.addCallTimingsLogs(callId, client.latencyTracker.completeCallTracking(callId))
 
                     // Start stats collection - interval is adjusted internally based on debug flags
                     if (getWebRTCReporter(callId) == null) {
@@ -587,8 +586,7 @@ class TelnyxClient(
                                 updateCallState(CallState.ACTIVE)
                                 
                                 // Complete call latency tracking
-                                client.debugDataCollector.addCallTimingsLogs(callId, client.latencyTracker.generateCallTimingsLogs(callId))
-                                client.latencyTracker.completeCallTracking(callId)
+                                client.debugDataCollector.addCallTimingsLogs(callId, client.latencyTracker.completeCallTracking(callId))
 
                                 // Start stats collection - interval is adjusted internally based on debug flags
                                 if (getWebRTCReporter(callId) == null) {
@@ -694,7 +692,7 @@ class TelnyxClient(
         this.useTrickleIce = useTrickleIce
 
         // Start latency tracking for outbound call
-        latencyTracker.startCallTracking(inviteCallId, isOutbound = true)
+        latencyTracker.startCallTracking(inviteCallId, isOutbound = true, useTrickleIce = useTrickleIce)
         
         val inviteCall = Call(
             context = context,
@@ -2528,8 +2526,7 @@ class TelnyxClient(
                     updateCallState(CallState.ACTIVE)
                     
                     // Complete call latency tracking
-                    client.debugDataCollector.addCallTimingsLogs(UUID.fromString(callId), client.latencyTracker.generateCallTimingsLogs(UUID.fromString(callId)))
-                    client.latencyTracker.completeCallTracking(UUID.fromString(callId))
+                    client.debugDataCollector.addCallTimingsLogs(UUID.fromString(callId), client.latencyTracker.completeCallTracking(UUID.fromString(callId)))
 
                     val answerResponse = AnswerResponse(
                         UUID.fromString(callId),
@@ -2569,8 +2566,7 @@ class TelnyxClient(
                     updateCallState(CallState.ACTIVE)
                     
                     // Complete call latency tracking
-                    client.debugDataCollector.addCallTimingsLogs(UUID.fromString(callId), client.latencyTracker.generateCallTimingsLogs(UUID.fromString(callId)))
-                    client.latencyTracker.completeCallTracking(UUID.fromString(callId))
+                    client.debugDataCollector.addCallTimingsLogs(UUID.fromString(callId), client.latencyTracker.completeCallTracking(UUID.fromString(callId)))
                 }
 
                 else -> {
@@ -2758,7 +2754,7 @@ class TelnyxClient(
                 callId = offerCallId
                 
                 // Start latency tracking when invite is received (for answer delay calculation)
-                client.latencyTracker.startCallTracking(offerCallId, isOutbound = false)
+                client.latencyTracker.startCallTracking(offerCallId, isOutbound = false, useTrickleIce = useTrickleIce)
                 client.latencyTracker.markInviteReceived(offerCallId)
 
                 // Notify debug data collector that a new call has started

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -485,6 +485,7 @@ class TelnyxClient(
                     updateCallState(CallState.ACTIVE)
                     
                     // Complete call latency tracking
+                    client.debugDataCollector.addCallTimingsLogs(callId, client.latencyTracker.generateCallTimingsLogs(callId))
                     client.latencyTracker.completeCallTracking(callId)
 
                     // Start stats collection - interval is adjusted internally based on debug flags
@@ -586,6 +587,7 @@ class TelnyxClient(
                                 updateCallState(CallState.ACTIVE)
                                 
                                 // Complete call latency tracking
+                                client.debugDataCollector.addCallTimingsLogs(callId, client.latencyTracker.generateCallTimingsLogs(callId))
                                 client.latencyTracker.completeCallTracking(callId)
 
                                 // Start stats collection - interval is adjusted internally based on debug flags
@@ -2526,6 +2528,7 @@ class TelnyxClient(
                     updateCallState(CallState.ACTIVE)
                     
                     // Complete call latency tracking
+                    client.debugDataCollector.addCallTimingsLogs(UUID.fromString(callId), client.latencyTracker.generateCallTimingsLogs(UUID.fromString(callId)))
                     client.latencyTracker.completeCallTracking(UUID.fromString(callId))
 
                     val answerResponse = AnswerResponse(
@@ -2566,6 +2569,7 @@ class TelnyxClient(
                     updateCallState(CallState.ACTIVE)
                     
                     // Complete call latency tracking
+                    client.debugDataCollector.addCallTimingsLogs(UUID.fromString(callId), client.latencyTracker.generateCallTimingsLogs(UUID.fromString(callId)))
                     client.latencyTracker.completeCallTracking(UUID.fromString(callId))
                 }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -398,6 +398,10 @@ class TelnyxClient(
         // Set trickle ICE for this call
         this.useTrickleIce = useTrickleIce
 
+        // Update the per-call tracker's ICE mode since the inbound tracker was
+        // started in onOfferReceived with the previous client-level value.
+        latencyTracker.updateIceMode(callId, useTrickleIce)
+
         val acceptCall =
             calls[callId] ?: throw IllegalStateException("Call not found for ID: $callId")
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/DebugDataCollector.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/DebugDataCollector.kt
@@ -15,6 +15,7 @@ import com.google.gson.GsonBuilder
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
+import com.telnyx.webrtc.sdk.utilities.CallTimingsLogEntry
 import timber.log.Timber
 import java.io.File
 import java.text.SimpleDateFormat
@@ -149,6 +150,22 @@ class DebugDataCollector(private val context: Context) {
     ) {
         callDebugData[callId]?.let { data ->
             data.logs.add(LogEntry(System.currentTimeMillis(), level, message, context))
+        }
+    }
+
+    /**
+     * Adds CallTimings log entries to the call's log data.
+     * These entries follow the JS SDK's CallTimings log format and are added
+     * to the 'logs' array in the JSON call report.
+     *
+     * @param callId The unique identifier for the call
+     * @param timingsLogs List of CallTimingsLogEntry objects from LatencyTracker
+     */
+    fun addCallTimingsLogs(callId: UUID, timingsLogs: List<CallTimingsLogEntry>) {
+        callDebugData[callId]?.let { data ->
+            timingsLogs.forEach { entry ->
+                data.logs.add(LogEntry(entry.timestamp, entry.level, entry.message, null))
+            }
         }
     }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
@@ -91,6 +91,10 @@ class LatencyTracker {
         const val MILESTONE_FIRST_RTP_RECEIVED = "first_rtp_received"
         const val MILESTONE_MEDIA_ACTIVE = "media_active"
         const val MILESTONE_CALL_ACTIVE = "call_active"
+        
+        // CallTimings log format column widths (must match JS SDK / portal regex)
+        private const val STEP_COLUMN_WIDTH = 40
+        private const val DELTA_COLUMN_WIDTH = 10
     }
     
     // Registration tracking
@@ -384,8 +388,8 @@ class LatencyTracker {
      * @return List of CallTimingsLogEntry objects, or empty list if no tracking data
      */
     fun generateCallTimingsLogs(callId: UUID): List<CallTimingsLogEntry> {
-        val state = callTrackers[callId] ?: return emptyList()
-        val milestones = state.milestones.toMap()
+        val state = callTrackers[callId]
+        val milestones = state?.milestones?.toMap().orEmpty()
         if (milestones.isEmpty()) return emptyList()
 
         val direction = if (state.isOutbound) "outbound" else "inbound"
@@ -400,8 +404,8 @@ class LatencyTracker {
         // portal can parse data rows with its regex:
         //   ~r/^(?<step>.+?)\s{2,}(?<delta>[\d.]+ms|-)\s+(?<from>[\d.]+)ms\s*$/
         // The key requirement is at least 2 spaces between columns.
-        val stepColumnWidth = 40  // left-padded step name column
-        val deltaColumnWidth = 10  // right-aligned delta column
+        val stepColumnWidth = STEP_COLUMN_WIDTH  // left-padded step name column
+        val deltaColumnWidth = DELTA_COLUMN_WIDTH  // right-aligned delta column
 
         // Header entries
         entries.add(

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
@@ -42,13 +42,13 @@ class LatencyTracker {
     
     companion object {
         private const val TAG = "LatencyTracker"
-        
+
         // Milestone names for registration
         const val MILESTONE_LOGIN_INITIATED = "login_initiated"
         const val MILESTONE_SOCKET_CONNECTED = "socket_connected"
         const val MILESTONE_LOGIN_SENT = "login_sent"
         const val MILESTONE_CLIENT_READY = "client_ready"
-        
+
         // Milestone names for calls
         const val MILESTONE_CALL_INITIATED = "call_initiated"
         const val MILESTONE_PEER_CREATED = "peer_connection_created"
@@ -61,37 +61,37 @@ class LatencyTracker {
         const val MILESTONE_ANSWER_SENT = "answer_sent"
         const val MILESTONE_REMOTE_SDP_RECEIVED = "remote_sdp_received"
         const val MILESTONE_REMOTE_SDP_SET = "remote_sdp_set"
-        
+
         // Inbound call specific milestones
         const val MILESTONE_INVITE_RECEIVED = "invite_received"
         const val MILESTONE_ANSWER_INITIATED = "answer_initiated"
-        
+
         // Outbound call specific milestones
         const val MILESTONE_REMOTE_RINGING = "remote_side_ringing"
         const val MILESTONE_CALL_ANSWERED_REMOTE = "call_answered_by_remote"
-        
+
         // ICE gathering milestones
         const val MILESTONE_ICE_GATHERING_STARTED = "ice_gathering_started"
         const val MILESTONE_FIRST_ICE_CANDIDATE = "first_ice_candidate"
         const val MILESTONE_FIRST_SRFLX_RELAY_CANDIDATE = "first_srflx_relay_candidate"
         const val MILESTONE_ICE_GATHERING_COMPLETE = "ice_gathering_complete"
-        
+
         // ICE connection milestones
         const val MILESTONE_ICE_CHECKING = "ice_checking"
         const val MILESTONE_ICE_CONNECTED = "ice_connected"
         const val MILESTONE_ICE_COMPLETED = "ice_completed"
-        
+
         // DTLS milestones
         const val MILESTONE_DTLS_CONNECTING = "dtls_connecting"
         const val MILESTONE_DTLS_CONNECTED = "dtls_connected"
-        
+
         // Peer connection milestones
         const val MILESTONE_PEER_CONNECTED = "peer_connected"
         const val MILESTONE_FIRST_RTP_SENT = "first_rtp_sent"
         const val MILESTONE_FIRST_RTP_RECEIVED = "first_rtp_received"
         const val MILESTONE_MEDIA_ACTIVE = "media_active"
         const val MILESTONE_CALL_ACTIVE = "call_active"
-        
+
         // CallTimings log format column widths (must match JS SDK / portal regex)
         private const val STEP_COLUMN_WIDTH = 40
         private const val DELTA_COLUMN_WIDTH = 10
@@ -107,6 +107,7 @@ class LatencyTracker {
     private data class CallTrackingState(
         val startTime: Long = System.currentTimeMillis(),
         val isOutbound: Boolean = false,
+        val iceMode: String = "trickle",
         val milestones: ConcurrentHashMap<String, Long> = ConcurrentHashMap()
     )
     private val callTrackers = ConcurrentHashMap<UUID, CallTrackingState>()
@@ -158,19 +159,19 @@ class LatencyTracker {
      */
     fun completeRegistrationTracking() {
         if (!isTrackingRegistration) return
-        
+
         markRegistrationMilestone(MILESTONE_CLIENT_READY)
         isTrackingRegistration = false
-        
+
         val registrationLatency = System.currentTimeMillis() - registrationStartTime
-        
+
         val metrics = LatencyMetrics(
             callId = null,
             isOutbound = false,
             registrationLatencyMs = registrationLatency,
             milestones = registrationMilestones.toMap()
         )
-        
+
         emitMetrics(metrics)
         Logger.i(TAG, "Registration completed in ${registrationLatency}ms")
         Logger.d(TAG, metrics.toFormattedString())
@@ -183,10 +184,11 @@ class LatencyTracker {
      * @param callId The unique identifier for the call
      * @param isOutbound True for outbound calls, false for inbound
      */
-    fun startCallTracking(callId: UUID, isOutbound: Boolean) {
+    fun startCallTracking(callId: UUID, isOutbound: Boolean, useTrickleIce: Boolean = true) {
         val state = CallTrackingState(
             startTime = System.currentTimeMillis(),
-            isOutbound = isOutbound
+            isOutbound = isOutbound,
+            iceMode = if (useTrickleIce) "trickle" else "standard"
         )
         callTrackers[callId] = state
         markCallMilestone(callId, MILESTONE_CALL_INITIATED)
@@ -294,20 +296,24 @@ class LatencyTracker {
      * Call this when the call reaches ACTIVE state.
      * @param callId The call identifier
      */
-    fun completeCallTracking(callId: UUID) {
-        val state = callTrackers[callId] ?: return
-        
+    fun completeCallTracking(callId: UUID): List<CallTimingsLogEntry> {
+        val state = callTrackers[callId] ?: return emptyList()
+
         markCallMilestone(callId, MILESTONE_CALL_ACTIVE)
-        
+
+        // Generate CallTimings logs BEFORE removing the tracker,
+        // so MILESTONE_CALL_ACTIVE is included in the output.
+        val timingsLogs = generateCallTimingsLogs(callId)
+
         val milestones = state.milestones.toMap()
         val totalTime = System.currentTimeMillis() - state.startTime
-        
+
         // Calculate derived metrics
         val iceGatheringLatency = calculateIceGatheringLatency(milestones)
         val signalingLatency = calculateSignalingLatency(milestones, state.isOutbound)
         val mediaEstablishmentLatency = calculateMediaEstablishmentLatency(milestones)
         val timeToFirstRtp = calculateTimeToFirstRtp(milestones)
-        
+
         val metrics = LatencyMetrics(
             callId = callId,
             isOutbound = state.isOutbound,
@@ -318,13 +324,15 @@ class LatencyTracker {
             mediaEstablishmentLatencyMs = mediaEstablishmentLatency,
             milestones = milestones
         )
-        
+
         emitMetrics(metrics)
         Logger.i(TAG, "Call $callId completed in ${totalTime}ms")
         Logger.d(TAG, metrics.toFormattedString())
-        
+
         // Clean up
         callTrackers.remove(callId)
+
+        return timingsLogs
     }
 
     /**
@@ -393,7 +401,7 @@ class LatencyTracker {
         if (milestones.isEmpty()) return emptyList()
 
         val direction = if (state.isOutbound) "outbound" else "inbound"
-        val mode = "trickle" // Android SDK uses trickle ICE
+        val mode = state?.iceMode ?: "trickle"
         val prefix = "[CallTimings][$direction][$mode]"
 
         val stepMapping = if (state.isOutbound) outboundStepMapping else inboundStepMapping
@@ -495,7 +503,7 @@ class LatencyTracker {
         val state = callTrackers[callId] ?: return null
         val milestones = state.milestones.toMap()
         val currentTime = System.currentTimeMillis() - state.startTime
-        
+
         return LatencyMetrics(
             callId = callId,
             isOutbound = state.isOutbound,

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
@@ -392,9 +392,8 @@ class LatencyTracker {
      * @return List of CallTimingsLogEntry objects, or empty list if no tracking data
      */
     fun generateCallTimingsLogs(callId: UUID): List<CallTimingsLogEntry> {
-        val state = callTrackers[callId] ?: return emptyList()
-        val milestones = state.milestones.toMap().orEmpty()
-        if (milestones.isEmpty()) return emptyList()
+        val state = callTrackers[callId]?.takeIf { it.milestones.isNotEmpty() } ?: return emptyList()
+        val milestones = state.milestones.toMap()
 
         val direction = if (state.isOutbound) "outbound" else "inbound"
         val mode = state.iceMode
@@ -404,10 +403,6 @@ class LatencyTracker {
         val entries = mutableListOf<CallTimingsLogEntry>()
         val timestamp = System.currentTimeMillis()
 
-        // Column widths must match the JS SDK format so the call-report-stats
-        // portal can parse data rows with its regex:
-        //   ~r/^(?<step>.+?)\s{2,}(?<delta>[\d.]+ms|-)\s+(?<from>[\d.]+)ms\s*$/
-        // The key requirement is at least 2 spaces between columns.
         // Column separator: at least 2 spaces between columns to satisfy
         // the portal regex (?<step>.+?)\s{2,}(?<delta>[\d.]+ms|-)
         val colSep = "  "  // 2-space minimum separator between columns

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
@@ -91,10 +91,6 @@ class LatencyTracker {
         const val MILESTONE_FIRST_RTP_RECEIVED = "first_rtp_received"
         const val MILESTONE_MEDIA_ACTIVE = "media_active"
         const val MILESTONE_CALL_ACTIVE = "call_active"
-
-        // CallTimings log format column widths (must match JS SDK / portal regex)
-        private const val STEP_COLUMN_WIDTH = 40
-        private const val DELTA_COLUMN_WIDTH = 10
     }
     
     // Registration tracking
@@ -396,15 +392,15 @@ class LatencyTracker {
      * @return List of CallTimingsLogEntry objects, or empty list if no tracking data
      */
     fun generateCallTimingsLogs(callId: UUID): List<CallTimingsLogEntry> {
-        val state = callTrackers[callId]
-        val milestones = state?.milestones?.toMap().orEmpty()
+        val state = callTrackers[callId] ?: return emptyList()
+        val milestones = state.milestones.toMap().orEmpty()
         if (milestones.isEmpty()) return emptyList()
 
-        val direction = if (state?.isOutbound == true) "outbound" else "inbound"
-        val mode = state?.iceMode ?: "trickle"
+        val direction = if (state.isOutbound) "outbound" else "inbound"
+        val mode = state.iceMode
         val prefix = "[CallTimings][$direction][$mode]"
 
-        val stepMapping = if (state?.isOutbound == true) outboundStepMapping else inboundStepMapping
+        val stepMapping = if (state.isOutbound) outboundStepMapping else inboundStepMapping
         val entries = mutableListOf<CallTimingsLogEntry>()
         val timestamp = System.currentTimeMillis()
 
@@ -412,8 +408,9 @@ class LatencyTracker {
         // portal can parse data rows with its regex:
         //   ~r/^(?<step>.+?)\s{2,}(?<delta>[\d.]+ms|-)\s+(?<from>[\d.]+)ms\s*$/
         // The key requirement is at least 2 spaces between columns.
-        val stepColumnWidth = STEP_COLUMN_WIDTH  // left-padded step name column
-        val deltaColumnWidth = DELTA_COLUMN_WIDTH  // right-aligned delta column
+        // Column separator: at least 2 spaces between columns to satisfy
+        // the portal regex (?<step>.+?)\s{2,}(?<delta>[\d.]+ms|-)
+        val colSep = "  "  // 2-space minimum separator between columns
 
         // Header entries
         entries.add(
@@ -426,7 +423,7 @@ class LatencyTracker {
         entries.add(
             CallTimingsLogEntry(
                 level = "info",
-                message = "$prefix ${String.format(Locale.US, "%-${stepColumnWidth}s", "Step")}${String.format(Locale.US, "%${deltaColumnWidth}s", "Delta")}    From Start",
+                message = "$prefix${colSep}Step${colSep}Delta${colSep}From Start",
                 timestamp = timestamp
             )
         )
@@ -454,15 +451,17 @@ class LatencyTracker {
             val deltaMs = if (previousMs != null) fromStartMs - previousMs else null
             previousMs = fromStartMs
 
-            val stepPadded = String.format(Locale.US, "%-${stepColumnWidth}s", stepName)
+            // Use explicit 2+ space separators instead of fixed-width padding
+            // so that long step names (e.g. "First server-reflexive/relay candidate found")
+            // still produce parsable rows with \s{2,} between columns.
             val message = if (deltaMs == null) {
                 // First row (Call Start): delta is "-"
                 val fromStartStr = String.format(Locale.US, "%.2f", fromStartMs.toDouble())
-                "$prefix $stepPadded${String.format(Locale.US, "%${deltaColumnWidth}s", "-")}        ${fromStartStr}ms"
+                "$prefix${colSep}$stepName${colSep}-${colSep}${fromStartStr}ms"
             } else {
                 val deltaStr = String.format(Locale.US, "%.2f", deltaMs.toDouble())
                 val fromStartStr = String.format(Locale.US, "%.2f", fromStartMs.toDouble())
-                "$prefix $stepPadded${String.format(Locale.US, "%${deltaColumnWidth}s", "${deltaStr}ms")}        ${fromStartStr}ms"
+                "$prefix${colSep}$stepName${colSep}${deltaStr}ms${colSep}${fromStartStr}ms"
             }
 
             entries.add(

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
@@ -13,6 +13,21 @@ import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
 /**
+ * Represents a single log entry for CallTimings data in the call report.
+ * These entries are added to the 'logs' array in the JSON call report
+ * to match the JS SDK's CallTimings log format.
+ *
+ * @property level Log level (always "info" for CallTimings)
+ * @property message The formatted CallTimings message
+ * @property timestamp The timestamp when the entry was created
+ */
+data class CallTimingsLogEntry(
+    val level: String,
+    val message: String,
+    val timestamp: Long
+)
+
+/**
  * Tracks and calculates latency metrics for WebRTC call establishment.
  * 
  * This class provides detailed timing information for:
@@ -306,7 +321,139 @@ class LatencyTracker {
         // Clean up
         callTrackers.remove(callId)
     }
-    
+
+    /**
+     * Ordered milestone-to-step mapping for outbound calls.
+     * Maps internal milestone names to JS SDK-compatible step names for log output.
+     */
+    private val outboundStepMapping = linkedMapOf(
+        MILESTONE_CALL_INITIATED to "Call Start",
+        MILESTONE_PEER_CREATED to "Peer object created",
+        MILESTONE_MEDIA_DEVICES_ACQUIRED to "Media devices acquired",
+        MILESTONE_PEER_SETUP_COMPLETE to "Peer setup complete",
+        MILESTONE_SDP_NEGOTIATION_STARTED to "SDP negotiation started",
+        MILESTONE_LOCAL_SDP_CREATED to "SDP offer generated",
+        MILESTONE_LOCAL_SDP_SET to "Local description applied",
+        MILESTONE_ICE_GATHERING_STARTED to "ICE candidate gathering started",
+        MILESTONE_INVITE_SENT to "SDP sent to server",
+        MILESTONE_FIRST_ICE_CANDIDATE to "First ICE candidate found",
+        MILESTONE_FIRST_SRFLX_RELAY_CANDIDATE to "First server-reflexive/relay candidate found",
+        MILESTONE_REMOTE_RINGING to "Remote side ringing",
+        MILESTONE_FIRST_RTP_RECEIVED to "Early media received from server",
+        MILESTONE_REMOTE_SDP_RECEIVED to "Remote SDP received",
+        MILESTONE_REMOTE_SDP_SET to "Remote description applied",
+        MILESTONE_ICE_GATHERING_COMPLETE to "All ICE candidates gathered",
+        MILESTONE_ICE_CONNECTED to "ICE connection established",
+        MILESTONE_DTLS_CONNECTED to "Secure media channel established (DTLS)",
+        MILESTONE_CALL_ANSWERED_REMOTE to "Call answered by remote side",
+        MILESTONE_CALL_ACTIVE to "Call is active"
+    )
+
+    /**
+     * Ordered milestone-to-step mapping for inbound calls.
+     */
+    private val inboundStepMapping = linkedMapOf(
+        MILESTONE_CALL_INITIATED to "Call Start",
+        MILESTONE_INVITE_RECEIVED to "Invite received",
+        MILESTONE_ANSWER_INITIATED to "Answer initiated",
+        MILESTONE_PEER_CREATED to "Peer object created",
+        MILESTONE_MEDIA_DEVICES_ACQUIRED to "Media devices acquired",
+        MILESTONE_PEER_SETUP_COMPLETE to "Peer setup complete",
+        MILESTONE_SDP_NEGOTIATION_STARTED to "SDP negotiation started",
+        MILESTONE_LOCAL_SDP_CREATED to "SDP answer generated",
+        MILESTONE_LOCAL_SDP_SET to "Local description applied",
+        MILESTONE_ICE_GATHERING_STARTED to "ICE candidate gathering started",
+        MILESTONE_FIRST_ICE_CANDIDATE to "First ICE candidate found",
+        MILESTONE_FIRST_SRFLX_RELAY_CANDIDATE to "First server-reflexive/relay candidate found",
+        MILESTONE_ANSWER_SENT to "Answer sent to server",
+        MILESTONE_REMOTE_SDP_RECEIVED to "Remote SDP received",
+        MILESTONE_REMOTE_SDP_SET to "Remote description applied",
+        MILESTONE_ICE_GATHERING_COMPLETE to "All ICE candidates gathered",
+        MILESTONE_ICE_CONNECTED to "ICE connection established",
+        MILESTONE_DTLS_CONNECTED to "Secure media channel established (DTLS)",
+        MILESTONE_CALL_ACTIVE to "Call is active"
+    )
+
+    /**
+     * Generates CallTimings log entries for a call based on tracked milestones.
+     * The output format matches the JS SDK's CallTimings log format:
+     *   [CallTimings][direction][mode] <step> <delta_ms> <from_start_ms>
+     *
+     * @param callId The call identifier
+     * @return List of CallTimingsLogEntry objects, or empty list if no tracking data
+     */
+    fun generateCallTimingsLogs(callId: UUID): List<CallTimingsLogEntry> {
+        val state = callTrackers[callId] ?: return emptyList()
+        val milestones = state.milestones.toMap()
+        if (milestones.isEmpty()) return emptyList()
+
+        val direction = if (state.isOutbound) "outbound" else "inbound"
+        val mode = "trickle" // Android SDK uses trickle ICE
+        val prefix = "[CallTimings][$direction][$mode]"
+
+        val stepMapping = if (state.isOutbound) outboundStepMapping else inboundStepMapping
+        val entries = mutableListOf<CallTimingsLogEntry>()
+        val timestamp = System.currentTimeMillis()
+
+        // Header entries
+        entries.add(
+            CallTimingsLogEntry(
+                level = "info",
+                message = "$prefix Call establishment timing breakdown:",
+                timestamp = timestamp
+            )
+        )
+        entries.add(
+            CallTimingsLogEntry(
+                level = "info",
+                message = "$prefix Step Delta From Start",
+                timestamp = timestamp
+            )
+        )
+        entries.add(
+            CallTimingsLogEntry(
+                level = "info",
+                message = "$prefix --------------------------------------------------------------------------",
+                timestamp = timestamp
+            )
+        )
+
+        // Step entries
+        var previousMs: Long? = null
+        for ((milestone, stepName) in stepMapping) {
+            val fromStartMs = milestones[milestone] ?: continue
+            val deltaMs = if (previousMs != null) fromStartMs - previousMs else null
+            previousMs = fromStartMs
+
+            val message = if (milestone == MILESTONE_CALL_INITIATED) {
+                "$prefix $stepName - ${String.format("%.2f", fromStartMs.toDouble())}ms"
+            } else {
+                val deltaStr = String.format("%.2f", (deltaMs ?: 0L).toDouble())
+                val fromStartStr = String.format("%.2f", fromStartMs.toDouble())
+                "$prefix $stepName ${deltaStr}ms ${fromStartStr}ms"
+            }
+
+            entries.add(
+                CallTimingsLogEntry(
+                    level = "info",
+                    message = message,
+                    timestamp = timestamp
+                )
+            )
+        }
+
+        // Footer
+        entries.add(
+            CallTimingsLogEntry(
+                level = "info",
+                message = "$prefix --------------------------------------------------------------------------",
+                timestamp = timestamp
+            )
+        )
+
+        return entries
+    }
+
     /**
      * Cancels tracking for a call (e.g., if call fails).
      * @param callId The call identifier

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
@@ -426,20 +426,29 @@ class LatencyTracker {
             )
         )
 
-        // Step entries — column-aligned to match JS SDK format
-        var previousMs: Long? = null
+        // Step entries — sorted by actual chronological order to avoid negative deltas.
+        // The stepMapping defines human-readable labels, but milestones may fire in
+        // a different order than the mapping (e.g. Trickle ICE candidates arrive early).
+        // We sort recorded milestones by their timestamp so deltas are always positive.
+        val recordedSteps = mutableListOf<Pair<String, Long>>()
         for ((milestone, stepName) in stepMapping) {
             val fromStartMs = milestones[milestone] ?: continue
+            recordedSteps.add(Pair(stepName, fromStartMs))
+        }
+        recordedSteps.sortBy { it.second }
+
+        var previousMs: Long? = null
+        for ((stepName, fromStartMs) in recordedSteps) {
             val deltaMs = if (previousMs != null) fromStartMs - previousMs else null
             previousMs = fromStartMs
 
             val stepPadded = String.format(Locale.US, "%-${stepColumnWidth}s", stepName)
-            val message = if (milestone == MILESTONE_CALL_INITIATED) {
-                // First row: delta is "-", from_start is 0.00ms
+            val message = if (deltaMs == null) {
+                // First row (Call Start): delta is "-"
                 val fromStartStr = String.format(Locale.US, "%.2f", fromStartMs.toDouble())
                 "$prefix $stepPadded${String.format(Locale.US, "%${deltaColumnWidth}s", "-")}        ${fromStartStr}ms"
             } else {
-                val deltaStr = String.format(Locale.US, "%.2f", (deltaMs ?: 0L).toDouble())
+                val deltaStr = String.format(Locale.US, "%.2f", deltaMs.toDouble())
                 val fromStartStr = String.format(Locale.US, "%.2f", fromStartMs.toDouble())
                 "$prefix $stepPadded${String.format(Locale.US, "%${deltaColumnWidth}s", "${deltaStr}ms")}        ${fromStartStr}ms"
             }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
@@ -9,6 +9,7 @@ import com.telnyx.webrtc.sdk.model.LatencyMetricsListener
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
@@ -413,7 +414,7 @@ class LatencyTracker {
         entries.add(
             CallTimingsLogEntry(
                 level = "info",
-                message = "$prefix ${String.format("%-${stepColumnWidth}s", "Step")}${String.format("%${deltaColumnWidth}s", "Delta")}    From Start",
+                message = "$prefix ${String.format(Locale.US, "%-${stepColumnWidth}s", "Step")}${String.format(Locale.US, "%${deltaColumnWidth}s", "Delta")}    From Start",
                 timestamp = timestamp
             )
         )
@@ -432,15 +433,15 @@ class LatencyTracker {
             val deltaMs = if (previousMs != null) fromStartMs - previousMs else null
             previousMs = fromStartMs
 
-            val stepPadded = String.format("%-${stepColumnWidth}s", stepName)
+            val stepPadded = String.format(Locale.US, "%-${stepColumnWidth}s", stepName)
             val message = if (milestone == MILESTONE_CALL_INITIATED) {
                 // First row: delta is "-", from_start is 0.00ms
-                val fromStartStr = String.format("%.2f", fromStartMs.toDouble())
-                "$prefix $stepPadded${String.format("%${deltaColumnWidth}s", "-")}        ${fromStartStr}ms"
+                val fromStartStr = String.format(Locale.US, "%.2f", fromStartMs.toDouble())
+                "$prefix $stepPadded${String.format(Locale.US, "%${deltaColumnWidth}s", "-")}        ${fromStartStr}ms"
             } else {
-                val deltaStr = String.format("%.2f", (deltaMs ?: 0L).toDouble())
-                val fromStartStr = String.format("%.2f", fromStartMs.toDouble())
-                "$prefix $stepPadded${String.format("%${deltaColumnWidth}s", "${deltaStr}ms")}        ${fromStartStr}ms"
+                val deltaStr = String.format(Locale.US, "%.2f", (deltaMs ?: 0L).toDouble())
+                val fromStartStr = String.format(Locale.US, "%.2f", fromStartMs.toDouble())
+                "$prefix $stepPadded${String.format(Locale.US, "%${deltaColumnWidth}s", "${deltaStr}ms")}        ${fromStartStr}ms"
             }
 
             entries.add(

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
@@ -395,6 +395,13 @@ class LatencyTracker {
         val entries = mutableListOf<CallTimingsLogEntry>()
         val timestamp = System.currentTimeMillis()
 
+        // Column widths must match the JS SDK format so the call-report-stats
+        // portal can parse data rows with its regex:
+        //   ~r/^(?<step>.+?)\s{2,}(?<delta>[\d.]+ms|-)\s+(?<from>[\d.]+)ms\s*$/
+        // The key requirement is at least 2 spaces between columns.
+        val stepColumnWidth = 40  // left-padded step name column
+        val deltaColumnWidth = 10  // right-aligned delta column
+
         // Header entries
         entries.add(
             CallTimingsLogEntry(
@@ -406,7 +413,7 @@ class LatencyTracker {
         entries.add(
             CallTimingsLogEntry(
                 level = "info",
-                message = "$prefix Step Delta From Start",
+                message = "$prefix ${String.format("%-${stepColumnWidth}s", "Step")}${String.format("%${deltaColumnWidth}s", "Delta")}    From Start",
                 timestamp = timestamp
             )
         )
@@ -418,19 +425,22 @@ class LatencyTracker {
             )
         )
 
-        // Step entries
+        // Step entries — column-aligned to match JS SDK format
         var previousMs: Long? = null
         for ((milestone, stepName) in stepMapping) {
             val fromStartMs = milestones[milestone] ?: continue
             val deltaMs = if (previousMs != null) fromStartMs - previousMs else null
             previousMs = fromStartMs
 
+            val stepPadded = String.format("%-${stepColumnWidth}s", stepName)
             val message = if (milestone == MILESTONE_CALL_INITIATED) {
-                "$prefix $stepName - ${String.format("%.2f", fromStartMs.toDouble())}ms"
+                // First row: delta is "-", from_start is 0.00ms
+                val fromStartStr = String.format("%.2f", fromStartMs.toDouble())
+                "$prefix $stepPadded${String.format("%${deltaColumnWidth}s", "-")}        ${fromStartStr}ms"
             } else {
                 val deltaStr = String.format("%.2f", (deltaMs ?: 0L).toDouble())
                 val fromStartStr = String.format("%.2f", fromStartMs.toDouble())
-                "$prefix $stepName ${deltaStr}ms ${fromStartStr}ms"
+                "$prefix $stepPadded${String.format("%${deltaColumnWidth}s", "${deltaStr}ms")}        ${fromStartStr}ms"
             }
 
             entries.add(

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
@@ -400,11 +400,11 @@ class LatencyTracker {
         val milestones = state?.milestones?.toMap().orEmpty()
         if (milestones.isEmpty()) return emptyList()
 
-        val direction = if (state.isOutbound) "outbound" else "inbound"
+        val direction = if (state?.isOutbound == true) "outbound" else "inbound"
         val mode = state?.iceMode ?: "trickle"
         val prefix = "[CallTimings][$direction][$mode]"
 
-        val stepMapping = if (state.isOutbound) outboundStepMapping else inboundStepMapping
+        val stepMapping = if (state?.isOutbound == true) outboundStepMapping else inboundStepMapping
         val entries = mutableListOf<CallTimingsLogEntry>()
         val timestamp = System.currentTimeMillis()
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/utilities/LatencyTracker.kt
@@ -222,6 +222,24 @@ class LatencyTracker {
     }
     
     /**
+     * Updates the ICE mode for an existing call tracker.
+     * Use this when the actual ICE mode is determined after tracking has started
+     * (e.g., inbound calls where the mode is set in acceptCall()).
+     * @param callId The call identifier
+     * @param useTrickleIce The actual trickle ICE setting for this call
+     */
+    fun updateIceMode(callId: UUID, useTrickleIce: Boolean) {
+        val state = callTrackers[callId] ?: return
+        val newMode = CallTrackingState(
+            startTime = state.startTime,
+            isOutbound = state.isOutbound,
+            iceMode = if (useTrickleIce) "trickle" else "standard",
+            milestones = state.milestones
+        )
+        callTrackers[callId] = newMode
+    }
+
+    /**
      * Marks when the user initiates answering an inbound call.
      * Call this at the start of acceptCall().
      * @param callId The call identifier

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/utilities/LatencyTrackerTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/utilities/LatencyTrackerTest.kt
@@ -1,0 +1,194 @@
+package com.telnyx.webrtc.sdk.utilities
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.UUID
+import java.util.regex.Pattern
+
+class LatencyTrackerTest {
+
+    private lateinit var tracker: LatencyTracker
+
+    @Before
+    fun setUp() {
+        tracker = LatencyTracker()
+    }
+
+    // ===== ICE Mode Tests =====
+
+    @Test
+    fun `outbound call with trickle ICE reports trickle mode`() {
+        val callId = UUID.randomUUID()
+        tracker.startCallTracking(callId, isOutbound = true, useTrickleIce = true)
+
+        // Simulate some milestones to get a complete call
+        tracker.markCallMilestone(callId, LatencyTracker.MILESTONE_PEER_CREATED)
+        tracker.markCallMilestone(callId, LatencyTracker.MILESTONE_CALL_ACTIVE)
+
+        val logs = tracker.completeCallTracking(callId)
+        assertTrue("Should produce log entries", logs.isNotEmpty())
+        assertTrue(
+            "Should report trickle mode",
+            logs.any { it.message.contains("[trickle]") }
+        )
+    }
+
+    @Test
+    fun `outbound call with standard ICE reports standard mode`() {
+        val callId = UUID.randomUUID()
+        tracker.startCallTracking(callId, isOutbound = true, useTrickleIce = false)
+
+        tracker.markCallMilestone(callId, LatencyTracker.MILESTONE_PEER_CREATED)
+        tracker.markCallMilestone(callId, LatencyTracker.MILESTONE_CALL_ACTIVE)
+
+        val logs = tracker.completeCallTracking(callId)
+        assertTrue(
+            "Should report standard mode",
+            logs.any { it.message.contains("[standard]") }
+        )
+    }
+
+    @Test
+    fun `inbound call with updated ICE mode reports correct mode after acceptCall`() {
+        val callId = UUID.randomUUID()
+
+        // Simulate inbound flow: tracking starts when invite is received
+        // At that point, the client field might still be "standard" from a previous call
+        tracker.startCallTracking(callId, isOutbound = false, useTrickleIce = false)
+        tracker.markInviteReceived(callId)
+
+        // User calls acceptCall with useTrickleIce = true
+        // This should update the tracker's ICE mode
+        tracker.updateIceMode(callId, useTrickleIce = true)
+        tracker.markAnswerInitiated(callId)
+
+        // Complete the call
+        tracker.markCallMilestone(callId, LatencyTracker.MILESTONE_PEER_CREATED)
+        tracker.markCallMilestone(callId, LatencyTracker.MILESTONE_CALL_ACTIVE)
+
+        val logs = tracker.completeCallTracking(callId)
+        assertTrue(
+            "Should report trickle mode after updateIceMode",
+            logs.any { it.message.contains("[trickle]") }
+        )
+        assertTrue(
+            "Should NOT report standard mode",
+            logs.none { it.message.contains("[standard]") }
+        )
+    }
+
+    @Test
+    fun `inbound call with standard ICE after previous trickle call reports standard`() {
+        val previousCallId = UUID.randomUUID()
+
+        // Previous call was trickle
+        tracker.startCallTracking(previousCallId, isOutbound = true, useTrickleIce = true)
+        tracker.completeCallTracking(previousCallId)
+
+        // New inbound call starts - client field still has useTrickleIce=true from previous call
+        val callId = UUID.randomUUID()
+        tracker.startCallTracking(callId, isOutbound = false, useTrickleIce = true)
+        tracker.markInviteReceived(callId)
+
+        // But user answers with standard ICE
+        tracker.updateIceMode(callId, useTrickleIce = false)
+        tracker.markAnswerInitiated(callId)
+
+        tracker.markCallMilestone(callId, LatencyTracker.MILESTONE_PEER_CREATED)
+        tracker.markCallMilestone(callId, LatencyTracker.MILESTONE_CALL_ACTIVE)
+
+        val logs = tracker.completeCallTracking(callId)
+        assertTrue(
+            "Should report standard mode after updateIceMode",
+            logs.any { it.message.contains("[standard]") }
+        )
+    }
+
+    // ===== Call is active milestone =====
+
+    @Test
+    fun `completeCallTracking includes Call is active row`() {
+        val callId = UUID.randomUUID()
+        tracker.startCallTracking(callId, isOutbound = true, useTrickleIce = true)
+
+        // Simulate some milestones
+        tracker.markCallMilestone(callId, LatencyTracker.MILESTONE_PEER_CREATED)
+        tracker.markCallMilestone(callId, LatencyTracker.MILESTONE_CALL_ACTIVE)
+
+        val logs = tracker.completeCallTracking(callId)
+        assertTrue(
+            "Should include 'Call is active' step",
+            logs.any { it.message.contains("Call is active") }
+        )
+    }
+
+    // ===== Portal regex parsing =====
+
+    @Test
+    fun `long step name still has at least 2 spaces before delta`() {
+        val callId = UUID.randomUUID()
+        tracker.startCallTracking(callId, isOutbound = true, useTrickleIce = true)
+
+        // This milestone has a long step name: "First server-reflexive/relay candidate found" (44 chars)
+        tracker.markCallMilestone(callId, LatencyTracker.MILESTONE_FIRST_SRFLX_RELAY_CANDIDATE)
+        tracker.markCallMilestone(callId, LatencyTracker.MILESTONE_CALL_ACTIVE)
+
+        val logs = tracker.completeCallTracking(callId)
+
+        // Portal regex: (?<step>.+?)\s{2,}(?<delta>[\d.]+ms|-)
+        val portalRegex = Pattern.compile("(?<step>.+?)\\s{2,}(?<delta>[\\d.]+ms|-)")
+
+        // Check data rows (skip header, separator, and footer lines)
+        val dataRows = logs.filter {
+            it.message.contains("[CallTimings]") &&
+                !it.message.contains("Step") &&
+                !it.message.contains("---")
+        }
+
+        for (row in dataRows) {
+            // Extract the part after the [CallTimings][direction][mode] prefix
+            val prefixPattern = Pattern.compile("\\[CallTimings]\\[\\w+\\[\\w+]")
+            val matcher = prefixPattern.matcher(row.message)
+            if (matcher.find()) {
+                val rowData = row.message.substring(matcher.end())
+                assertTrue(
+                    "Row data should match portal regex: '$rowData'",
+                    portalRegex.matcher(rowData).find()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `large delta values still parse correctly`() {
+        val callId = UUID.randomUUID()
+        tracker.startCallTracking(callId, isOutbound = true, useTrickleIce = true)
+
+        // Simulate milestones with large time gaps (just mark milestones in order)
+        tracker.markCallMilestone(callId, LatencyTracker.MILESTONE_PEER_CREATED)
+        tracker.markCallMilestone(callId, LatencyTracker.MILESTONE_CALL_ACTIVE)
+
+        val logs = tracker.completeCallTracking(callId)
+
+        // Verify that delta values are properly formatted with ms suffix
+        val dataRows = logs.filter {
+            it.message.contains("[CallTimings]") &&
+                !it.message.contains("Step") &&
+                !it.message.contains("---") &&
+                !it.message.contains("timing breakdown")
+        }
+
+        // Non-first rows should have delta values with "ms" suffix
+        val nonFirstRows = dataRows.filter { !it.message.contains("Call Start") }
+        for (row in nonFirstRows) {
+            // Delta should be a number followed by "ms"
+            val hasDeltaMs = row.message.contains(Regex("\\d+\\.\\d+ms"))
+            assertTrue(
+                "Non-first row should have delta with ms suffix: '${row.message}'",
+                hasDeltaMs
+            )
+        }
+    }
+}


### PR DESCRIPTION
Fixes VSDK-170

Three fixes to make CallTimings data parseable by the Call Report portal:

- **Locale fix**: Use `Locale.US` in `String.format()` so decimals use periods (not commas from Polish locale)
- **Column alignment**: Pad step/delta columns so the portal regex matches 2+ spaces between fields
- **Chronological sort**: Sort milestones by `fromStartMs` before computing deltas to prevent negative values