### PR TITLE
VSDK-331: AND-B21 Android bound cancellable scope in TelnyxCommon.observeConnectionMetrics

### DIFF
--- a/telnyx_common/build.gradle
+++ b/telnyx_common/build.gradle
@@ -62,4 +62,9 @@ dependencies {
     implementation 'androidx.room:room-ktx:2.6.1'
     kapt 'androidx.room:room-compiler:2.6.1'
 
+    testImplementation 'androidx.arch.core:core-testing:2.1.0'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
+    testImplementation deps.mockk.core
+
 }

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxCommon.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxCommon.kt
@@ -14,6 +14,8 @@ import com.telnyx.webrtc.sdk.stats.CallQualityMetrics
 import com.telnyx.webrtc.sdk.stats.ICECandidate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -56,6 +58,7 @@ class TelnyxCommon private constructor() {
      */
     private val _connectionMetrics = MutableStateFlow<SocketConnectionMetrics?>(null)
     val connectionMetrics: StateFlow<SocketConnectionMetrics?> = _connectionMetrics.asStateFlow()
+    private var connectionMetricsScope: CoroutineScope? = null
 
     private val holdStatusObservers: MutableMap<Call, Observer<Boolean>> = mutableMapOf()
 
@@ -187,20 +190,23 @@ class TelnyxCommon private constructor() {
      */
     internal fun getTelnyxClient(context: Context): TelnyxClient {
         return _telnyxClient ?: synchronized(this) {
-            _telnyxClient ?: TelnyxClient(context.applicationContext).also { 
+            _telnyxClient ?: TelnyxClient(context.applicationContext).also {
                 _telnyxClient = it
                 observeConnectionMetrics(it)
             }
         }
     }
-    
+
     /**
      * Observes connection metrics from the TelnyxClient and updates the state flow.
      *
      * @param client The TelnyxClient instance to observe
      */
     private fun observeConnectionMetrics(client: TelnyxClient) {
-        CoroutineScope(Dispatchers.Main).launch {
+        cancelConnectionMetricsObserver()
+        val metricsScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+        connectionMetricsScope = metricsScope
+        metricsScope.launch {
             client.socketConnectionMetricsFlow.collect { metrics ->
                 _connectionMetrics.value = metrics
                 Timber.d("Connection Quality: ${metrics.quality}, Interval: ${metrics.averageIntervalMs}ms, Jitter: ${metrics.jitterMs}ms")
@@ -208,11 +214,18 @@ class TelnyxCommon private constructor() {
         }
     }
 
+    private fun cancelConnectionMetricsObserver() {
+        connectionMetricsScope?.cancel()
+        connectionMetricsScope = null
+    }
+
     /**
      * Resets the singleton `TelnyxClient` instance to null.
      * This forces the client to be re-initialized on the next call to `getTelnyxClient`.
      */
     internal fun resetTelnyxClient() {
+        cancelConnectionMetricsObserver()
+        _connectionMetrics.value = null
         _telnyxClient = null
     }
 

--- a/telnyx_common/src/test/java/com/telnyx/webrtc/common/TelnyxCommonTest.kt
+++ b/telnyx_common/src/test/java/com/telnyx/webrtc/common/TelnyxCommonTest.kt
@@ -1,0 +1,65 @@
+package com.telnyx.webrtc.common
+
+import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.telnyx.webrtc.sdk.model.SocketConnectionMetrics
+import com.telnyx.webrtc.sdk.model.SocketConnectionQuality
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TelnyxCommonTest {
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val telnyxCommon = TelnyxCommon.getInstance()
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        context = mockk(relaxed = true)
+        every { context.applicationContext } returns context
+        telnyxCommon.resetTelnyxClient()
+    }
+
+    @After
+    fun tearDown() {
+        telnyxCommon.resetTelnyxClient()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun resetTelnyxClientCancelsPreviousConnectionMetricsCollector() = runTest(testDispatcher) {
+        val firstClient = telnyxCommon.getTelnyxClient(context)
+        val initialMetrics = SocketConnectionMetrics(quality = SocketConnectionQuality.GOOD)
+
+        firstClient.pingPong(initialMetrics)
+        runCurrent()
+
+        assertEquals(initialMetrics, telnyxCommon.connectionMetrics.value)
+
+        telnyxCommon.resetTelnyxClient()
+
+        assertNull(telnyxCommon.connectionMetrics.value)
+
+        firstClient.pingPong(SocketConnectionMetrics(quality = SocketConnectionQuality.POOR))
+        runCurrent()
+
+        assertNull(telnyxCommon.connectionMetrics.value)
+    }
+}


### PR DESCRIPTION
Ticket: VSDK-331 / AND-B21

## Summary
- Binds `TelnyxCommon` connection metrics collection to a stored cancellable coroutine scope.
- Cancels and clears the metrics collector when `resetTelnyxClient()` resets the singleton client.
- Adds focused unit coverage proving old-client metrics no longer update `TelnyxCommon.connectionMetrics` after reset.

## Behaviors

### Before changes
`TelnyxCommon.observeConnectionMetrics()` launched an untracked `CoroutineScope(Dispatchers.Main)` collector for each client instance, and `resetTelnyxClient()` only nulled the client reference.

### After changes
`TelnyxCommon` stores the metrics collector scope, cancels previous collectors before observing a new client, and cancels the collector when the client is reset while keeping the public `connectionMetrics` surface unchanged.

## Manual testing
1. `./gradlew :telnyx_common:testDebugUnitTest --tests com.telnyx.webrtc.common.TelnyxCommonTest`
2. `./gradlew :samples:xml_app:compileDebugKotlin :samples:compose_app:compileDebugKotlin`

## Notes
- Local planning marks this ticket P0 critical, but no extra manual-device gate is recorded beyond normal CI and review.
