### PR TITLE
VSDK-332: cancel decline service scope

### DIFF
--- a/docs-markdown/push-notification/app-setup.md
+++ b/docs-markdown/push-notification/app-setup.md
@@ -153,7 +153,11 @@ telnyxClient = TelnyxClient(context)
 val credentialConfig = CredentialConfig(
     sipUser = username,
     sipPassword = password,
-    fcmToken = fcmToken
+    sipCallerIDName = null,
+    sipCallerIDNumber = null,
+    fcmToken = fcmToken,
+    ringtone = null,
+    ringBackTone = null
 )
 
 telnyxClient.connect(

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/BackgroundCallDeclineService.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/BackgroundCallDeclineService.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -138,9 +139,12 @@ class BackgroundCallDeclineService : Service() {
 
                     // Observe socket responses to handle login success - must be done on main thread
                     operation.socketStatusJob = launch(Dispatchers.Main) {
-                        telnyxClient.socketResponseFlow.collectLatest { response ->
-                            handleSocketResponse(response, operation)
-                        }
+                        val replayedResponseCount = telnyxClient.socketResponseFlow.replayCache.size
+                        telnyxClient.socketResponseFlow
+                            .drop(replayedResponseCount)
+                            .collectLatest { response ->
+                                handleSocketResponse(response, operation)
+                            }
                     }
 
                     // Connect with decline_push parameter

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/BackgroundCallDeclineService.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/BackgroundCallDeclineService.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -87,8 +86,10 @@ class BackgroundCallDeclineService : Service() {
         }
 
         fun disconnectClient(reason: String) {
+            val client = telnyxClient ?: return
+            telnyxClient = null
             try {
-                telnyxClient?.disconnect()
+                client.disconnect()
             } catch (e: Exception) {
                 Timber.e(e, "Failed to disconnect background decline client: $reason")
             }
@@ -134,11 +135,10 @@ class BackgroundCallDeclineService : Service() {
 
         operation.operationJob = serviceScope.launch {
             try {
-                val telnyxClient = TelnyxClient(applicationContext)
-                operation.telnyxClient = telnyxClient
-
                 ProfileManager.getProfilesList(this@BackgroundCallDeclineService).lastOrNull()?.let { lastProfile ->
                     val fcmToken = lastProfile.fcmToken ?: ""
+                    val telnyxClient = TelnyxClient(applicationContext)
+                    operation.telnyxClient = telnyxClient
 
                     // Set up timeout to ensure service doesn't run indefinitely
                     operation.timeoutJob = launch {
@@ -149,9 +149,7 @@ class BackgroundCallDeclineService : Service() {
 
                     // Observe socket responses to handle login success - must be done on main thread
                     operation.socketStatusJob = launch(Dispatchers.Main) {
-                        val replayedResponseCount = telnyxClient.socketResponseFlow.replayCache.size
                         telnyxClient.socketResponseFlow
-                            .drop(replayedResponseCount)
                             .collectLatest { response ->
                                 handleSocketResponse(response, operation)
                             }
@@ -166,25 +164,31 @@ class BackgroundCallDeclineService : Service() {
                     if (!lastProfile.sipToken.isNullOrEmpty()) {
                         telnyxClient.connectWithDeclinePush(
                             serverConfigurationFor(lastProfile.isDev),
-                            lastProfile.toTokenConfig(fcmToken),
+                            lastProfile.toTokenConfig(fcmToken).copy(autoReconnect = false),
                             txPushMetaData
                         )
                     } else {
                         telnyxClient.connectWithDeclinePush(
                             serverConfigurationFor(lastProfile.isDev),
-                            lastProfile.toCredentialConfig(fcmToken),
+                            lastProfile.toCredentialConfig(fcmToken).copy(autoReconnect = false),
                             txPushMetaData
                         )
                     }
+
+                    if (!isActiveOperation(operation)) {
+                        Timber.d("Disconnecting superseded background decline startId=${operation.startId}")
+                        operation.disconnectClient("Superseded after background decline connect")
+                        return@launch
+                    }
                 } ?: run {
                     Timber.w("No profile found, stopping service")
-                    finishAndStop(operation, "No profile found", disconnect = false)
+                    finishAndStop(operation, "No profile found")
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 Timber.e(e, "Error during background decline operation")
-                finishAndStop(operation, "Error during background decline operation", disconnect = false)
+                finishAndStop(operation, "Error during background decline operation")
             }
         }
     }
@@ -251,10 +255,8 @@ class BackgroundCallDeclineService : Service() {
                 operation.timeoutJob?.cancel()
                 operation.socketStatusJob?.cancel()
 
-                if (disconnect && isActiveOperation(operation)) {
+                if (disconnect) {
                     operation.disconnectClient(reason)
-                } else if (disconnect) {
-                    Timber.d("Skipping disconnect for superseded background decline startId=${operation.startId}")
                 }
 
                 Timber.d("$reason, stopping service for startId=${operation.startId}")

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/BackgroundCallDeclineService.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/BackgroundCallDeclineService.kt
@@ -137,8 +137,20 @@ class BackgroundCallDeclineService : Service() {
             try {
                 ProfileManager.getProfilesList(this@BackgroundCallDeclineService).lastOrNull()?.let { lastProfile ->
                     val fcmToken = lastProfile.fcmToken ?: ""
-                    val telnyxClient = TelnyxClient(applicationContext)
+
+                    if (!isActiveOperation(operation)) {
+                        Timber.d("Skipping client creation for superseded background decline startId=${operation.startId}")
+                        return@launch
+                    }
+
+                    val telnyxClient = TelnyxClient.createDeclinePushClient(applicationContext)
                     operation.telnyxClient = telnyxClient
+
+                    if (!isActiveOperation(operation)) {
+                        Timber.d("Disconnecting superseded background decline startId=${operation.startId}")
+                        operation.disconnectClient("Superseded after background decline client creation")
+                        return@launch
+                    }
 
                     // Set up timeout to ensure service doesn't run indefinitely
                     operation.timeoutJob = launch {

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/BackgroundCallDeclineService.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/BackgroundCallDeclineService.kt
@@ -184,6 +184,11 @@ class BackgroundCallDeclineService : Service() {
                 "Superseding background decline startId=${previous.startId} with startId=${operation.startId}"
             )
             previous.cancel("Superseded by newer background decline startId=${operation.startId}")
+            try {
+                TelnyxCommon.getInstance().getTelnyxClient(this@BackgroundCallDeclineService).disconnect()
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to disconnect superseded background decline socket")
+            }
             stopServiceForStart(previous.startId, "Superseded by newer background decline")
         }
     }

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/BackgroundCallDeclineService.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/BackgroundCallDeclineService.kt
@@ -10,9 +10,9 @@ import android.content.Intent
 import android.os.IBinder
 import com.google.gson.Gson
 import com.telnyx.webrtc.common.ProfileManager
-import com.telnyx.webrtc.common.TelnyxCommon
 import com.telnyx.webrtc.common.util.toCredentialConfig
 import com.telnyx.webrtc.common.util.toTokenConfig
+import com.telnyx.webrtc.sdk.TelnyxClient
 import com.telnyx.webrtc.sdk.model.PushMetaData
 import com.telnyx.webrtc.sdk.model.SocketMethod
 import com.telnyx.webrtc.sdk.model.SocketStatus
@@ -66,6 +66,7 @@ class BackgroundCallDeclineService : Service() {
         var timeoutJob: Job? = null
         var socketStatusJob: Job? = null
         var disconnectJob: Job? = null
+        var telnyxClient: TelnyxClient? = null
         private var isCompleting = false
 
         fun markCompleting(): Boolean = synchronized(this) {
@@ -83,6 +84,14 @@ class BackgroundCallDeclineService : Service() {
             timeoutJob?.cancel(cancellation)
             socketStatusJob?.cancel(cancellation)
             disconnectJob?.cancel(cancellation)
+        }
+
+        fun disconnectClient(reason: String) {
+            try {
+                telnyxClient?.disconnect()
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to disconnect background decline client: $reason")
+            }
         }
     }
 
@@ -125,7 +134,8 @@ class BackgroundCallDeclineService : Service() {
 
         operation.operationJob = serviceScope.launch {
             try {
-                val telnyxClient = TelnyxCommon.getInstance().getTelnyxClient(this@BackgroundCallDeclineService)
+                val telnyxClient = TelnyxClient(applicationContext)
+                operation.telnyxClient = telnyxClient
 
                 ProfileManager.getProfilesList(this@BackgroundCallDeclineService).lastOrNull()?.let { lastProfile ->
                     val fcmToken = lastProfile.fcmToken ?: ""
@@ -145,6 +155,11 @@ class BackgroundCallDeclineService : Service() {
                             .collectLatest { response ->
                                 handleSocketResponse(response, operation)
                             }
+                    }
+
+                    if (!isActiveOperation(operation)) {
+                        Timber.d("Skipping connect for superseded background decline startId=${operation.startId}")
+                        return@launch
                     }
 
                     // Connect with decline_push parameter
@@ -184,11 +199,7 @@ class BackgroundCallDeclineService : Service() {
                 "Superseding background decline startId=${previous.startId} with startId=${operation.startId}"
             )
             previous.cancel("Superseded by newer background decline startId=${operation.startId}")
-            try {
-                TelnyxCommon.getInstance().getTelnyxClient(this@BackgroundCallDeclineService).disconnect()
-            } catch (e: Exception) {
-                Timber.e(e, "Failed to disconnect superseded background decline socket")
-            }
+            previous.disconnectClient("Superseded by newer background decline")
             stopServiceForStart(previous.startId, "Superseded by newer background decline")
         }
     }
@@ -241,8 +252,7 @@ class BackgroundCallDeclineService : Service() {
                 operation.socketStatusJob?.cancel()
 
                 if (disconnect && isActiveOperation(operation)) {
-                    val telnyxClient = TelnyxCommon.getInstance().getTelnyxClient(this@BackgroundCallDeclineService)
-                    telnyxClient.disconnect()
+                    operation.disconnectClient(reason)
                 } else if (disconnect) {
                     Timber.d("Skipping disconnect for superseded background decline startId=${operation.startId}")
                 }
@@ -288,7 +298,10 @@ class BackgroundCallDeclineService : Service() {
         super.onDestroy()
         synchronized(operationLock) {
             activeOperation.also { activeOperation = null }
-        }?.cancel("BackgroundCallDeclineService onDestroy")
+        }?.let { operation ->
+            operation.cancel("BackgroundCallDeclineService onDestroy")
+            operation.disconnectClient("BackgroundCallDeclineService onDestroy")
+        }
         serviceScope.cancel(CancellationException("BackgroundCallDeclineService onDestroy"))
 
         Timber.d("BackgroundCallDeclineService destroyed")

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/BackgroundCallDeclineService.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/BackgroundCallDeclineService.kt
@@ -20,14 +20,16 @@ import com.telnyx.webrtc.sdk.model.TxServerConfiguration
 import com.telnyx.webrtc.sdk.verto.receive.LoginResponse
 import com.telnyx.webrtc.sdk.verto.receive.ReceivedMessageBody
 import com.telnyx.webrtc.sdk.verto.receive.SocketResponse
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import androidx.lifecycle.Observer
-import kotlinx.coroutines.flow.collectLatest
 
 /**
  * Background service for handling call decline without launching the main application.
@@ -54,9 +56,34 @@ class BackgroundCallDeclineService : Service() {
         }
     }
 
-    private val serviceScope = CoroutineScope(Dispatchers.IO + Job())
-    private var timeoutJob: Job? = null
-    private var socketStatusJob: Job? = null
+    private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val operationLock = Any()
+    private var activeOperation: DeclineOperation? = null
+
+    private class DeclineOperation(val startId: Int) {
+        var operationJob: Job? = null
+        var timeoutJob: Job? = null
+        var socketStatusJob: Job? = null
+        var disconnectJob: Job? = null
+        private var isCompleting = false
+
+        fun markCompleting(): Boolean = synchronized(this) {
+            if (isCompleting) {
+                false
+            } else {
+                isCompleting = true
+                true
+            }
+        }
+
+        fun cancel(reason: String) {
+            val cancellation = CancellationException(reason)
+            operationJob?.cancel(cancellation)
+            timeoutJob?.cancel(cancellation)
+            socketStatusJob?.cancel(cancellation)
+            disconnectJob?.cancel(cancellation)
+        }
+    }
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -76,10 +103,10 @@ class BackgroundCallDeclineService : Service() {
         }
 
         if (txPushMetadata != null) {
-            performBackgroundDecline(txPushMetadataJson)
+            performBackgroundDecline(txPushMetadataJson, startId)
         } else {
             Timber.w("No push metadata provided, stopping service")
-            stopSelf()
+            stopServiceForStart(startId, "No push metadata provided")
         }
 
         return START_NOT_STICKY
@@ -89,26 +116,30 @@ class BackgroundCallDeclineService : Service() {
      * Performs the background call decline operation.
      *
      * @param txPushMetaData The push metadata as JSON string.
+     * @param startId The service start id associated with this decline request.
      */
-    private fun performBackgroundDecline(txPushMetaData: String?) {
-        serviceScope.launch {
+    private fun performBackgroundDecline(txPushMetaData: String?, startId: Int) {
+        val operation = DeclineOperation(startId)
+        activateOperation(operation)
+
+        operation.operationJob = serviceScope.launch {
             try {
                 val telnyxClient = TelnyxCommon.getInstance().getTelnyxClient(this@BackgroundCallDeclineService)
-                
+
                 ProfileManager.getProfilesList(this@BackgroundCallDeclineService).lastOrNull()?.let { lastProfile ->
                     val fcmToken = lastProfile.fcmToken ?: ""
 
                     // Set up timeout to ensure service doesn't run indefinitely
-                    timeoutJob = launch {
+                    operation.timeoutJob = launch {
                         delay(CONNECTION_TIMEOUT_MS)
                         Timber.w("Background decline operation timed out")
-                        disconnectAndStop()
+                        finishAndStop(operation, "Background decline operation timed out")
                     }
 
                     // Observe socket responses to handle login success - must be done on main thread
-                    socketStatusJob = launch(Dispatchers.Main) {
+                    operation.socketStatusJob = launch(Dispatchers.Main) {
                         telnyxClient.socketResponseFlow.collectLatest { response ->
-                            handleSocketResponse(response)
+                            handleSocketResponse(response, operation)
                         }
                     }
 
@@ -128,12 +159,28 @@ class BackgroundCallDeclineService : Service() {
                     }
                 } ?: run {
                     Timber.w("No profile found, stopping service")
-                    stopSelf()
+                    finishAndStop(operation, "No profile found", disconnect = false)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Timber.e(e, "Error during background decline operation")
-                stopSelf()
+                finishAndStop(operation, "Error during background decline operation", disconnect = false)
             }
+        }
+    }
+
+    private fun activateOperation(operation: DeclineOperation) {
+        val previousOperation = synchronized(operationLock) {
+            activeOperation.also { activeOperation = operation }
+        }
+
+        previousOperation?.let { previous ->
+            Timber.d(
+                "Superseding background decline startId=${previous.startId} with startId=${operation.startId}"
+            )
+            previous.cancel("Superseded by newer background decline startId=${operation.startId}")
+            stopServiceForStart(previous.startId, "Superseded by newer background decline")
         }
     }
 
@@ -141,8 +188,9 @@ class BackgroundCallDeclineService : Service() {
      * Handles socket responses during the decline operation.
      *
      * @param response The socket response.
+     * @param operation The decline operation associated with this response collector.
      */
-    private fun handleSocketResponse(response: SocketResponse<ReceivedMessageBody>) {
+    private fun handleSocketResponse(response: SocketResponse<ReceivedMessageBody>, operation: DeclineOperation) {
         when (response.status) {
             SocketStatus.MESSAGERECEIVED -> {
                 if (response.data?.method == SocketMethod.LOGIN.methodName) {
@@ -150,13 +198,13 @@ class BackgroundCallDeclineService : Service() {
                     if (loginResponse != null) {
                         Timber.d("Login successful for decline operation, disconnecting")
                         // Login successful, now disconnect
-                        disconnectAndStop()
+                        finishAndStop(operation, "Background decline operation completed")
                     }
                 }
             }
             SocketStatus.ERROR -> {
                 Timber.e("Socket error during decline operation: ${response.errorMessage}")
-                disconnectAndStop()
+                finishAndStop(operation, "Socket error during decline operation")
             }
             else -> {
                 // Handle other statuses if needed
@@ -168,21 +216,55 @@ class BackgroundCallDeclineService : Service() {
     /**
      * Disconnects from the socket and stops the service.
      */
-    private fun disconnectAndStop() {
-        serviceScope.launch {
+    private fun finishAndStop(
+        operation: DeclineOperation,
+        reason: String,
+        disconnect: Boolean = true
+    ) {
+        if (!operation.markCompleting()) {
+            Timber.d("Ignoring duplicate finish for background decline startId=${operation.startId}")
+            return
+        }
+
+        operation.disconnectJob = serviceScope.launch {
             try {
-                timeoutJob?.cancel()
-                socketStatusJob?.cancel()
-                val telnyxClient = TelnyxCommon.getInstance().getTelnyxClient(this@BackgroundCallDeclineService)
-                telnyxClient.disconnect()
-                
-                Timber.d("Background decline operation completed, stopping service")
+                operation.timeoutJob?.cancel()
+                operation.socketStatusJob?.cancel()
+
+                if (disconnect && isActiveOperation(operation)) {
+                    val telnyxClient = TelnyxCommon.getInstance().getTelnyxClient(this@BackgroundCallDeclineService)
+                    telnyxClient.disconnect()
+                } else if (disconnect) {
+                    Timber.d("Skipping disconnect for superseded background decline startId=${operation.startId}")
+                }
+
+                Timber.d("$reason, stopping service for startId=${operation.startId}")
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Timber.e(e, "Error during disconnect")
             } finally {
-                stopSelf()
+                clearActiveOperation(operation)
+                stopServiceForStart(operation.startId, reason)
             }
         }
+    }
+
+    private fun isActiveOperation(operation: DeclineOperation): Boolean = synchronized(operationLock) {
+        activeOperation === operation
+    }
+
+    private fun clearActiveOperation(operation: DeclineOperation) {
+        synchronized(operationLock) {
+            if (activeOperation === operation) {
+                activeOperation = null
+            }
+        }
+    }
+
+    private fun stopServiceForStart(startId: Int, reason: String) {
+        val stopped = stopSelfResult(startId)
+        Timber.d("stopSelfResult($startId)=$stopped: $reason")
     }
 
     private fun serverConfigurationFor(isDev: Boolean): TxServerConfiguration {
@@ -195,9 +277,11 @@ class BackgroundCallDeclineService : Service() {
 
     override fun onDestroy() {
         super.onDestroy()
-        timeoutJob?.cancel()
-        socketStatusJob?.cancel()
-        
+        synchronized(operationLock) {
+            activeOperation.also { activeOperation = null }
+        }?.cancel("BackgroundCallDeclineService onDestroy")
+        serviceScope.cancel(CancellationException("BackgroundCallDeclineService onDestroy"))
+
         Timber.d("BackgroundCallDeclineService destroyed")
     }
 }

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/BackgroundCallDeclineService.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/BackgroundCallDeclineService.kt
@@ -87,7 +87,13 @@ class BackgroundCallDeclineService : Service() {
 
         fun disconnectClient(reason: String) {
             val client = telnyxClient ?: return
-            telnyxClient = null
+            disconnectClient(client, reason)
+        }
+
+        fun disconnectClient(client: TelnyxClient, reason: String) {
+            if (telnyxClient === client) {
+                telnyxClient = null
+            }
             try {
                 client.disconnect()
             } catch (e: Exception) {
@@ -148,7 +154,7 @@ class BackgroundCallDeclineService : Service() {
 
                     if (!isActiveOperation(operation)) {
                         Timber.d("Disconnecting superseded background decline startId=${operation.startId}")
-                        operation.disconnectClient("Superseded after background decline client creation")
+                        operation.disconnectClient(telnyxClient, "Superseded after background decline client creation")
                         return@launch
                     }
 
@@ -189,7 +195,7 @@ class BackgroundCallDeclineService : Service() {
 
                     if (!isActiveOperation(operation)) {
                         Timber.d("Disconnecting superseded background decline startId=${operation.startId}")
-                        operation.disconnectClient("Superseded after background decline connect")
+                        operation.disconnectClient(telnyxClient, "Superseded after background decline connect")
                         return@launch
                     }
                 } ?: run {

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/CallNotificationReceiver.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/notification/CallNotificationReceiver.kt
@@ -83,9 +83,6 @@ class CallNotificationReceiver : BroadcastReceiver() {
 
     private fun handleRejectCall(context: Context, txPushMetadata: PushMetaData?) {
         txPushMetadata?.let {
-            // Set handling push to true to prevent disconnect
-            TelnyxCommon.getInstance().setHandlingPush(true)
-
             // Use background service to decline the call without launching the app
             BackgroundCallDeclineService.startService(context, txPushMetadata)
             

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -56,9 +56,11 @@ import kotlin.concurrent.timerTask
  *
  * @param context the Context that the application is using
  */
-class TelnyxClient(
+class TelnyxClient private constructor(
     var context: Context,
+    startsInDeclinePushMode: Boolean,
 ) : TxSocketListener {
+    constructor(context: Context) : this(context, false)
 
     internal var webRTCReportersMap: ConcurrentHashMap<UUID, WebRTCReporter> =
         ConcurrentHashMap<UUID, WebRTCReporter>()
@@ -103,6 +105,9 @@ class TelnyxClient(
      * Companion object containing constant values used throughout the client.
      */
     companion object {
+        fun createDeclinePushClient(context: Context): TelnyxClient =
+            TelnyxClient(context, true)
+
         /** Number of times to retry registration */
         const val RETRY_REGISTER_TIME = 3
 
@@ -153,7 +158,7 @@ class TelnyxClient(
     private var gatewayResponseTimer: Timer? = null
     private var waitingForReg = true
     @Volatile
-    private var isDeclinePushConnection = false
+    private var isDeclinePushConnection = startsInDeclinePushMode
     private var registrationRetryCounter = 0
     private var connectRetryCounter = 0
     private var gatewayState = "idle"
@@ -1093,7 +1098,9 @@ class TelnyxClient(
             host_address = Config.TELNYX_PROD_HOST_ADDRESS,
             port = Config.TELNYX_PORT
         )
-        registerNetworkCallback()
+        if (!isDeclinePushConnection) {
+            registerNetworkCallback()
+        }
     }
 
     private var rawRingtone: Any? = null

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1460,7 +1460,6 @@ class TelnyxClient private constructor(
         config: TelnyxConfig,
         txPushMetaData: String? = null,
     ) {
-        isDeclinePushConnection = true
         emitSocketResponse(SocketResponse.initialised())
         waitingForReg = true
         invalidateGatewayResponseTimer()

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1196,6 +1196,7 @@ class TelnyxClient private constructor(
             providedServerConfig.host
         }
 
+        socket.destroy()
         socket = TxSocket(
             host_address = providedHostAddress!!,
             port = providedServerConfig.port
@@ -1262,6 +1263,7 @@ class TelnyxClient private constructor(
         if (credentialConfig.region != Region.AUTO)
             providedHostAddress = "${credentialConfig.region.value}.$providedHostAddress"
 
+        socket.destroy()
         socket = TxSocket(
             host_address = providedHostAddress!!,
             port = providedServerConfig.port
@@ -1350,6 +1352,7 @@ class TelnyxClient private constructor(
         if (tokenConfig.region != Region.AUTO)
             providedHostAddress = "${tokenConfig.region.value}.$providedHostAddress"
 
+        socket.destroy()
         socket = TxSocket(
             host_address = providedHostAddress!!,
             port = providedServerConfig.port
@@ -1395,6 +1398,7 @@ class TelnyxClient private constructor(
             }
         } else {
             emitSocketResponse(SocketResponse.error("No Network Connection", null))
+            clearTransientDeclinePushMode()
         }
     }
 
@@ -1430,6 +1434,7 @@ class TelnyxClient private constructor(
 
         providedHostAddress = providedServerConfig.host
 
+        socket.destroy()
         socket = TxSocket(
             host_address = providedHostAddress!!,
             port = providedServerConfig.port
@@ -1462,12 +1467,14 @@ class TelnyxClient private constructor(
             }
         } else {
             emitSocketResponse(SocketResponse.error("No Network Connection", null))
+            clearTransientDeclinePushMode()
         }
     }
 
     /**
      * Connects to the socket with decline_push parameter for background call decline.
      * This method is specifically designed for declining calls without launching the main app.
+     * Use [createDeclinePushClient] so decline work is isolated from the normal SDK client.
      *
      * @param providedServerConfig The server configuration for connection
      * @param config The configuration for login (either CredentialConfig or TokenConfig)
@@ -1478,6 +1485,16 @@ class TelnyxClient private constructor(
         config: TelnyxConfig,
         txPushMetaData: String? = null,
     ) {
+        if (!isDedicatedDeclinePushClient) {
+            emitSocketResponse(
+                SocketResponse.error(
+                    "connectWithDeclinePush requires a dedicated decline push client",
+                    null
+                )
+            )
+            return
+        }
+
         isDeclinePushConnection = true
         val declineConfig = when (config) {
             is CredentialConfig -> config.copy(autoReconnect = false)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -144,6 +144,7 @@ class TelnyxClient private constructor(
 
     // Counter for reconnection retries when server closes connection during reconnection
     private var reconnectionRetryCounter = AtomicInteger(0)
+    private val connectionGeneration = AtomicInteger(0)
 
     // Owns TelnyxClient-level async work; TxSocket owns its socket connection scope.
     private val clientScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -1028,23 +1029,25 @@ class TelnyxClient private constructor(
             return@withContext
         }
 
-        // Create new socket connection
-        socketReconnection = TxSocket(
+        val generation = nextConnectionGeneration()
+        val reconnectSocket = TxSocket(
             socket.host_address,
             socket.port
         )
         cancelSocketConnectJob()
+        socketReconnection = reconnectSocket
         // Cancel old socket coroutines
         socket.cancel("TxSocket destroyed, initializing new socket and connecting.")
         // Destroy old socket
         socket.destroy()
         launchSocketConnect {
-            if (isDeclinePushConnection) {
+            if (isDeclinePushConnection || connectionGeneration.get() != generation) {
+                reconnectSocket.destroy()
                 return@launchSocketConnect
             }
 
             // Socket is now the reconnectionSocket
-            socket = socketReconnection!!
+            socket = reconnectSocket
 
             if (providedHostAddress == null) {
                 providedHostAddress =
@@ -1063,12 +1066,11 @@ class TelnyxClient private constructor(
             }
 
             // Connect to new socket
-            socket.connect(
-                listener = this@TelnyxClient,
-                providedHostAddress = providedHostAddress,
-                providedPort = providedPort,
-                pushmetaData = pushMetaData
-            ) {
+            reconnectSocket.connect(this@TelnyxClient, providedHostAddress, providedPort, pushMetaData) socketConnect@ {
+                if (!isCurrentConnectionGeneration(generation, reconnectSocket)) {
+                    return@socketConnect
+                }
+
                 //We can safely assume that the socket is connected at this point
                 // Login with stored configuration
                 credentialSessionConfig?.let {
@@ -1076,7 +1078,7 @@ class TelnyxClient private constructor(
                 } ?: tokenLogin(tokenSessionConfig!!)
 
                 // Change an ongoing call's socket to the new socket.
-                call?.let { call?.socket = socket }
+                call?.let { call?.socket = reconnectSocket }
             }
         }
     }
@@ -1156,6 +1158,12 @@ class TelnyxClient private constructor(
         }
     }
 
+    private fun nextConnectionGeneration(): Int = connectionGeneration.incrementAndGet()
+
+    private fun isCurrentConnectionGeneration(generation: Int, txSocket: TxSocket): Boolean {
+        return connectionGeneration.get() == generation && socket === txSocket
+    }
+
     private fun disconnectTransientDeclinePushConnection() {
         if (isDeclinePushConnection && !isDedicatedDeclinePushClient) {
             disconnect()
@@ -1196,11 +1204,13 @@ class TelnyxClient private constructor(
             providedServerConfig.host
         }
 
+        val generation = nextConnectionGeneration()
         socket.destroy()
-        socket = TxSocket(
+        val connectSocket = TxSocket(
             host_address = providedHostAddress!!,
             port = providedServerConfig.port
         )
+        socket = connectSocket
 
         providedPort = providedServerConfig.port
         providedTurn = providedServerConfig.turn
@@ -1208,12 +1218,10 @@ class TelnyxClient private constructor(
         if (ConnectivityHelper.isNetworkEnabled(context)) {
             Logger.d(message = "Provided Host Address: $providedHostAddress")
             launchSocketConnect {
-                socket.connect(
-                    listener = this@TelnyxClient,
-                    providedHostAddress = providedHostAddress,
-                    providedPort = providedPort,
-                    pushmetaData = pushMetaData
-                ) {
+                connectSocket.connect(this, providedHostAddress, providedPort, pushMetaData) socketConnect@ {
+                    if (!isCurrentConnectionGeneration(generation, connectSocket)) {
+                        return@socketConnect
+                    }
                 }
             }
         } else {
@@ -1263,11 +1271,13 @@ class TelnyxClient private constructor(
         if (credentialConfig.region != Region.AUTO)
             providedHostAddress = "${credentialConfig.region.value}.$providedHostAddress"
 
+        val generation = nextConnectionGeneration()
         socket.destroy()
-        socket = TxSocket(
+        val connectSocket = TxSocket(
             host_address = providedHostAddress!!,
             port = providedServerConfig.port
         )
+        socket = connectSocket
 
         providedPort = providedServerConfig.port
         providedTurn = providedServerConfig.turn
@@ -1276,12 +1286,22 @@ class TelnyxClient private constructor(
             Logger.d(message = "Provided Host Address: $providedHostAddress")
 
             launchSocketConnect {
+                if (!isCurrentConnectionGeneration(generation, connectSocket)) {
+                    connectSocket.destroy()
+                    return@launchSocketConnect
+                }
+
                 if (credentialConfig.fallbackOnRegionFailure) {
                     providedHostAddress = ConnectivityHelper.resolveReachableHost(
                         providedHostAddress!!,
                         providedPort!!
                     )
                     Logger.d(message = "Verified Host Address: $providedHostAddress")
+                }
+
+                if (!isCurrentConnectionGeneration(generation, connectSocket)) {
+                    connectSocket.destroy()
+                    return@launchSocketConnect
                 }
 
                 if (txPushMetaData != null) {
@@ -1295,13 +1315,8 @@ class TelnyxClient private constructor(
                         voiceSdkId = voiceSDKID
                     )
                 }
-                socket.connect(
-                    listener = this@TelnyxClient,
-                    providedHostAddress = providedHostAddress,
-                    providedPort = providedPort,
-                    pushmetaData = pushMetaData
-                ) {
-                    if (autoLogin) {
+                connectSocket.connect(this@TelnyxClient, providedHostAddress, providedPort, pushMetaData) {
+                    if (autoLogin && isCurrentConnectionGeneration(generation, connectSocket)) {
                         credentialLogin(credentialConfig)
                     }
                 }
@@ -1352,11 +1367,13 @@ class TelnyxClient private constructor(
         if (tokenConfig.region != Region.AUTO)
             providedHostAddress = "${tokenConfig.region.value}.$providedHostAddress"
 
+        val generation = nextConnectionGeneration()
         socket.destroy()
-        socket = TxSocket(
+        val connectSocket = TxSocket(
             host_address = providedHostAddress!!,
             port = providedServerConfig.port
         )
+        socket = connectSocket
 
         providedPort = providedServerConfig.port
         providedTurn = providedServerConfig.turn
@@ -1365,12 +1382,22 @@ class TelnyxClient private constructor(
             Logger.d(message = "Provided Host Address: $providedHostAddress")
 
             launchSocketConnect {
+                if (!isCurrentConnectionGeneration(generation, connectSocket)) {
+                    connectSocket.destroy()
+                    return@launchSocketConnect
+                }
+
                 if (tokenConfig.fallbackOnRegionFailure) {
                     providedHostAddress = ConnectivityHelper.resolveReachableHost(
                         providedHostAddress!!,
                         providedPort!!
                     )
                     Logger.d(message = "Verified Host Address: $providedHostAddress")
+                }
+
+                if (!isCurrentConnectionGeneration(generation, connectSocket)) {
+                    connectSocket.destroy()
+                    return@launchSocketConnect
                 }
 
                 if (txPushMetaData != null) {
@@ -1384,13 +1411,8 @@ class TelnyxClient private constructor(
                         voiceSdkId = voiceSDKID
                     )
                 }
-                socket.connect(
-                    listener = this@TelnyxClient,
-                    providedHostAddress = providedHostAddress,
-                    providedPort = providedPort,
-                    pushmetaData = pushMetaData
-                ) {
-                    if (autoLogin) {
+                connectSocket.connect(this@TelnyxClient, providedHostAddress, providedPort, pushMetaData) {
+                    if (autoLogin && isCurrentConnectionGeneration(generation, connectSocket)) {
                         tokenLogin(tokenConfig)
                     }
                 }
@@ -1434,11 +1456,13 @@ class TelnyxClient private constructor(
 
         providedHostAddress = providedServerConfig.host
 
+        val generation = nextConnectionGeneration()
         socket.destroy()
-        socket = TxSocket(
+        val connectSocket = TxSocket(
             host_address = providedHostAddress!!,
             port = providedServerConfig.port
         )
+        socket = connectSocket
 
         providedPort = providedServerConfig.port
         providedTurn = providedServerConfig.turn
@@ -1448,12 +1472,16 @@ class TelnyxClient private constructor(
             Logger.d(message = "Provided Host Address: $providedHostAddress")
 
             launchSocketConnect {
-                socket.connect(
-                    listener = this@TelnyxClient,
-                    providedHostAddress = providedHostAddress,
-                    providedPort = providedPort,
-                    pushmetaData = null
-                ) {
+                if (!isCurrentConnectionGeneration(generation, connectSocket)) {
+                    connectSocket.destroy()
+                    return@launchSocketConnect
+                }
+
+                connectSocket.connect(this@TelnyxClient, providedHostAddress, providedPort, null) socketConnect@ {
+                    if (!isCurrentConnectionGeneration(generation, connectSocket)) {
+                        return@socketConnect
+                    }
+
                     // Perform anonymous login after socket is connected
                     anonymousLogin(
                         targetId = targetId,
@@ -1514,11 +1542,13 @@ class TelnyxClient private constructor(
                 providedServerConfig.host
             }
 
+            val generation = nextConnectionGeneration()
             socket.destroy()
-            socket = TxSocket(
+            val connectSocket = TxSocket(
                 host_address = providedHostAddress!!,
                 port = providedServerConfig.port
             )
+            socket = connectSocket
 
             providedPort = providedServerConfig.port
             providedTurn = providedServerConfig.turn
@@ -1538,12 +1568,11 @@ class TelnyxClient private constructor(
                     )
                 }
                 launchSocketConnect {
-                    socket.connect(
-                        listener = this@TelnyxClient,
-                        providedHostAddress = providedHostAddress,
-                        providedPort = providedPort,
-                        pushmetaData = pushMetaData
-                    ) {
+                    connectSocket.connect(this, providedHostAddress, providedPort, pushMetaData) socketConnect@ {
+                        if (!isCurrentConnectionGeneration(generation, connectSocket)) {
+                            return@socketConnect
+                        }
+
                         when (declineConfig) {
                             is CredentialConfig -> {
                                 setSDKLogLevel(declineConfig.logLevel, declineConfig.customLogger)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -105,6 +105,9 @@ class TelnyxClient private constructor(
      * Companion object containing constant values used throughout the client.
      */
     companion object {
+        /**
+         * Creates a client isolated for background decline-push operations.
+         */
         fun createDeclinePushClient(context: Context): TelnyxClient =
             TelnyxClient(context, true)
 
@@ -2480,6 +2483,12 @@ class TelnyxClient private constructor(
 
         socket.isLoggedIn = true
 
+        if (reconnecting && getActiveCalls().isEmpty()) {
+            reconnecting = false
+            reconnectionRetryCounter.set(0)
+            cancelReconnectionTimer()
+        }
+
         if (isDeclinePushConnection && !isDedicatedDeclinePushClient) {
             disconnect()
             return
@@ -3527,8 +3536,12 @@ class TelnyxClient private constructor(
      * @see [TxSocket]
      */
     override fun onDisconnect() {
+        disconnectInternal(allowReconnectRetry = true)
+    }
+
+    private fun disconnectInternal(allowReconnectRetry: Boolean) {
         // Check if we should retry reconnection instead of giving up
-        if (reconnecting && getActiveCalls().isNotEmpty()) {
+        if (allowReconnectRetry && reconnecting && getActiveCalls().isNotEmpty()) {
             if (reconnectionRetryCounter.get() < MAX_RECONNECTION_RETRIES) {
                 val retryCount = reconnectionRetryCounter.incrementAndGet()
                 val backoffDelay = RECONNECTION_RETRY_BASE_DELAY * (1L shl (retryCount - 1))
@@ -3915,11 +3928,8 @@ class TelnyxClient private constructor(
      */
     fun disconnect() {
         Logger.d(message = "Disconnecting TelnyxClient and clearing states")
-        cancelSocketConnectJob()
-        cancelAcceptCallJobs()
-        reconnecting = false
         cancelReconnectionTimer()
-        onDisconnect()
+        disconnectInternal(allowReconnectRetry = false)
         // Keep clientScope reusable for later reconnects; socket.destroy() cancels socket-owned work.
         clientScope.coroutineContext.cancelChildren()
     }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1461,7 +1461,7 @@ class TelnyxClient(
 
         providedHostAddress = if (txPushMetaData != null) {
             val metadata = Gson().fromJson(txPushMetaData, PushMetaData::class.java)
-            processCallFromPush(metadata)
+            pushMetaData = metadata
             providedServerConfig.host
         } else {
             providedServerConfig.host
@@ -2241,7 +2241,7 @@ class TelnyxClient(
 
         Logger.d(message = "isCallPendingFromPush $isCallPendingFromPush")
         //if there is a call pending from push, attach it
-        if (isCallPendingFromPush) {
+        if (!isDeclinePushConnection && isCallPendingFromPush) {
             attachCall()
         }
         

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -957,8 +957,8 @@ class TelnyxClient private constructor(
             )
             // User has been logged in
             resetGatewayCounters()
-            if (reconnecting && credentialSessionConfig != null || tokenSessionConfig != null) {
-                runBlocking { reconnectToSocket() }
+            if (reconnecting && (credentialSessionConfig != null || tokenSessionConfig != null)) {
+                clientScope.launch { reconnectToSocket() }
             }
         }
 
@@ -992,7 +992,7 @@ class TelnyxClient private constructor(
                     startReconnectionTimer()
                 } else {
                     //Network is switched here. Either from Wifi to LTE or vice-versa
-                    runBlocking { reconnectToSocket() }
+                    clientScope.launch { reconnectToSocket() }
                 }
             }, RECONNECT_DELAY)
         }
@@ -1066,7 +1066,13 @@ class TelnyxClient private constructor(
             }
 
             // Connect to new socket
-            reconnectSocket.connect(this@TelnyxClient, providedHostAddress, providedPort, pushMetaData) socketConnect@ {
+            reconnectSocket.connect(
+                this@TelnyxClient,
+                providedHostAddress,
+                providedPort,
+                pushMetaData,
+                isCurrentConnection = { isCurrentConnectionGeneration(generation, reconnectSocket) }
+            ) socketConnect@ {
                 if (!isCurrentConnectionGeneration(generation, reconnectSocket)) {
                     return@socketConnect
                 }
@@ -1074,8 +1080,12 @@ class TelnyxClient private constructor(
                 //We can safely assume that the socket is connected at this point
                 // Login with stored configuration
                 credentialSessionConfig?.let {
-                    credentialLogin(it)
-                } ?: tokenLogin(tokenSessionConfig!!)
+                    credentialLogin(it, reconnectSocket) {
+                        isCurrentConnectionGeneration(generation, reconnectSocket)
+                    }
+                } ?: tokenLogin(tokenSessionConfig!!, reconnectSocket) {
+                    isCurrentConnectionGeneration(generation, reconnectSocket)
+                }
 
                 // Change an ongoing call's socket to the new socket.
                 call?.let { call?.socket = reconnectSocket }
@@ -1218,7 +1228,13 @@ class TelnyxClient private constructor(
         if (ConnectivityHelper.isNetworkEnabled(context)) {
             Logger.d(message = "Provided Host Address: $providedHostAddress")
             launchSocketConnect {
-                connectSocket.connect(this, providedHostAddress, providedPort, pushMetaData) socketConnect@ {
+                connectSocket.connect(
+                    this,
+                    providedHostAddress,
+                    providedPort,
+                    pushMetaData,
+                    isCurrentConnection = { isCurrentConnectionGeneration(generation, connectSocket) }
+                ) socketConnect@ {
                     if (!isCurrentConnectionGeneration(generation, connectSocket)) {
                         return@socketConnect
                     }
@@ -1315,9 +1331,17 @@ class TelnyxClient private constructor(
                         voiceSdkId = voiceSDKID
                     )
                 }
-                connectSocket.connect(this@TelnyxClient, providedHostAddress, providedPort, pushMetaData) {
+                connectSocket.connect(
+                    this@TelnyxClient,
+                    providedHostAddress,
+                    providedPort,
+                    pushMetaData,
+                    isCurrentConnection = { isCurrentConnectionGeneration(generation, connectSocket) }
+                ) {
                     if (autoLogin && isCurrentConnectionGeneration(generation, connectSocket)) {
-                        credentialLogin(credentialConfig)
+                        credentialLogin(credentialConfig, connectSocket) {
+                            isCurrentConnectionGeneration(generation, connectSocket)
+                        }
                     }
                 }
             }
@@ -1411,9 +1435,17 @@ class TelnyxClient private constructor(
                         voiceSdkId = voiceSDKID
                     )
                 }
-                connectSocket.connect(this@TelnyxClient, providedHostAddress, providedPort, pushMetaData) {
+                connectSocket.connect(
+                    this@TelnyxClient,
+                    providedHostAddress,
+                    providedPort,
+                    pushMetaData,
+                    isCurrentConnection = { isCurrentConnectionGeneration(generation, connectSocket) }
+                ) {
                     if (autoLogin && isCurrentConnectionGeneration(generation, connectSocket)) {
-                        tokenLogin(tokenConfig)
+                        tokenLogin(tokenConfig, connectSocket) {
+                            isCurrentConnectionGeneration(generation, connectSocket)
+                        }
                     }
                 }
 
@@ -1477,7 +1509,13 @@ class TelnyxClient private constructor(
                     return@launchSocketConnect
                 }
 
-                connectSocket.connect(this@TelnyxClient, providedHostAddress, providedPort, null) socketConnect@ {
+                connectSocket.connect(
+                    this@TelnyxClient,
+                    providedHostAddress,
+                    providedPort,
+                    null,
+                    isCurrentConnection = { isCurrentConnectionGeneration(generation, connectSocket) }
+                ) socketConnect@ {
                     if (!isCurrentConnectionGeneration(generation, connectSocket)) {
                         return@socketConnect
                     }
@@ -1490,6 +1528,8 @@ class TelnyxClient private constructor(
                         conversationId = conversationId,
                         userVariables = userVariables,
                         reconnection = reconnection,
+                        targetSocket = connectSocket,
+                        canSend = { isCurrentConnectionGeneration(generation, connectSocket) },
                     )
                 }
             }
@@ -1568,7 +1608,13 @@ class TelnyxClient private constructor(
                     )
                 }
                 launchSocketConnect {
-                    connectSocket.connect(this, providedHostAddress, providedPort, pushMetaData) socketConnect@ {
+                    connectSocket.connect(
+                        this,
+                        providedHostAddress,
+                        providedPort,
+                        pushMetaData,
+                        isCurrentConnection = { isCurrentConnectionGeneration(generation, connectSocket) }
+                    ) socketConnect@ {
                         if (!isCurrentConnectionGeneration(generation, connectSocket)) {
                             return@socketConnect
                         }
@@ -1576,12 +1622,16 @@ class TelnyxClient private constructor(
                         when (declineConfig) {
                             is CredentialConfig -> {
                                 setSDKLogLevel(declineConfig.logLevel, declineConfig.customLogger)
-                                credentialLoginWithDeclinePush(declineConfig)
+                                credentialLoginWithDeclinePush(declineConfig, connectSocket) {
+                                    isCurrentConnectionGeneration(generation, connectSocket)
+                                }
                             }
 
                             is TokenConfig -> {
                                 setSDKLogLevel(declineConfig.logLevel, declineConfig.customLogger)
-                                tokenLoginWithDeclinePush(declineConfig)
+                                tokenLoginWithDeclinePush(declineConfig, connectSocket) {
+                                    isCurrentConnectionGeneration(generation, connectSocket)
+                                }
                             }
                         }
                     }
@@ -1689,6 +1739,17 @@ class TelnyxClient private constructor(
      */
     @Deprecated("telnyxclient.credentialLogin is deprecated. Use telnyxclient.connect(..) instead.")
     fun credentialLogin(config: CredentialConfig) {
+        credentialLogin(config, socket) { true }
+    }
+
+    private fun credentialLogin(
+        config: CredentialConfig,
+        targetSocket: TxSocket,
+        canSend: () -> Boolean,
+    ) {
+        if (!canSend()) {
+            return
+        }
 
         val uuid: String = UUID.randomUUID().toString()
         val user = config.sipUser
@@ -1741,7 +1802,10 @@ class TelnyxClient private constructor(
         latencyTracker.startRegistrationTracking()
         latencyTracker.markRegistrationMilestone(LatencyTracker.MILESTONE_LOGIN_SENT)
 
-        socket.send(loginMessage)
+        if (!canSend()) {
+            return
+        }
+        targetSocket.send(loginMessage)
     }
 
 
@@ -1819,6 +1883,18 @@ class TelnyxClient private constructor(
                 "with autoLogin set to true instead."
     )
     fun tokenLogin(config: TokenConfig) {
+        tokenLogin(config, socket) { true }
+    }
+
+    private fun tokenLogin(
+        config: TokenConfig,
+        targetSocket: TxSocket,
+        canSend: () -> Boolean,
+    ) {
+        if (!canSend()) {
+            return
+        }
+
         val uuid: String = UUID.randomUUID().toString()
         val token = config.sipToken
         val fcmToken = config.fcmToken
@@ -1861,7 +1937,10 @@ class TelnyxClient private constructor(
         latencyTracker.startRegistrationTracking()
         latencyTracker.markRegistrationMilestone(LatencyTracker.MILESTONE_LOGIN_SENT)
         
-        socket.send(loginMessage)
+        if (!canSend()) {
+            return
+        }
+        targetSocket.send(loginMessage)
     }
 
     /**
@@ -1883,6 +1962,32 @@ class TelnyxClient private constructor(
         userVariables: Map<String, Any>? = null,
         reconnection: Boolean = false,
     ) {
+        anonymousLogin(
+            targetId = targetId,
+            targetType = targetType,
+            targetVersionId = targetVersionId,
+            conversationId = conversationId,
+            userVariables = userVariables,
+            reconnection = reconnection,
+            targetSocket = socket,
+            canSend = { true },
+        )
+    }
+
+    private fun anonymousLogin(
+        targetId: String,
+        targetType: String = "ai_assistant",
+        targetVersionId: String? = null,
+        conversationId: String? = null,
+        userVariables: Map<String, Any>? = null,
+        reconnection: Boolean = false,
+        targetSocket: TxSocket,
+        canSend: () -> Boolean,
+    ) {
+        if (!canSend()) {
+            return
+        }
+
         val uuid: String = UUID.randomUUID().toString()
 
         val userAgent = UserAgent(
@@ -1908,7 +2013,10 @@ class TelnyxClient private constructor(
         )
 
         Logger.d(message = "Anonymous Login Message: ${Gson().toJson(loginMessage)}")
-        socket.send(loginMessage)
+        if (!canSend()) {
+            return
+        }
+        targetSocket.send(loginMessage)
     }
 
     fun sendAIAssistantMessage(
@@ -1989,7 +2097,15 @@ class TelnyxClient private constructor(
      *
      * @param config The credential configuration for login
      */
-    private fun credentialLoginWithDeclinePush(config: CredentialConfig) {
+    private fun credentialLoginWithDeclinePush(
+        config: CredentialConfig,
+        targetSocket: TxSocket = socket,
+        canSend: () -> Boolean = { true },
+    ) {
+        if (!canSend()) {
+            return
+        }
+
         val uuid: String = UUID.randomUUID().toString()
         val user = config.sipUser
         val password = config.sipPassword
@@ -2037,7 +2153,10 @@ class TelnyxClient private constructor(
         )
         Logger.d(message = "Auto login with credentialConfig for decline push")
 
-        socket.send(loginMessage)
+        if (!canSend()) {
+            return
+        }
+        targetSocket.send(loginMessage)
     }
 
     /**
@@ -2046,7 +2165,15 @@ class TelnyxClient private constructor(
      *
      * @param config The token configuration for login
      */
-    private fun tokenLoginWithDeclinePush(config: TokenConfig) {
+    private fun tokenLoginWithDeclinePush(
+        config: TokenConfig,
+        targetSocket: TxSocket = socket,
+        canSend: () -> Boolean = { true },
+    ) {
+        if (!canSend()) {
+            return
+        }
+
         val uuid: String = UUID.randomUUID().toString()
         val token = config.sipToken
         val fcmToken = config.fcmToken
@@ -2086,7 +2213,10 @@ class TelnyxClient private constructor(
         )
         Logger.d(message = "Auto login with tokenConfig for decline push")
 
-        socket.send(loginMessage)
+        if (!canSend()) {
+            return
+        }
+        targetSocket.send(loginMessage)
     }
 
 
@@ -2460,7 +2590,7 @@ class TelnyxClient private constructor(
                             this@TelnyxClient.javaClass.simpleName
                         )
                     )
-                    runBlocking { reconnectToSocket() }
+                    clientScope.launch { reconnectToSocket() }
                 } else {
                     invalidateGatewayResponseTimer()
                     emitSocketResponse(

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -152,6 +152,8 @@ class TelnyxClient(
     private var autoReconnectLogin: Boolean = true
     private var gatewayResponseTimer: Timer? = null
     private var waitingForReg = true
+    @Volatile
+    private var isDeclinePushConnection = false
     private var registrationRetryCounter = 0
     private var connectRetryCounter = 0
     private var gatewayState = "idle"
@@ -936,6 +938,10 @@ class TelnyxClient(
     internal var isNetworkCallbackRegistered = false
     private val networkCallback = object : ConnectivityHelper.NetworkCallback() {
         override fun onNetworkAvailable() {
+            if (isDeclinePushConnection) {
+                return
+            }
+
             Logger.d(
                 message = Logger.formatMessage(
                     "[%s] :: There is a network available",
@@ -950,6 +956,10 @@ class TelnyxClient(
         }
 
         override fun onNetworkUnavailable() {
+            if (isDeclinePushConnection) {
+                return
+            }
+
             Logger.d(
                 message = Logger.formatMessage(
                     "[%s] :: There is no network available",
@@ -987,6 +997,10 @@ class TelnyxClient(
      * @see [TelnyxConfig]
      */
     private suspend fun reconnectToSocket() = withContext(Dispatchers.Default) {
+        if (isDeclinePushConnection) {
+            return@withContext
+        }
+
         // Start the reconnection timer to track timeout
         startReconnectionTimer()
 
@@ -1004,6 +1018,9 @@ class TelnyxClient(
 
         //Delay for network to be properly established
         delay(RECONNECT_DELAY)
+        if (isDeclinePushConnection) {
+            return@withContext
+        }
 
         // Create new socket connection
         socketReconnection = TxSocket(
@@ -1016,6 +1033,10 @@ class TelnyxClient(
         // Destroy old socket
         socket.destroy()
         launchSocketConnect {
+            if (isDeclinePushConnection) {
+                return@launchSocketConnect
+            }
+
             // Socket is now the reconnectionSocket
             socket = socketReconnection!!
 
@@ -1432,6 +1453,7 @@ class TelnyxClient(
         config: TelnyxConfig,
         txPushMetaData: String? = null,
     ) {
+        isDeclinePushConnection = true
         emitSocketResponse(SocketResponse.initialised())
         waitingForReg = true
         invalidateGatewayResponseTimer()
@@ -2346,7 +2368,7 @@ class TelnyxClient(
             }
 
             (GatewayState.FAIL_WAIT.state), (GatewayState.DOWN.state) -> {
-                if (autoReconnectLogin && connectRetryCounter < RETRY_CONNECT_TIME) {
+                if (!isDeclinePushConnection && autoReconnectLogin && connectRetryCounter < RETRY_CONNECT_TIME) {
                     connectRetryCounter++
                     Logger.d(
                         message = Logger.formatMessage(
@@ -3275,6 +3297,8 @@ class TelnyxClient(
         // Reset reconnection state
         reconnecting = false
         reconnectionRetryCounter.set(0)
+        socketReconnection?.destroy()
+        socketReconnection = null
         
         // Clear connection metrics on disconnect
         currentSocketConnectionMetrics = null

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1150,6 +1150,18 @@ class TelnyxClient private constructor(
         this.useTrickleIce = enabled
     }
 
+    private fun clearTransientDeclinePushMode() {
+        if (!isDedicatedDeclinePushClient) {
+            isDeclinePushConnection = false
+        }
+    }
+
+    private fun disconnectTransientDeclinePushConnection() {
+        if (isDeclinePushConnection && !isDedicatedDeclinePushClient) {
+            disconnect()
+        }
+    }
+
     /**
      * Connects to the socket using this client as the listener
      * Will respond with 'No Network Connection' if there is no network available
@@ -1170,6 +1182,7 @@ class TelnyxClient private constructor(
         txPushMetaData: String? = null,
     ) {
 
+        clearTransientDeclinePushMode()
         emitSocketResponse(SocketResponse.initialised())
         waitingForReg = true
         invalidateGatewayResponseTimer()
@@ -1228,6 +1241,7 @@ class TelnyxClient private constructor(
         txPushMetaData: String? = null,
         autoLogin: Boolean = true,
     ) {
+        clearTransientDeclinePushMode()
         isSocketDebug = credentialConfig.debug
         emitSocketResponse(SocketResponse.initialised())
         waitingForReg = true
@@ -1292,6 +1306,7 @@ class TelnyxClient private constructor(
             }
         } else {
             emitSocketResponse(SocketResponse.error("No Network Connection", null))
+            clearTransientDeclinePushMode()
         }
     }
 
@@ -1315,6 +1330,7 @@ class TelnyxClient private constructor(
         txPushMetaData: String? = null,
         autoLogin: Boolean = true,
     ) {
+        clearTransientDeclinePushMode()
         isSocketDebug = tokenConfig.debug
         emitSocketResponse(SocketResponse.initialised())
         waitingForReg = true
@@ -1404,6 +1420,7 @@ class TelnyxClient private constructor(
         reconnection: Boolean = false,
         logLevel: LogLevel = LogLevel.NONE,
     ) {
+        clearTransientDeclinePushMode()
         emitSocketResponse(SocketResponse.initialised())
         waitingForReg = true
         invalidateGatewayResponseTimer()
@@ -1466,64 +1483,70 @@ class TelnyxClient private constructor(
             is CredentialConfig -> config.copy(autoReconnect = false)
             is TokenConfig -> config.copy(autoReconnect = false)
         }
-        emitSocketResponse(SocketResponse.initialised())
-        waitingForReg = true
-        invalidateGatewayResponseTimer()
-        resetGatewayCounters()
+        try {
+            emitSocketResponse(SocketResponse.initialised())
+            waitingForReg = true
+            invalidateGatewayResponseTimer()
+            resetGatewayCounters()
 
-        providedHostAddress = if (txPushMetaData != null) {
-            val metadata = Gson().fromJson(txPushMetaData, PushMetaData::class.java)
-            pushMetaData = metadata
-            providedServerConfig.host
-        } else {
-            providedServerConfig.host
-        }
-
-        socket.destroy()
-        socket = TxSocket(
-            host_address = providedHostAddress!!,
-            port = providedServerConfig.port
-        )
-
-        providedPort = providedServerConfig.port
-        providedTurn = providedServerConfig.turn
-        providedStun = providedServerConfig.stun
-
-        if (ConnectivityHelper.isNetworkEnabled(context)) {
-            Logger.d(message = "Provided Host Address: $providedHostAddress")
-            if (txPushMetaData != null) {
+            providedHostAddress = if (txPushMetaData != null) {
                 val metadata = Gson().fromJson(txPushMetaData, PushMetaData::class.java)
-                voiceSDKID = metadata.voiceSdkId
-            } else if (voiceSDKID != null) {
-                pushMetaData = PushMetaData(
-                    callerName = "",
-                    callerNumber = "",
-                    callId = "",
-                    voiceSdkId = voiceSDKID
-                )
+                pushMetaData = metadata
+                providedServerConfig.host
+            } else {
+                providedServerConfig.host
             }
-            launchSocketConnect {
-                socket.connect(
-                    listener = this@TelnyxClient,
-                    providedHostAddress = providedHostAddress,
-                    providedPort = providedPort,
-                    pushmetaData = pushMetaData
-                ) {
-                    when (declineConfig) {
-                        is CredentialConfig -> {
-                            setSDKLogLevel(declineConfig.logLevel, declineConfig.customLogger)
-                            credentialLoginWithDeclinePush(declineConfig)
-                        }
 
-                        is TokenConfig -> {
-                            setSDKLogLevel(declineConfig.logLevel, declineConfig.customLogger)
-                            tokenLoginWithDeclinePush(declineConfig)
+            socket.destroy()
+            socket = TxSocket(
+                host_address = providedHostAddress!!,
+                port = providedServerConfig.port
+            )
+
+            providedPort = providedServerConfig.port
+            providedTurn = providedServerConfig.turn
+            providedStun = providedServerConfig.stun
+
+            if (ConnectivityHelper.isNetworkEnabled(context)) {
+                Logger.d(message = "Provided Host Address: $providedHostAddress")
+                if (txPushMetaData != null) {
+                    val metadata = Gson().fromJson(txPushMetaData, PushMetaData::class.java)
+                    voiceSDKID = metadata.voiceSdkId
+                } else if (voiceSDKID != null) {
+                    pushMetaData = PushMetaData(
+                        callerName = "",
+                        callerNumber = "",
+                        callId = "",
+                        voiceSdkId = voiceSDKID
+                    )
+                }
+                launchSocketConnect {
+                    socket.connect(
+                        listener = this@TelnyxClient,
+                        providedHostAddress = providedHostAddress,
+                        providedPort = providedPort,
+                        pushmetaData = pushMetaData
+                    ) {
+                        when (declineConfig) {
+                            is CredentialConfig -> {
+                                setSDKLogLevel(declineConfig.logLevel, declineConfig.customLogger)
+                                credentialLoginWithDeclinePush(declineConfig)
+                            }
+
+                            is TokenConfig -> {
+                                setSDKLogLevel(declineConfig.logLevel, declineConfig.customLogger)
+                                tokenLoginWithDeclinePush(declineConfig)
+                            }
                         }
                     }
                 }
+            } else {
+                emitSocketResponse(SocketResponse.error("No Network Connection", null))
+                clearTransientDeclinePushMode()
             }
-        } else {
-            emitSocketResponse(SocketResponse.error("No Network Connection", null))
+        } catch (e: Exception) {
+            clearTransientDeclinePushMode()
+            throw e
         }
     }
 
@@ -2315,6 +2338,7 @@ class TelnyxClient private constructor(
                                     SocketError.GATEWAY_TIMEOUT_ERROR.errorCode
                                 )
                             )
+                            disconnectTransientDeclinePushConnection()
                         }
                     },
                     GATEWAY_RESPONSE_DELAY
@@ -2367,6 +2391,7 @@ class TelnyxClient private constructor(
                         SocketError.GATEWAY_TIMEOUT_ERROR.errorCode
                     )
                 )
+                disconnectTransientDeclinePushConnection()
             }
 
             GatewayState.FAILED.state -> {
@@ -2377,6 +2402,7 @@ class TelnyxClient private constructor(
                         SocketError.GATEWAY_FAILURE_ERROR.errorCode
                     )
                 )
+                disconnectTransientDeclinePushConnection()
             }
 
             (GatewayState.FAIL_WAIT.state), (GatewayState.DOWN.state) -> {
@@ -2397,6 +2423,7 @@ class TelnyxClient private constructor(
                             SocketError.GATEWAY_FAILURE_ERROR.errorCode
                         )
                     )
+                    disconnectTransientDeclinePushConnection()
                 }
             }
 
@@ -2408,6 +2435,7 @@ class TelnyxClient private constructor(
                         SocketError.GATEWAY_TIMEOUT_ERROR.errorCode
                     )
                 )
+                disconnectTransientDeclinePushConnection()
             }
 
             GatewayState.UNREGED.state -> {
@@ -2559,11 +2587,13 @@ class TelnyxClient private constructor(
         if (errorCode == null && attachCallId == id) {
             Logger.d(message = "Call Failed Error Received")
             emitSocketResponse(SocketResponse.error("Call Failed", null))
+            disconnectTransientDeclinePushConnection()
             return
         }
         val errorMessage = jsonObject.get("error").asJsonObject.get("message").asString
         Logger.d(message = "onErrorReceived $errorMessage, code: $errorCode")
         emitSocketResponse(SocketResponse.error(errorMessage, errorCode))
+        disconnectTransientDeclinePushConnection()
     }
 
     override fun onByeReceived(jsonObject: JsonObject) {
@@ -3318,9 +3348,7 @@ class TelnyxClient private constructor(
         cancelSocketConnectJob()
         cancelAcceptCallJobs()
         socket.destroy()
-        if (!isDedicatedDeclinePushClient) {
-            isDeclinePushConnection = false
-        }
+        clearTransientDeclinePushMode()
     }
 
     /**

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1445,6 +1445,7 @@ class TelnyxClient(
             providedServerConfig.host
         }
 
+        socket.destroy()
         socket = TxSocket(
             host_address = providedHostAddress!!,
             port = providedServerConfig.port

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -2480,6 +2480,11 @@ class TelnyxClient private constructor(
 
         socket.isLoggedIn = true
 
+        if (isDeclinePushConnection && !isDedicatedDeclinePushClient) {
+            disconnect()
+            return
+        }
+
         Logger.d(message = "isCallPendingFromPush $isCallPendingFromPush")
         //if there is a call pending from push, attach it
         if (!isDeclinePushConnection && isCallPendingFromPush) {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -153,6 +153,7 @@ class TelnyxClient private constructor(
     private var reconnectTimeOutJob: Job? = null
     private var socketConnectJob: Job? = null
     private val acceptCallJobs = ConcurrentHashMap<UUID, Job>()
+    private var reconnectJob: Job? = null
 
     // Gateway registration variables
     private var autoReconnectLogin: Boolean = true
@@ -958,7 +959,7 @@ class TelnyxClient private constructor(
             // User has been logged in
             resetGatewayCounters()
             if (reconnecting && (credentialSessionConfig != null || tokenSessionConfig != null)) {
-                clientScope.launch { reconnectToSocket() }
+                launchReconnectJob()
             }
         }
 
@@ -992,9 +993,27 @@ class TelnyxClient private constructor(
                     startReconnectionTimer()
                 } else {
                     //Network is switched here. Either from Wifi to LTE or vice-versa
-                    clientScope.launch { reconnectToSocket() }
+                    launchReconnectJob()
                 }
             }, RECONNECT_DELAY)
+        }
+    }
+
+    private fun launchReconnectJob(delayMs: Long = 0L) {
+        reconnectJob?.cancel()
+        val job = clientScope.launch {
+            if (delayMs > 0L) {
+                delay(delayMs)
+            }
+            if (reconnecting) {
+                reconnectToSocket()
+            }
+        }
+        reconnectJob = job
+        job.invokeOnCompletion {
+            if (reconnectJob === job) {
+                reconnectJob = null
+            }
         }
     }
 
@@ -1004,7 +1023,10 @@ class TelnyxClient private constructor(
      * @see [TelnyxConfig]
      */
     private suspend fun reconnectToSocket() = withContext(Dispatchers.Default) {
-        if (isDeclinePushConnection) {
+        val credentialConfig = credentialSessionConfig
+        val tokenConfig = tokenSessionConfig
+
+        if (isDeclinePushConnection || !reconnecting || (credentialConfig == null && tokenConfig == null)) {
             return@withContext
         }
 
@@ -1025,7 +1047,7 @@ class TelnyxClient private constructor(
 
         //Delay for network to be properly established
         delay(RECONNECT_DELAY)
-        if (isDeclinePushConnection) {
+        if (isDeclinePushConnection || !reconnecting) {
             return@withContext
         }
 
@@ -1041,7 +1063,7 @@ class TelnyxClient private constructor(
         // Destroy old socket
         socket.destroy()
         launchSocketConnect {
-            if (isDeclinePushConnection || connectionGeneration.get() != generation) {
+            if (isDeclinePushConnection || !reconnecting || connectionGeneration.get() != generation) {
                 reconnectSocket.destroy()
                 return@launchSocketConnect
             }
@@ -1066,7 +1088,7 @@ class TelnyxClient private constructor(
             }
 
             // Connect to new socket
-            reconnectSocket.connect(
+            reconnectSocket.connectWithConnectionGuard(
                 this@TelnyxClient,
                 providedHostAddress,
                 providedPort,
@@ -1079,12 +1101,14 @@ class TelnyxClient private constructor(
 
                 //We can safely assume that the socket is connected at this point
                 // Login with stored configuration
-                credentialSessionConfig?.let {
+                credentialConfig?.let {
                     credentialLogin(it, reconnectSocket) {
                         isCurrentConnectionGeneration(generation, reconnectSocket)
                     }
-                } ?: tokenLogin(tokenSessionConfig!!, reconnectSocket) {
-                    isCurrentConnectionGeneration(generation, reconnectSocket)
+                } ?: tokenConfig?.let {
+                    tokenLogin(it, reconnectSocket) {
+                        isCurrentConnectionGeneration(generation, reconnectSocket)
+                    }
                 }
 
                 // Change an ongoing call's socket to the new socket.
@@ -1180,6 +1204,21 @@ class TelnyxClient private constructor(
         }
     }
 
+    private fun shouldIgnoreDeclinePushCallEvent(methodName: String): Boolean {
+        if (!isDeclinePushConnection) {
+            return false
+        }
+
+        Logger.d(
+            message = Logger.formatMessage(
+                "[%s] :: Ignoring %s during decline push connection",
+                this@TelnyxClient.javaClass.simpleName,
+                methodName
+            )
+        )
+        return true
+    }
+
     /**
      * Connects to the socket using this client as the listener
      * Will respond with 'No Network Connection' if there is no network available
@@ -1228,7 +1267,7 @@ class TelnyxClient private constructor(
         if (ConnectivityHelper.isNetworkEnabled(context)) {
             Logger.d(message = "Provided Host Address: $providedHostAddress")
             launchSocketConnect {
-                connectSocket.connect(
+                connectSocket.connectWithConnectionGuard(
                     this,
                     providedHostAddress,
                     providedPort,
@@ -1331,7 +1370,7 @@ class TelnyxClient private constructor(
                         voiceSdkId = voiceSDKID
                     )
                 }
-                connectSocket.connect(
+                connectSocket.connectWithConnectionGuard(
                     this@TelnyxClient,
                     providedHostAddress,
                     providedPort,
@@ -1435,7 +1474,7 @@ class TelnyxClient private constructor(
                         voiceSdkId = voiceSDKID
                     )
                 }
-                connectSocket.connect(
+                connectSocket.connectWithConnectionGuard(
                     this@TelnyxClient,
                     providedHostAddress,
                     providedPort,
@@ -1509,7 +1548,7 @@ class TelnyxClient private constructor(
                     return@launchSocketConnect
                 }
 
-                connectSocket.connect(
+                connectSocket.connectWithConnectionGuard(
                     this@TelnyxClient,
                     providedHostAddress,
                     providedPort,
@@ -1542,7 +1581,8 @@ class TelnyxClient private constructor(
     /**
      * Connects to the socket with decline_push parameter for background call decline.
      * This method is specifically designed for declining calls without launching the main app.
-     * Use [createDeclinePushClient] so decline work is isolated from the normal SDK client.
+     * Prefer [createDeclinePushClient] so decline work is isolated from the normal SDK client.
+     * Calling this method on an existing client remains supported for compatibility.
      *
      * @param providedServerConfig The server configuration for connection
      * @param config The configuration for login (either CredentialConfig or TokenConfig)
@@ -1553,16 +1593,6 @@ class TelnyxClient private constructor(
         config: TelnyxConfig,
         txPushMetaData: String? = null,
     ) {
-        if (!isDedicatedDeclinePushClient) {
-            emitSocketResponse(
-                SocketResponse.error(
-                    "connectWithDeclinePush requires a dedicated decline push client",
-                    null
-                )
-            )
-            return
-        }
-
         isDeclinePushConnection = true
         val declineConfig = when (config) {
             is CredentialConfig -> config.copy(autoReconnect = false)
@@ -1608,7 +1638,7 @@ class TelnyxClient private constructor(
                     )
                 }
                 launchSocketConnect {
-                    connectSocket.connect(
+                    connectSocket.connectWithConnectionGuard(
                         this,
                         providedHostAddress,
                         providedPort,
@@ -2590,7 +2620,7 @@ class TelnyxClient private constructor(
                             this@TelnyxClient.javaClass.simpleName
                         )
                     )
-                    clientScope.launch { reconnectToSocket() }
+                    launchReconnectJob()
                 } else {
                     invalidateGatewayResponseTimer()
                     emitSocketResponse(
@@ -2773,6 +2803,10 @@ class TelnyxClient private constructor(
     }
 
     override fun onByeReceived(jsonObject: JsonObject) {
+        if (shouldIgnoreDeclinePushCallEvent(SocketMethod.BYE.methodName)) {
+            return
+        }
+
         Logger.d(
             message = Logger.formatMessage(
                 "[%s] :: onByeReceived JSON: %s",
@@ -2849,6 +2883,10 @@ class TelnyxClient private constructor(
     }
 
     override fun onAnswerReceived(jsonObject: JsonObject) {
+        if (shouldIgnoreDeclinePushCallEvent(SocketMethod.ANSWER.methodName)) {
+            return
+        }
+
         val params = jsonObject.getAsJsonObject("params")
         val callId = params.get("callID").asString
         val callUuid = UUID.fromString(callId)
@@ -3030,6 +3068,10 @@ class TelnyxClient private constructor(
     }
 
     override fun onMediaReceived(jsonObject: JsonObject) {
+        if (shouldIgnoreDeclinePushCallEvent(SocketMethod.MEDIA.methodName)) {
+            return
+        }
+
         val params = jsonObject.getAsJsonObject("params")
         val callId = params.get("callID").asString
         val mediaCall = calls[UUID.fromString(callId)]
@@ -3081,6 +3123,10 @@ class TelnyxClient private constructor(
     }
 
     override fun onOfferReceived(jsonObject: JsonObject) {
+        if (shouldIgnoreDeclinePushCallEvent(SocketMethod.INVITE.methodName)) {
+            return
+        }
+
         if (jsonObject.has("params")) {
             Logger.d(
                 message = Logger.formatMessage(
@@ -3235,6 +3281,10 @@ class TelnyxClient private constructor(
     }
 
     override fun onRingingReceived(jsonObject: JsonObject) {
+        if (shouldIgnoreDeclinePushCallEvent(SocketMethod.RINGING.methodName)) {
+            return
+        }
+
         Logger.d(
             message = Logger.formatMessage(
                 "[%s] :: onRingingReceived [%s]",
@@ -3292,6 +3342,10 @@ class TelnyxClient private constructor(
     }
 
     override fun onIceCandidateReceived(iceCandidate: IceCandidate) {
+        if (shouldIgnoreDeclinePushCallEvent("ICE_CANDIDATE")) {
+            return
+        }
+
         call?.apply {
             updateCallState(CallState.CONNECTING)
         }
@@ -3321,6 +3375,10 @@ class TelnyxClient private constructor(
     }
 
     override fun onAttachReceived(jsonObject: JsonObject) {
+        if (shouldIgnoreDeclinePushCallEvent(SocketMethod.ATTACH.methodName)) {
+            return
+        }
+
         // reset reconnecting state
         reconnecting = false
         reconnectionRetryCounter.set(0)
@@ -3484,13 +3542,7 @@ class TelnyxClient private constructor(
                 socket.destroy()
                 
                 // Schedule retry with exponential backoff
-                clientScope.launch {
-                    delay(backoffDelay)
-                    // Only retry if still reconnecting (timer hasn't expired)
-                    if (reconnecting) {
-                        reconnectToSocket()
-                    }
-                }
+                launchReconnectJob(backoffDelay)
                 return
             } else {
                 Logger.d(
@@ -3514,7 +3566,10 @@ class TelnyxClient private constructor(
         
         // Reset reconnection state
         reconnecting = false
+        reconnectJob?.cancel()
+        reconnectJob = null
         reconnectionRetryCounter.set(0)
+        nextConnectionGeneration()
         socketReconnection?.destroy()
         socketReconnection = null
         
@@ -3569,6 +3624,10 @@ class TelnyxClient private constructor(
      * @param jsonObject the socket response containing modify data
      */
     override fun onModifyReceived(jsonObject: JsonObject) {
+        if (shouldIgnoreDeclinePushCallEvent(SocketMethod.MODIFY.methodName)) {
+            return
+        }
+
         Logger.i(message = "MODIFY RECEIVED :: $jsonObject")
 
         try {
@@ -3752,6 +3811,10 @@ class TelnyxClient private constructor(
     }
 
     override fun onCandidateReceived(jsonObject: JsonObject) {
+        if (shouldIgnoreDeclinePushCallEvent(SocketMethod.CANDIDATE.methodName)) {
+            return
+        }
+
         Logger.d(tag = "onCandidateReceived", message = "ICE CANDIDATE RECEIVED :: $jsonObject")
 
         if (jsonObject.has("params")) {
@@ -3816,6 +3879,10 @@ class TelnyxClient private constructor(
     }
 
     override fun onEndOfCandidatesReceived(jsonObject: JsonObject) {
+        if (shouldIgnoreDeclinePushCallEvent(SocketMethod.END_OF_CANDIDATES.methodName)) {
+            return
+        }
+
         Logger.d(message = "END OF CANDIDATES RECEIVED :: $jsonObject")
     }
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -56,6 +56,7 @@ import kotlin.concurrent.timerTask
  *
  * @param context the Context that the application is using
  */
+@Suppress("LargeClass")
 class TelnyxClient private constructor(
     var context: Context,
     startsInDeclinePushMode: Boolean,
@@ -1025,11 +1026,13 @@ class TelnyxClient private constructor(
      * @see [TxSocket]
      * @see [TelnyxConfig]
      */
+    @Suppress("ComplexMethod")
     private suspend fun reconnectToSocket() = withContext(Dispatchers.Default) {
         val credentialConfig = credentialSessionConfig
         val tokenConfig = tokenSessionConfig
+        val hasReconnectConfig = credentialConfig != null || tokenConfig != null
 
-        if (isDeclinePushConnection || !reconnecting || (credentialConfig == null && tokenConfig == null)) {
+        if (isDeclinePushConnection || !reconnecting || !hasReconnectConfig) {
             return@withContext
         }
 
@@ -1271,7 +1274,7 @@ class TelnyxClient private constructor(
             Logger.d(message = "Provided Host Address: $providedHostAddress")
             launchSocketConnect {
                 connectSocket.connectWithConnectionGuard(
-                    this,
+                    this@TelnyxClient,
                     providedHostAddress,
                     providedPort,
                     pushMetaData,
@@ -1642,7 +1645,7 @@ class TelnyxClient private constructor(
                 }
                 launchSocketConnect {
                     connectSocket.connectWithConnectionGuard(
-                        this,
+                        this@TelnyxClient,
                         providedHostAddress,
                         providedPort,
                         pushMetaData,

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -157,6 +157,7 @@ class TelnyxClient private constructor(
     private var autoReconnectLogin: Boolean = true
     private var gatewayResponseTimer: Timer? = null
     private var waitingForReg = true
+    private val isDedicatedDeclinePushClient = startsInDeclinePushMode
     @Volatile
     private var isDeclinePushConnection = startsInDeclinePushMode
     private var registrationRetryCounter = 0
@@ -1460,6 +1461,11 @@ class TelnyxClient private constructor(
         config: TelnyxConfig,
         txPushMetaData: String? = null,
     ) {
+        isDeclinePushConnection = true
+        val declineConfig = when (config) {
+            is CredentialConfig -> config.copy(autoReconnect = false)
+            is TokenConfig -> config.copy(autoReconnect = false)
+        }
         emitSocketResponse(SocketResponse.initialised())
         waitingForReg = true
         invalidateGatewayResponseTimer()
@@ -1503,15 +1509,15 @@ class TelnyxClient private constructor(
                     providedPort = providedPort,
                     pushmetaData = pushMetaData
                 ) {
-                    when (config) {
+                    when (declineConfig) {
                         is CredentialConfig -> {
-                            setSDKLogLevel(config.logLevel, config.customLogger)
-                            credentialLoginWithDeclinePush(config)
+                            setSDKLogLevel(declineConfig.logLevel, declineConfig.customLogger)
+                            credentialLoginWithDeclinePush(declineConfig)
                         }
 
                         is TokenConfig -> {
-                            setSDKLogLevel(config.logLevel, config.customLogger)
-                            tokenLoginWithDeclinePush(config)
+                            setSDKLogLevel(declineConfig.logLevel, declineConfig.customLogger)
+                            tokenLoginWithDeclinePush(declineConfig)
                         }
                     }
                 }
@@ -3312,6 +3318,9 @@ class TelnyxClient private constructor(
         cancelSocketConnectJob()
         cancelAcceptCallJobs()
         socket.destroy()
+        if (!isDedicatedDeclinePushClient) {
+            isDeclinePushConnection = false
+        }
     }
 
     /**

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -74,6 +74,7 @@ class TxSocket(
         providedHostAddress: String? = Config.TELNYX_PROD_HOST_ADDRESS,
         providedPort: Int? = Config.TELNYX_PORT,
         pushmetaData: PushMetaData? = null,
+        isCurrentConnection: () -> Boolean = { true },
         onConnected:(Boolean) -> Unit = {}
     ): Job {
         isDestroyed = false
@@ -132,13 +133,13 @@ class TxSocket(
 
         Logger.d(message = "request2 : ${request.url.encodedQuery}")
 
-        if (shouldIgnoreSocketCallback()) return@launch
+        if (shouldIgnoreSocketCallback(isCurrentConnection)) return@launch
 
         val createdWebSocket = client.newWebSocket(
             request,
             object : WebSocketListener() {
                 override fun onOpen(webSocket: WebSocket, response: Response) {
-                    if (shouldIgnoreSocketCallback()) return
+                    if (shouldIgnoreSocketCallback(isCurrentConnection)) return
 
                     Logger.v(
                         message = Logger.formatMessage("[%s] Connection established :: $host_address",
@@ -150,7 +151,7 @@ class TxSocket(
                 }
 
                 override fun onMessage(webSocket: WebSocket, text: String) {
-                    if (shouldIgnoreSocketCallback()) return
+                    if (shouldIgnoreSocketCallback(isCurrentConnection)) return
 
                     super.onMessage(webSocket, text)
                     Logger.v(
@@ -314,7 +315,7 @@ class TxSocket(
                 }
 
                 override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
-                    if (shouldIgnoreSocketCallback()) return
+                    if (shouldIgnoreSocketCallback(isCurrentConnection)) return
 
                     super.onClosing(webSocket, code, reason)
                     Logger.i(tag = "TxSocket", message = "Socket is closing: $code :: $reason")
@@ -322,7 +323,7 @@ class TxSocket(
                 }
 
                 override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
-                    if (shouldIgnoreSocketCallback()) return
+                    if (shouldIgnoreSocketCallback(isCurrentConnection)) return
 
                     super.onClosed(webSocket, code, reason)
                     Logger.i(tag = "TxSocket", message = "Socket is closed: $code :: $reason")
@@ -334,7 +335,7 @@ class TxSocket(
                 }
 
                 override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
-                    if (shouldIgnoreSocketCallback()) return
+                    if (shouldIgnoreSocketCallback(isCurrentConnection)) return
 
                     Logger.i(tag = "TxSocket",
                         message = "Socket failure: $t :: response: $response :: Will attempt to reconnect")
@@ -383,14 +384,14 @@ class TxSocket(
         )
 
         webSocket = createdWebSocket
-        if (shouldIgnoreSocketCallback()) {
+        if (shouldIgnoreSocketCallback(isCurrentConnection)) {
             createdWebSocket.close(WEBSOCKET_NORMAL_CLOSURE, "Websocket connection closed")
         }
         }
     }
 
-    private fun shouldIgnoreSocketCallback(): Boolean {
-        return isDestroyed || !job.isActive
+    private fun shouldIgnoreSocketCallback(isCurrentConnection: () -> Boolean = { true }): Boolean {
+        return isDestroyed || !job.isActive || !isCurrentConnection()
     }
 
     /**

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -75,9 +75,10 @@ class TxSocket(
         providedPort: Int? = Config.TELNYX_PORT,
         pushmetaData: PushMetaData? = null,
         onConnected:(Boolean) -> Unit = {}
-    ): Job = launch(Dispatchers.IO) {
+    ): Job {
         isDestroyed = false
 
+        return launch(Dispatchers.IO) {
         val loggingInterceptor = HttpLoggingInterceptor()
         loggingInterceptor.apply {
             if (BuildConfig.DEBUG){
@@ -131,7 +132,9 @@ class TxSocket(
 
         Logger.d(message = "request2 : ${request.url.encodedQuery}")
 
-        webSocket = client.newWebSocket(
+        if (shouldIgnoreSocketCallback()) return@launch
+
+        val createdWebSocket = client.newWebSocket(
             request,
             object : WebSocketListener() {
                 override fun onOpen(webSocket: WebSocket, response: Response) {
@@ -378,6 +381,12 @@ class TxSocket(
                 }
             }
         )
+
+        webSocket = createdWebSocket
+        if (shouldIgnoreSocketCallback()) {
+            createdWebSocket.close(WEBSOCKET_NORMAL_CLOSURE, "Websocket connection closed")
+        }
+        }
     }
 
     private fun shouldIgnoreSocketCallback(): Boolean {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -46,6 +46,8 @@ class TxSocket(
     internal var isLoggedIn = false
     internal var isConnected = false
     internal var isPing = false
+    @Volatile
+    private var isDestroyed = false
 
     private lateinit var client: OkHttpClient
     private lateinit var webSocket: WebSocket
@@ -74,6 +76,7 @@ class TxSocket(
         pushmetaData: PushMetaData? = null,
         onConnected:(Boolean) -> Unit = {}
     ): Job = launch(Dispatchers.IO) {
+        isDestroyed = false
 
         val loggingInterceptor = HttpLoggingInterceptor()
         loggingInterceptor.apply {
@@ -132,6 +135,8 @@ class TxSocket(
             request,
             object : WebSocketListener() {
                 override fun onOpen(webSocket: WebSocket, response: Response) {
+                    if (shouldIgnoreSocketCallback()) return
+
                     Logger.v(
                         message = Logger.formatMessage("[%s] Connection established :: $host_address",
                         this@TxSocket.javaClass.simpleName)
@@ -142,6 +147,8 @@ class TxSocket(
                 }
 
                 override fun onMessage(webSocket: WebSocket, text: String) {
+                    if (shouldIgnoreSocketCallback()) return
+
                     super.onMessage(webSocket, text)
                     Logger.v(
                         message = Logger.formatMessage("[%s] Receiving [%s]",
@@ -304,12 +311,16 @@ class TxSocket(
                 }
 
                 override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                    if (shouldIgnoreSocketCallback()) return
+
                     super.onClosing(webSocket, code, reason)
                     Logger.i(tag = "TxSocket", message = "Socket is closing: $code :: $reason")
                     listener.onDisconnect()
                 }
 
                 override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                    if (shouldIgnoreSocketCallback()) return
+
                     super.onClosed(webSocket, code, reason)
                     Logger.i(tag = "TxSocket", message = "Socket is closed: $code :: $reason")
                     // Only cleanup if not already disconnected (prevents double cleanup)
@@ -320,6 +331,8 @@ class TxSocket(
                 }
 
                 override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                    if (shouldIgnoreSocketCallback()) return
+
                     Logger.i(tag = "TxSocket",
                         message = "Socket failure: $t :: response: $response :: Will attempt to reconnect")
 
@@ -367,6 +380,10 @@ class TxSocket(
         )
     }
 
+    private fun shouldIgnoreSocketCallback(): Boolean {
+        return isDestroyed || !job.isActive
+    }
+
     /**
      * Sets the ongoingCall boolean value to true
      */
@@ -397,6 +414,7 @@ class TxSocket(
      * Closes our websocket connection and cancels our coroutine job
      */
     internal fun destroy() {
+        isDestroyed = true
         isConnected = false
         isLoggedIn = false
         ongoingCall = false

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -74,6 +74,21 @@ class TxSocket(
         providedHostAddress: String? = Config.TELNYX_PROD_HOST_ADDRESS,
         providedPort: Int? = Config.TELNYX_PORT,
         pushmetaData: PushMetaData? = null,
+        onConnected:(Boolean) -> Unit = {}
+    ): Job = connectWithConnectionGuard(
+        listener,
+        providedHostAddress,
+        providedPort,
+        pushmetaData,
+        isCurrentConnection = { true },
+        onConnected = onConnected
+    )
+
+    internal fun connectWithConnectionGuard(
+        listener: TelnyxClient,
+        providedHostAddress: String? = Config.TELNYX_PROD_HOST_ADDRESS,
+        providedPort: Int? = Config.TELNYX_PORT,
+        pushmetaData: PushMetaData? = null,
         isCurrentConnection: () -> Boolean = { true },
         onConnected:(Boolean) -> Unit = {}
     ): Job {

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientCoroutineScopeTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientCoroutineScopeTest.kt
@@ -40,7 +40,11 @@ class TelnyxClientCoroutineScopeTest {
             socketSource.contains("parentScope"),
             "TxSocket should own its connect coroutine scope."
         )
-        assertTrue(socketSource.contains("): Job = launch(Dispatchers.IO)"))
+        assertTrue(
+            Regex("""\):\s*Job\s*\{\s*isDestroyed\s*=\s*false\s*return\s+launch\s*\(\s*Dispatchers\.IO\s*\)""")
+                .containsMatchIn(socketSource),
+            "TxSocket connect should return the owned Dispatchers.IO launch job."
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Cancels the BackgroundCallDeclineService parent scope on destroy and keeps decline operations scoped per startId.
- Fixes rebase review issues in TelnyxClient guarded socket connect call sites.
- Updates the coroutine-scope regression test and decline-push docs example.

## Verification
- ./gradlew :telnyx_common:compileDebugKotlin :telnyx_rtc:compileDebugKotlin :telnyx_rtc:testDebugUnitTest --tests 'com.telnyx.webrtc.sdk.TelnyxClientCoroutineScopeTest' --tests 'com.telnyx.webrtc.sdk.utilities.LatencyTrackerTest'\n- git diff --check\n\n## Linear\n- VSDK-332 / AND-B22