### PR TITLE
VSDK-330: AND-B18 Android MediaPlayer leak in playRingtone uncaught NPE in playRingBackTone

### DIFF
--- a/telnyx_rtc/src/main/AndroidManifest.xml
+++ b/telnyx_rtc/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
    >
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <application>
     </application>
 </manifest>

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1992,18 +1992,20 @@ class TelnyxClient(
                 } else if (it.getRingtoneType() == RAW) {
                     mediaPlayer = MediaPlayer.create(context, it as Int)
                 }
-                mediaPlayer ?: kotlin.run {
+                val player = mediaPlayer ?: kotlin.run {
                     Logger.d(message = "Ringtone not valid:: No ringtone will be played")
                     return
                 }
-                mediaPlayer!!.setWakeMode(context, PowerManager.PARTIAL_WAKE_LOCK)
-                if (mediaPlayer?.isPlaying == false) {
-                    mediaPlayer!!.start()
-                    mediaPlayer!!.isLooping = true
+                player.setWakeMode(context, PowerManager.PARTIAL_WAKE_LOCK)
+                if (!player.isPlaying) {
+                    player.start()
+                    player.isLooping = true
                 }
                 Logger.d(message = "Ringtone playing")
             } catch (e: TypeCastException) {
                 Logger.e(message = "Exception: ${e.message}")
+            } catch (e: IllegalStateException) {
+                releaseMediaPlayerAfterPlaybackFailure(e)
             }
         } ?: run {
             Logger.d(message = "No ringtone specified :: No ringtone will be played")
@@ -2041,15 +2043,29 @@ class TelnyxClient(
     private fun playRingBackTone() {
         rawRingbackTone?.let {
             stopMediaPlayer()
-            mediaPlayer = MediaPlayer.create(context, it)
-            mediaPlayer!!.setWakeMode(context, PowerManager.PARTIAL_WAKE_LOCK)
-            if (mediaPlayer?.isPlaying == false) {
-                mediaPlayer!!.start()
-                mediaPlayer!!.isLooping = true
+            try {
+                mediaPlayer = MediaPlayer.create(context, it)
+                val player = mediaPlayer ?: kotlin.run {
+                    Logger.d(message = "Ringback tone not valid:: No ringback tone will be played")
+                    return
+                }
+                player.setWakeMode(context, PowerManager.PARTIAL_WAKE_LOCK)
+                if (!player.isPlaying) {
+                    player.start()
+                    player.isLooping = true
+                }
+            } catch (e: IllegalStateException) {
+                releaseMediaPlayerAfterPlaybackFailure(e)
             }
         } ?: run {
             Logger.d(message = "No ringtone specified :: No ringtone will be played")
         }
+    }
+
+    private fun releaseMediaPlayerAfterPlaybackFailure(exception: Exception) {
+        Logger.e(message = "Exception: ${exception.message}")
+        mediaPlayer?.release()
+        mediaPlayer = null
     }
 
     /**

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -2004,7 +2004,7 @@ class TelnyxClient(
                 Logger.d(message = "Ringtone playing")
             } catch (e: TypeCastException) {
                 Logger.e(message = "Exception: ${e.message}")
-            } catch (e: IllegalStateException) {
+            } catch (e: RuntimeException) {
                 releaseMediaPlayerAfterPlaybackFailure(e)
             }
         } ?: run {
@@ -2054,7 +2054,7 @@ class TelnyxClient(
                     player.start()
                     player.isLooping = true
                 }
-            } catch (e: IllegalStateException) {
+            } catch (e: RuntimeException) {
                 releaseMediaPlayerAfterPlaybackFailure(e)
             }
         } ?: run {

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -499,6 +499,31 @@ class TelnyxClientTest : BaseTest() {
     }
 
     @Test
+    fun `playRingtone releases media player when runtime setup failure throws`() {
+        val ringtoneResource = 124
+        val mockMediaPlayer = Mockito.mock(MediaPlayer::class.java)
+        Mockito.doThrow(SecurityException("wake lock permission denied"))
+            .`when`(mockMediaPlayer)
+            .setWakeMode(mockContext, PowerManager.PARTIAL_WAKE_LOCK)
+        setTelnyxClientField("rawRingtone", ringtoneResource)
+
+        val mediaPlayerStatic = Mockito.mockStatic(MediaPlayer::class.java)
+        try {
+            mediaPlayerStatic.`when`<MediaPlayer?> {
+                MediaPlayer.create(mockContext, ringtoneResource)
+            }.thenReturn(mockMediaPlayer)
+
+            assertDoesNotThrow {
+                client.playRingtone()
+            }
+        } finally {
+            mediaPlayerStatic.close()
+        }
+
+        Mockito.verify(mockMediaPlayer).release()
+    }
+
+    @Test
     fun `Test playing ringBacktone when one hasn't been set logs error and does not throw exception`() {
         assertDoesNotThrow {
             client = Mockito.spy(TelnyxClient(mockContext))

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -2,10 +2,12 @@ package com.telnyx.webrtc.sdk
 
 import android.content.Context
 import android.media.AudioManager
+import android.media.MediaPlayer
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import android.os.PowerManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.LiveData
@@ -471,11 +473,81 @@ class TelnyxClientTest : BaseTest() {
     }
 
     @Test
+    fun `playRingtone releases media player when start throws`() {
+        val ringtoneResource = 123
+        val mockMediaPlayer = Mockito.mock(MediaPlayer::class.java)
+        Mockito.`when`(mockMediaPlayer.isPlaying).thenReturn(false)
+        Mockito.doThrow(IllegalStateException("start failed"))
+            .`when`(mockMediaPlayer)
+            .start()
+        setTelnyxClientField("rawRingtone", ringtoneResource)
+
+        val mediaPlayerStatic = Mockito.mockStatic(MediaPlayer::class.java)
+        try {
+            mediaPlayerStatic.`when`<MediaPlayer?> {
+                MediaPlayer.create(mockContext, ringtoneResource)
+            }.thenReturn(mockMediaPlayer)
+
+            assertDoesNotThrow {
+                client.playRingtone()
+            }
+        } finally {
+            mediaPlayerStatic.close()
+        }
+
+        Mockito.verify(mockMediaPlayer).release()
+    }
+
+    @Test
     fun `Test playing ringBacktone when one hasn't been set logs error and does not throw exception`() {
         assertDoesNotThrow {
             client = Mockito.spy(TelnyxClient(mockContext))
-            client.playRingtone()
+            invokePlayRingBackTone()
         }
+    }
+
+    @Test
+    fun `playRingBackTone does not throw when media player creation returns null`() {
+        val ringbackToneResource = 456
+        setTelnyxClientField("rawRingbackTone", ringbackToneResource)
+
+        val mediaPlayerStatic = Mockito.mockStatic(MediaPlayer::class.java)
+        try {
+            mediaPlayerStatic.`when`<MediaPlayer?> {
+                MediaPlayer.create(mockContext, ringbackToneResource)
+            }.thenReturn(null)
+
+            assertDoesNotThrow {
+                invokePlayRingBackTone()
+            }
+        } finally {
+            mediaPlayerStatic.close()
+        }
+    }
+
+    @Test
+    fun `playRingBackTone releases media player when setWakeMode throws`() {
+        val ringbackToneResource = 789
+        val mockMediaPlayer = Mockito.mock(MediaPlayer::class.java)
+        Mockito.doThrow(IllegalStateException("wake mode failed"))
+            .`when`(mockMediaPlayer)
+            .setWakeMode(mockContext, PowerManager.PARTIAL_WAKE_LOCK)
+        setTelnyxClientField("rawRingbackTone", ringbackToneResource)
+
+        val mediaPlayerStatic = Mockito.mockStatic(MediaPlayer::class.java)
+        try {
+            mediaPlayerStatic.`when`<MediaPlayer?> {
+                MediaPlayer.create(mockContext, ringbackToneResource)
+            }.thenReturn(mockMediaPlayer)
+
+            assertDoesNotThrow {
+                invokePlayRingBackTone()
+            }
+        } finally {
+            mediaPlayerStatic.close()
+        }
+
+        Mockito.verify(mockMediaPlayer).release()
     }
 
     @Test
@@ -780,5 +852,19 @@ class TelnyxClientTest : BaseTest() {
 
         @Suppress("UNCHECKED_CAST")
         return data as T
+    }
+
+    private fun setTelnyxClientField(fieldName: String, value: Any?) {
+        TelnyxClient::class.java.getDeclaredField(fieldName).apply {
+            isAccessible = true
+            set(client, value)
+        }
+    }
+
+    private fun invokePlayRingBackTone() {
+        TelnyxClient::class.java.getDeclaredMethod("playRingBackTone").apply {
+            isAccessible = true
+            invoke(client)
+        }
     }
 }


### PR DESCRIPTION
Ticket: VSDK-330 / AND-B18

## Summary
- Adds the SDK `WAKE_LOCK` manifest permission required by `MediaPlayer.setWakeMode(...)`.
- Releases the current ringtone/ringback `MediaPlayer` when playback setup fails.
- Guards `playRingBackTone` against `MediaPlayer.create(...)` returning null.
- Adds focused `TelnyxClientTest` regression coverage for ringtone/ringback failure paths.

## Behaviors

### Before changes
`playRingtone` could leak a created `MediaPlayer` when playback setup threw, while `playRingBackTone` force-unwrapped `MediaPlayer.create(...)` and could crash or leak on setup failure.

### After changes
Ringtone and ringback playback use a checked local player before setup, release and clear the current player on failure, and log/return cleanly when ringback player creation returns null.

## Manual testing
1. `./gradlew :telnyx_rtc:testDebugUnitTest --tests com.telnyx.webrtc.sdk.TelnyxClientTest`
2. `./gradlew :telnyx_rtc:detekt`
3. `git diff --check`

## Notes
- Local planning marks this ticket P0 critical, but no extra manual-device gate is recorded beyond normal CI and review.
