### PR TITLE
Expand 3.6.0 changelog notes

### DIFF
--- a/telnyx_rtc/CHANGELOG.md
+++ b/telnyx_rtc/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Enhancement
 - Auto-include `answered_device_token` in `telnyx_rtc.answer` from the configured `fcmToken` for push-when-active flows (VSDK-431)
+- Add `pushWhenActive` support to `CredentialConfig` and `TokenConfig` so apps can opt in to receiving push notifications while a client is active.
+- Add `Answered Elsewhere` push cleanup handling to dismiss incoming call notifications and stop ringing services when a call is picked up on another device.
+- Persist the selected environment for push answer and decline flows.
+- Keep `telnyx_common` profile config helpers opted out of push-when-active by default.
+- Add guidance for push-when-active multi-device flows, answered-elsewhere cleanup, and missed-call notification handling in the push notification docs and sample READMEs.
 
 ## [3.5.0](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/3.5.0) (2026-03-20)
 

--- a/telnyx_rtc/CHANGELOG.md
+++ b/telnyx_rtc/CHANGELOG.md
@@ -17,10 +17,9 @@
 
 ### Enhancement
 - Auto-include `answered_device_token` in `telnyx_rtc.answer` from the configured `fcmToken` for push-when-active flows (VSDK-431)
-- Add `pushWhenActive` support to `CredentialConfig` and `TokenConfig` so apps can opt in to receiving push notifications while a client is active.
+- Add `pushWhenActive` support to `CredentialConfig` and `TokenConfig` so apps can opt in to receiving push notifications while a client is active. Default behavior is unchanged for existing users.
 - Add `Answered Elsewhere` push cleanup handling to dismiss incoming call notifications and stop ringing services when a call is picked up on another device.
-- Persist the selected environment for push answer and decline flows.
-- Keep `telnyx_common` profile config helpers opted out of push-when-active by default.
+- Push answer and decline flows now correctly preserve the user-selected environment (production vs development) across app restarts and config recreations.
 - Add guidance for push-when-active multi-device flows, answered-elsewhere cleanup, and missed-call notification handling in the push notification docs and sample READMEs.
 - Add missing latency measurement milestones (WEBRTC-3426)
 


### PR DESCRIPTION
## Summary
- Expand the 3.6.0 changelog entry to include pushWhenActive support, Answered Elsewhere cleanup handling, environment persistence, common-helper default behavior, and docs updates.
- Keep the release notes under Enhancement rather than Bug Fixing.

## Testing
- Not run; changelog-only update.