### PR TITLE
[VSDK-359] Add ktlint + .editorconfig at repo root

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,39 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 120
+
+[*.{kt,kts}]
+indent_size = 4
+continuation_indent_size = 4
+max_line_length = 120
+
+# Kotlin-specific: disable some ktlint rules that are too noisy for existing codebases
+[*.{kt,kts}]
+ktlint_disabled_rules = no-wildcard-imports,import-ordering
+
+[*.{xml,gradle,gradle.kts}]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.{json,md}]
+indent_size = 2
+
+# Gradle files
+[*.gradle]
+indent_size = 2
+
+[*.gradle.kts]
+indent_size = 4
+
+# Android XML resources
+[*.{xml,html}]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,10 +15,13 @@ continuation_indent_size = 4
 max_line_length = 120
 
 # Kotlin-specific: disable some ktlint rules that are too noisy for existing codebases
+# ktlint 1.x syntax: use ktlint_standard_<rule> = disabled
 [*.{kt,kts}]
-ktlint_disabled_rules = no-wildcard-imports,import-ordering
+ktlint_standard_no-wildcard-imports = disabled
+ktlint_standard_import-ordering = disabled
 
-[*.{xml,gradle,gradle.kts}]
+# XML, Gradle (Groovy), HTML
+[*.{xml,gradle,html}]
 indent_size = 2
 
 [*.{yml,yaml}]
@@ -27,13 +30,18 @@ indent_size = 2
 [*.{json,md}]
 indent_size = 2
 
-# Gradle files
-[*.gradle]
-indent_size = 2
-
+# Gradle Kotlin DSL
 [*.gradle.kts]
 indent_size = 4
 
-# Android XML resources
-[*.{xml,html}]
+# Properties files
+[*.properties]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+indent_size = 2
+
+# TOML files (e.g., version catalogs)
+[*.toml]
 indent_size = 2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ buildscript {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
         classpath("org.jetbrains.kotlinx:kover:0.5.1")
         classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.21.0")
+        classpath("org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin:12.1.2")
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.9.20")
         classpath("com.android.tools.build:gradle:$androidGradlePluginVersion")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
@@ -35,6 +36,19 @@ allprojects {
 
     configurations.all {
         resolutionStrategy.force("org.objenesis:objenesis:3.3")
+    }
+}
+
+// ktlint configuration applied to all subprojects
+subprojects {
+    apply(plugin = "org.jlleitschuh.gradle.ktlint")
+
+    extensions.configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
+        version.set("1.3.1")
+        android.set(true)
+        outputToConsole.set(true)
+        // Don't fail the build on existing code — tooling-only for now
+        ignoreFailures.set(true)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,8 +47,11 @@ subprojects {
         version.set("1.3.1")
         android.set(true)
         outputToConsole.set(true)
-        // Don't fail the build on existing code — tooling-only for now
+        // Transitional: keep ignoreFailures until ktlint-baseline.xml is generated.
+        // To migrate: run ./gradlew ktlintBaseline, then uncomment the baseline line below
+        // and remove ignoreFailures.
         ignoreFailures.set(true)
+        // baseline.set(file("ktlint-baseline.xml"))
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ pluginManagement {
         id("org.jetbrains.kotlin.android") version "1.9.23"
         id("org.jetbrains.kotlin.plugin.compose") version "1.9.23"
         id("io.gitlab.arturbosch.detekt") version "1.23.7"
+        id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
         id("com.google.gms.google-services") version "4.4.2" apply false
     }
 }


### PR DESCRIPTION
## Summary

Adds ktlint linting tooling and an `.editorconfig` to the repository root.

## Changes

- **`.editorconfig`** — Standard Kotlin/Android editor config:
  - UTF-8 charset, LF line endings
  - 4-space indent for Kotlin (`.kt`, `.kts`)
  - 2-space indent for XML, YAML, JSON, Markdown
  - Max line length: 120
  - Trailing whitespace trimmed, final newline inserted
  - Disables `no-wildcard-imports` and `import-ordering` rules for existing codebase

- **`build.gradle.kts`** — ktlint-gradle plugin integration:
  - Adds `org.jlleitschuh.gradle.ktlint:ktlint-gradle:12.1.2` to buildscript classpath
  - Applies ktlint plugin to all subprojects
  - Configures ktlint engine version 1.3.1 with `android = true`
  - Sets `ignoreFailures = true` so existing violations don't break the build

- **`settings.gradle.kts`** — Registers ktlint plugin in plugins block

## Verification

```bash
./gradlew ktlintCheck
# BUILD SUCCESSFUL in 21s
# 34 actionable tasks: 34 executed
```

ktlint reports existing style violations but does not fail the build (`ignoreFailures = true`). Fixing violations is deferred to follow-up PRs.

## Ticket

[VSDK-359](https://telnyx.atlassian.net/browse/VSDK-359)