### PR TITLE
Handle push active parent call IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,9 +390,9 @@ Behavior:
 - **Push-when-active enabled** with a non-blank configured `fcmToken`: the SDK
   populates `answered_device_token` with the same value, so the backend can
   identify the answering device without any extra work in the app.
-- **Parent call ID mapping**: if push metadata includes `parent_call_id`, use it
-  as the notification/UI call ID and fall back to `call_id`. The SDK maps that
-  app-facing ID back to the socket `callID` for answer/end signaling.
+- **Push call ID mapping**: pass the full push metadata to the SDK. The SDK maps
+  the app-visible push `call_id` back to the socket `callID` for answer/end
+  signaling.
 - **Explicit override**: if you pass a non-blank `answeredDeviceToken` argument
   to `acceptCall(callId, destinationNumber, …)`, that explicit value always
   takes precedence. Blank values are ignored and fall back to the configured

--- a/README.md
+++ b/README.md
@@ -390,6 +390,9 @@ Behavior:
 - **Push-when-active enabled** with a non-blank configured `fcmToken`: the SDK
   populates `answered_device_token` with the same value, so the backend can
   identify the answering device without any extra work in the app.
+- **Parent call ID mapping**: if push metadata includes `parent_call_id`, use it
+  as the notification/UI call ID and fall back to `call_id`. The SDK maps that
+  app-facing ID back to the socket `callID` for answer/end signaling.
 - **Explicit override**: if you pass a non-blank `answeredDeviceToken` argument
   to `acceptCall(callId, destinationNumber, …)`, that explicit value always
   takes precedence. Blank values are ignored and fall back to the configured

--- a/docs-markdown/push-notification/app-setup.md
+++ b/docs-markdown/push-notification/app-setup.md
@@ -30,8 +30,8 @@ When `pushWhenActive` is `true`:
 
 1. The login payload includes `push_when_active = true` and `pn_late_fanout = true` in `userVariables` so the backend keeps the push-when-active call on the push/on-hold route and allows late fan-out to additional active sockets.
 2. When `acceptCall(...)` is invoked, the SDK sends `answered_device_token` inside the `telnyx_rtc.answer` payload. The value is the same FCM token supplied through `CredentialConfig(fcmToken = ...)` or `TokenConfig(fcmToken = ...)`, so apps do not need to pass it again at answer time.
-3. If push metadata includes `parent_call_id`, apps can use it as the notification/UI call ID and fall back to `call_id` when it is missing. The SDK maps that app-facing ID to the socket `callID` internally after the INVITE arrives.
-4. If the socket is already connected and the INVITE arrives without a push, the SDK uses the INVITE variable `telnyx_rtc_svar_parent_call_id` for the same app-ID-to-socket-callID mapping.
+3. When your app passes the full push metadata to `connect(txPushMetaData = ...)`, the SDK uses the push payload `call_id` as the app-facing call ID and maps it internally to the socket `callID` used for signaling.
+4. If there is no pending push remap for the incoming INVITE, the SDK keeps the socket `callID` as the app-facing ID. INVITE variables such as `telnyx_rtc_svar_parent_call_id` are surfaced to the app, but are not used for SDK call-ID remapping.
 5. If no `fcmToken` is configured, or it is empty or whitespace-only, the `answered_device_token` field is omitted.
 
 The default value of `pushWhenActive` is `false`, which preserves the existing single-device behavior.
@@ -182,7 +182,7 @@ You are now ready to receive push notifications via Firebase Messaging Service.
 ### Handling Push Notifications once received - TxPushMetaData
 The Telnyx SDK provides a `TxPushMetaData` object that can be used to handle push notifications when a call is received. You can parse the `TxPushMetaData` object to get the call details that then need to be provided to the `connect` method when reconnecting to the socket as a result of reacting to a push notification.
 
-For push-when-active multi-device calls, prefer `parent_call_id` from the push metadata as the notification/UI call ID and fall back to `call_id`. Continue passing the full metadata JSON to `connect(txPushMetaData = ...)`; the SDK uses it to map the app-facing ID back to the socket `callID` used for signaling.
+For push-when-active multi-device calls, continue passing the full metadata JSON to `connect(txPushMetaData = ...)`. The SDK uses the push payload `call_id` as the app-facing ID when it needs to remap that call to the socket `callID` used for signaling.
 
 ```kotlin
     private const val MISSED_CALL = "Missed call!"

--- a/docs-markdown/push-notification/app-setup.md
+++ b/docs-markdown/push-notification/app-setup.md
@@ -30,7 +30,9 @@ When `pushWhenActive` is `true`:
 
 1. The login payload includes `push_when_active = true` and `pn_late_fanout = true` in `userVariables` so the backend keeps the push-when-active call on the push/on-hold route and allows late fan-out to additional active sockets.
 2. When `acceptCall(...)` is invoked, the SDK sends `answered_device_token` inside the `telnyx_rtc.answer` payload. The value is the same FCM token supplied through `CredentialConfig(fcmToken = ...)` or `TokenConfig(fcmToken = ...)`, so apps do not need to pass it again at answer time.
-3. If no `fcmToken` is configured, or it is empty or whitespace-only, the `answered_device_token` field is omitted.
+3. If push metadata includes `parent_call_id`, apps can use it as the notification/UI call ID and fall back to `call_id` when it is missing. The SDK maps that app-facing ID to the socket `callID` internally after the INVITE arrives.
+4. If the socket is already connected and the INVITE arrives without a push, the SDK uses the INVITE variable `telnyx_rtc_svar_parent_call_id` for the same app-ID-to-socket-callID mapping.
+5. If no `fcmToken` is configured, or it is empty or whitespace-only, the `answered_device_token` field is omitted.
 
 The default value of `pushWhenActive` is `false`, which preserves the existing single-device behavior.
 
@@ -179,6 +181,8 @@ You are now ready to receive push notifications via Firebase Messaging Service.
 
 ### Handling Push Notifications once received - TxPushMetaData
 The Telnyx SDK provides a `TxPushMetaData` object that can be used to handle push notifications when a call is received. You can parse the `TxPushMetaData` object to get the call details that then need to be provided to the `connect` method when reconnecting to the socket as a result of reacting to a push notification.
+
+For push-when-active multi-device calls, prefer `parent_call_id` from the push metadata as the notification/UI call ID and fall back to `call_id`. Continue passing the full metadata JSON to `connect(txPushMetaData = ...)`; the SDK uses it to map the app-facing ID back to the socket `callID` used for signaling.
 
 ```kotlin
     private const val MISSED_CALL = "Missed call!"

--- a/telnyx_rtc/CHANGELOG.md
+++ b/telnyx_rtc/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Enhancement
 - Auto-include `pn_late_fanout` alongside `push_when_active` in login `userVariables` for push-when-active multi-device routing
 
+### Bug Fixing
+- Use the push payload `call_id` as the stable app-facing ID for push-when-active remaps while keeping the socket `callID` for answer/end signaling.
+
 ## [3.6.0](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/3.6.0) (2026-07-16)
 
 ### Enhancement

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -82,6 +82,7 @@ data class Call(
     var inviteResponse: InviteResponse? = null
     var answerResponse: AnswerResponse? = null
     lateinit var callId: UUID
+    internal var signalingCallId: UUID? = null
 
     internal var telnyxSessionId: UUID? = null
     internal var telnyxLegId: UUID? = null
@@ -183,6 +184,8 @@ data class Call(
         client.acceptCall(callId, destinationNumber, customHeaders, debug)
     }
 
+    internal fun currentSignalingCallId(): UUID = signalingCallId ?: callId
+
     /**
      * Accepts an attach invitation
      * Functions the same as the acceptCall but changes the attach param to true
@@ -242,7 +245,7 @@ data class Call(
 
         // Track mute/unmute state change
         val state = if (muted) "muted" else "unmuted"
-        client.debugDataCollector.onTrackStateChange(callId, "audio", state)
+        client.debugDataCollector.onTrackStateChange(currentSignalingCallId(), "audio", state)
     }
 
     /**
@@ -254,14 +257,14 @@ data class Call(
             loudSpeakerLiveData.postValue(true)
             audioManager.isSpeakerphoneOn = true
             // Track speaker output change
-            client.debugDataCollector.onSpeakerOutputChange(callId, "LOUDSPEAKER", true)
-            client.debugDataCollector.onAudioDeviceChange(callId, "Speaker enabled")
+            client.debugDataCollector.onSpeakerOutputChange(currentSignalingCallId(), "LOUDSPEAKER", true)
+            client.debugDataCollector.onAudioDeviceChange(currentSignalingCallId(), "Speaker enabled")
         } else {
             loudSpeakerLiveData.postValue(false)
             audioManager.isSpeakerphoneOn = false
             // Track speaker output change
-            client.debugDataCollector.onSpeakerOutputChange(callId, "LOUDSPEAKER", false)
-            client.debugDataCollector.onAudioDeviceChange(callId, "Speaker disabled")
+            client.debugDataCollector.onSpeakerOutputChange(currentSignalingCallId(), "LOUDSPEAKER", false)
+            client.debugDataCollector.onAudioDeviceChange(currentSignalingCallId(), "Speaker disabled")
         }
         Timber.e("audioManager.isSpeakerphoneOn ${audioManager.isSpeakerphoneOn}")
     }
@@ -298,6 +301,7 @@ data class Call(
      * @param holdAction, the modification action to perform
      */
     private fun sendHoldModifier(callId: UUID, holdAction: String) {
+        val signalingCallId = client.signalingCallId(callId)
         val uuid: String = UUID.randomUUID().toString()
         val modifyMessageBody = SendingMessageBody(
             id = uuid,
@@ -306,7 +310,7 @@ data class Call(
                 sessid = sessionId,
                 action = holdAction,
                 dialogParams = CallDialogParams(
-                    callId = callId,
+                    callId = signalingCallId,
                 )
             )
         )
@@ -321,6 +325,7 @@ data class Call(
      */
 
     fun dtmf(callId: UUID, tone: String) {
+        val signalingCallId = client.signalingCallId(callId)
         val uuid: String = UUID.randomUUID().toString()
         val infoMessageBody = SendingMessageBody(
             id = uuid,
@@ -329,7 +334,7 @@ data class Call(
                 sessid = sessionId,
                 dtmf = tone,
                 dialogParams = CallDialogParams(
-                    callId = callId,
+                    callId = signalingCallId,
                 )
             )
         )
@@ -487,7 +492,7 @@ data class Call(
         // Potentially add logic here if needed when a candidate is received,
         // but the primary action is adding it to the list for the timer.
         iceCandidateList.add(candidate)
-        Logger.d(message = "Call [$callId] received ICE candidate. List size: ${iceCandidateList.size}")
+        Logger.d(message = "Call [${currentSignalingCallId()}] received ICE candidate. List size: ${iceCandidateList.size}")
     }
 
     /**
@@ -504,7 +509,7 @@ data class Call(
     ) {
         // Ensure peerConnection is initialized for this Call instance before proceeding
         if (peerConnection == null) {
-            Logger.e(message = "PeerConnection not initialized for Call [$callId] before starting outgoing call.")
+            Logger.e(message = "PeerConnection not initialized for Call [${currentSignalingCallId()}] before starting outgoing call.")
             updateCallState(CallState.ERROR)
             return
         }
@@ -516,7 +521,7 @@ data class Call(
             override fun onCreateSuccess(sessionDescription: SessionDescription?) {
                 if (client.getUseTrickleIce()) {
                     // For trickle ICE, send INVITE immediately without waiting for candidates
-                    Logger.d(message = "Trickle ICE enabled - sending INVITE immediately for Call [$callId]")
+                    Logger.d(message = "Trickle ICE enabled - sending INVITE immediately for Call [${currentSignalingCallId()}]")
 
                     sendInviteImmediately(
                         callerName,
@@ -540,7 +545,7 @@ data class Call(
             }
 
             override fun onCreateFailure(p0: String?) {
-                 Logger.e(message = "Failed to create SDP offer for Call [$callId]: $p0")
+                 Logger.e(message = "Failed to create SDP offer for Call [${currentSignalingCallId()}]: $p0")
                  updateCallState(CallState.ERROR)
             }
         })
@@ -562,7 +567,7 @@ data class Call(
             // Add trickle ICE capability to SDP
             sdpDescription = SdpUtils.addTrickleIceCapability(sdpDescription)
             
-            Logger.d(message = "Sending INVITE immediately with trickle ICE for Call [$callId]")
+            Logger.d(message = "Sending INVITE immediately with trickle ICE for Call [${currentSignalingCallId()}]")
             
             val inviteMessageBody = SendingMessageBody(
                 id = outgoingInviteUUID!!,
@@ -584,10 +589,10 @@ data class Call(
             )
             socket.send(inviteMessageBody)
             // Track invite sent milestone
-            client.latencyTracker.markCallMilestone(callId, LatencyTracker.MILESTONE_INVITE_SENT)
+            client.latencyTracker.markCallMilestone(currentSignalingCallId(), LatencyTracker.MILESTONE_INVITE_SENT)
         } else {
-            if (sdpDescription == null) Logger.e(message = "Failed to get local SDP description for Call [$callId]. Cannot send invite.")
-            if (outgoingInviteUUID == null) Logger.e(message = "Missing outgoingInviteUUID for Call [$callId]. Cannot send invite.")
+            if (sdpDescription == null) Logger.e(message = "Failed to get local SDP description for Call [${currentSignalingCallId()}]. Cannot send invite.")
+            if (outgoingInviteUUID == null) Logger.e(message = "Missing outgoingInviteUUID for Call [${currentSignalingCallId()}]. Cannot send invite.")
             updateCallState(CallState.ERROR)
         }
     }
@@ -637,16 +642,16 @@ data class Call(
                         )
                         socket.send(inviteMessageBody)
                         // Track invite sent milestone
-                        client.latencyTracker.markCallMilestone(callId, LatencyTracker.MILESTONE_INVITE_SENT)
+                        client.latencyTracker.markCallMilestone(currentSignalingCallId(), LatencyTracker.MILESTONE_INVITE_SENT)
                         resetIceCandidateTimer() // Stop timer after sending
                     } else {
-                         if (sdpDescription == null) Logger.e(message = "Failed to get local SDP description for Call [$callId]. Cannot send invite.")
-                         if (outgoingInviteUUID == null) Logger.e(message = "Missing outgoingInviteUUID for Call [$callId]. Cannot send invite.")
+                         if (sdpDescription == null) Logger.e(message = "Failed to get local SDP description for Call [${currentSignalingCallId()}]. Cannot send invite.")
+                         if (outgoingInviteUUID == null) Logger.e(message = "Missing outgoingInviteUUID for Call [${currentSignalingCallId()}]. Cannot send invite.")
                          resetIceCandidateTimer() // Reset timer even on failure
                          updateCallState(CallState.ERROR) // Mark call as errored if SDP/UUID is missing
                     }
                 } else {
-                    Logger.d(message = "Call [$callId] - Event-ICE_CANDIDATE_DELAY - Waiting for STUN or TURN")
+                    Logger.d(message = "Call [${currentSignalingCallId()}] - Event-ICE_CANDIDATE_DELAY - Waiting for STUN or TURN")
                 }
             },
             ICE_CANDIDATE_DELAY, ICE_CANDIDATE_PERIOD
@@ -662,7 +667,7 @@ data class Call(
         iceCandidateTimer?.purge()
         iceCandidateTimer = null
         iceCandidateList.clear()
-        Logger.d(message =  "Call [${this.callId}] ICE candidate timer reset.")
+        Logger.d(message =  "Call [${currentSignalingCallId()}] ICE candidate timer reset.")
     }
 
     /**
@@ -672,13 +677,13 @@ data class Call(
      * @return true if the renegotiation was successfully triggered, false otherwise
      */
     fun forceIceRenegotiationForTesting(): Boolean {
-        Logger.w(tag = "Call:IceRenegotiationTest", message = "Forcing ICE renegotiation for testing in Call [${this.callId}]")
+        Logger.w(tag = "Call:IceRenegotiationTest", message = "Forcing ICE renegotiation for testing in Call [${currentSignalingCallId()}]")
         
         return peerConnection?.let { peer ->
             peer.forceIceRenegotiationForTesting()
             true
         } ?: run {
-            Logger.e(tag = "Call:IceRenegotiationTest", message = "Cannot force ICE renegotiation - peerConnection is null in Call [${this.callId}]")
+            Logger.e(tag = "Call:IceRenegotiationTest", message = "Cannot force ICE renegotiation - peerConnection is null in Call [${currentSignalingCallId()}]")
             false
         }
     }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -266,6 +266,8 @@ class TelnyxClient private constructor(
 
     // Keeps track of all the created calls by theirs UUIDs
     internal val calls: MutableMap<UUID, Call> = mutableMapOf()
+    private val socketCallIdByAppCallId: MutableMap<UUID, UUID> = mutableMapOf()
+    private val appCallIdBySocketCallId: MutableMap<UUID, UUID> = mutableMapOf()
 
     // Keeps track of pending ICE candidates that arrive before remote description is set
     private val pendingIceCandidates: MutableMap<UUID, MutableList<PendingIceCandidate>> =
@@ -335,6 +337,7 @@ class TelnyxClient private constructor(
 
     private var isCallPendingFromPush: Boolean = false
     private var pushMetaData: PushMetaData? = null
+    private var pendingPushAppCallId: UUID? = null
 
     /**
      * Processes an incoming call notification from a push message.
@@ -345,6 +348,8 @@ class TelnyxClient private constructor(
         Logger.d("processCallFromPush PushMetaData", metaData.toJson())
         isCallPendingFromPush = true
         this.pushMetaData = metaData
+        // Push path: app-provided FCM metadata can seed UI with parent_call_id before the INVITE arrives.
+        pendingPushAppCallId = pushAppCallId(metaData)
     }
 
     /**
@@ -420,6 +425,19 @@ class TelnyxClient private constructor(
         // caller-provided values still win; null/blank inputs fall back to the session's
         // configured push token, and only the resulting non-blank value is sent.
         val resolvedAnsweredDeviceToken = resolveAnsweredDeviceToken(answeredDeviceToken)
+        val signalingCallId = signalingCallId(callId)
+        if (signalingCallId != callId) {
+            return acceptCall(
+                callId = signalingCallId,
+                destinationNumber = destinationNumber,
+                customHeaders = customHeaders,
+                debug = debug,
+                useTrickleIce = useTrickleIce,
+                audioConstraints = audioConstraints,
+                mutedMicOnStart = mutedMicOnStart,
+                answeredDeviceToken = answeredDeviceToken
+            )
+        }
 
         val callDebug = debug
         val socketPortalDebug = isSocketDebug
@@ -690,6 +708,34 @@ class TelnyxClient private constructor(
         return configured?.trim()?.takeIf { it.isNotEmpty() }
     }
 
+    private fun pushWhenActiveEnabled(): Boolean =
+        credentialSessionConfig?.pushWhenActive == true || tokenSessionConfig?.pushWhenActive == true
+
+    private fun String?.toUuidOrNull(): UUID? =
+        this?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+
+    private fun pushAppCallId(metaData: PushMetaData): UUID? {
+        if (!pushWhenActiveEnabled()) return null
+        return metaData.parentCallId.toUuidOrNull() ?: metaData.callId.toUuidOrNull()
+    }
+
+    private fun inviteVariables(params: JsonObject): Map<String, String> {
+        val variablesElement = params.get("variables")
+        if (variablesElement?.isJsonObject != true) return emptyMap()
+        val variables = variablesElement.asJsonObject
+        return variables.entrySet().mapNotNull { (key, value) ->
+            value.takeIf { !it.isJsonNull }?.asString?.let { key to it }
+        }.toMap()
+    }
+
+    private fun inviteAppCallId(variables: Map<String, String>, socketCallId: UUID): UUID? {
+        if (!pushWhenActiveEnabled()) return null
+        // Socket path: already-connected clients get the parent ID from INVITE variables instead of push metadata.
+        return variables["telnyx_rtc_svar_parent_call_id"].toUuidOrNull()
+            ?: pendingPushAppCallId
+            ?: appCallIdBySocketCallId[socketCallId]
+    }
+
 
     /**
      * Creates a new outgoing call invitation.
@@ -846,7 +892,9 @@ class TelnyxClient private constructor(
      * @see [Call]
      */
     fun endCall(callId: UUID) {
-        val endCall = calls[callId]
+        val signalingCallId = signalingCallId(callId)
+        val appFacingCallId = appCallId(signalingCallId)
+        val endCall = calls[signalingCallId]
         endCall?.apply {
             val uuid: String = UUID.randomUUID().toString()
             // Determine cause code and name based on call state
@@ -862,7 +910,7 @@ class TelnyxClient private constructor(
 
             Logger.d(
                 tag = "EndCall",
-                message = "Ending call with ID: $callId, current state: ${callStateFlow.value}, cause: $causeName ($causeCode)"
+                message = "Ending call with ID: $signalingCallId, current state: ${callStateFlow.value}, cause: $causeName ($causeCode)"
             )
 
             val byeMessageBody = SendingMessageBody(
@@ -872,13 +920,13 @@ class TelnyxClient private constructor(
                     causeCode,
                     causeName,
                     ByeDialogParams(
-                        callId
+                        signalingCallId
                     )
                 )
             )
 
             val byeResponseForUi = ByeResponse(
-                callId = callId,
+                callId = appFacingCallId,
                 cause = causeName,
                 causeCode = causeCode
                 // sipCode and sipReason are null here
@@ -895,12 +943,12 @@ class TelnyxClient private constructor(
             updateCallState(CallState.DONE(terminationReason))
 
             // Stop reporter before releasing the peer connection
-            removeWebRTCReporter(callId)?.stopStats()
+            removeWebRTCReporter(signalingCallId)?.stopStats()
 
             // Log debug data for the ended call
-            client.debugDataCollector.onCallEnded(callId, causeName)
+            client.debugDataCollector.onCallEnded(signalingCallId, causeName)
 
-            client.removeFromCalls(callId)
+            client.removeFromCalls(signalingCallId)
             client.callNotOngoing()
             socket.send(byeMessageBody)
             resetCallOptions()
@@ -922,6 +970,20 @@ class TelnyxClient private constructor(
         calls[call.callId] = call
     }
 
+    internal fun registerCallIdAlias(appCallId: UUID, socketCallId: UUID) {
+        if (appCallId == socketCallId) {
+            pendingPushAppCallId = null
+            return
+        }
+        socketCallIdByAppCallId[appCallId] = socketCallId
+        appCallIdBySocketCallId[socketCallId] = appCallId
+        pendingPushAppCallId = null
+    }
+
+    internal fun signalingCallId(appCallId: UUID): UUID = socketCallIdByAppCallId[appCallId] ?: appCallId
+
+    internal fun appCallId(socketCallId: UUID): UUID = appCallIdBySocketCallId[socketCallId] ?: socketCallId
+
     /**
      * Remove specified call from the calls MutableMap
      * @param callId, the UUID used to identify a specific
@@ -929,6 +991,7 @@ class TelnyxClient private constructor(
     internal fun removeFromCalls(callId: UUID) {
         cancelAcceptCallJob(callId)
         calls.remove(callId)
+        appCallIdBySocketCallId.remove(callId)?.let { socketCallIdByAppCallId.remove(it) }
         
         // Clean up latency tracking for this call
         latencyTracker.cancelCallTracking(callId)
@@ -2851,6 +2914,7 @@ class TelnyxClient private constructor(
             val sipCode = params.get("sipCode")?.asInt
             val sipReason = params.get("sipReason")?.asString
 
+            val appFacingCallId = appCallId(callId)
             val byeCall = calls[callId]
             byeCall?.apply {
                 val terminationReason = CallTerminationReason(
@@ -2863,7 +2927,7 @@ class TelnyxClient private constructor(
 
                 // Create the rich ByeResponse to be sent to the UI/ViewModel
                 val byeResponseForUi = ByeResponse(
-                    callId = callId,
+                    callId = appFacingCallId,
                     cause = cause,
                     causeCode = causeCode,
                     sipCode = sipCode,
@@ -3167,6 +3231,9 @@ class TelnyxClient private constructor(
             ).apply {
                 val params = jsonObject.getAsJsonObject("params")
                 val offerCallId = UUID.fromString(params.get("callID").asString)
+                val variables = inviteVariables(params)
+                val appCallId = inviteAppCallId(variables, offerCallId) ?: offerCallId
+                registerCallIdAlias(appCallId, offerCallId)
                 val remoteSdp = params.get("sdp").asString
 
                 // Check if remote party supports trickle ICE
@@ -3266,12 +3333,13 @@ class TelnyxClient private constructor(
                 )
 
                 val inviteResponse = InviteResponse(
-                    callId,
+                    appCallId,
                     remoteSdp,
                     callerName,
                     callerNumber,
                     sessionId,
-                    customHeaders = customHeaders?.toCustomHeaders() ?: arrayListOf()
+                    customHeaders = customHeaders?.toCustomHeaders() ?: arrayListOf(),
+                    variables = variables
                 )
                 this.inviteResponse = inviteResponse
 

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -266,8 +266,8 @@ class TelnyxClient private constructor(
 
     // Keeps track of all the created calls by theirs UUIDs
     internal val calls: MutableMap<UUID, Call> = mutableMapOf()
-    private val socketCallIdByAppCallId: MutableMap<UUID, UUID> = mutableMapOf()
-    private val appCallIdBySocketCallId: MutableMap<UUID, UUID> = mutableMapOf()
+    private val socketCallIdByAppCallId: ConcurrentHashMap<UUID, UUID> = ConcurrentHashMap()
+    private val appCallIdBySocketCallId: ConcurrentHashMap<UUID, UUID> = ConcurrentHashMap()
 
     // Keeps track of pending ICE candidates that arrive before remote description is set
     private val pendingIceCandidates: MutableMap<UUID, MutableList<PendingIceCandidate>> =
@@ -732,7 +732,7 @@ class TelnyxClient private constructor(
         if (!pushWhenActiveEnabled()) return null
         // Socket path: already-connected clients get the parent ID from INVITE variables instead of push metadata.
         return variables["telnyx_rtc_svar_parent_call_id"].toUuidOrNull()
-            ?: pendingPushAppCallId
+            ?: pendingPushAppCallId.takeIf { isCallPendingFromPush }
             ?: appCallIdBySocketCallId[socketCallId]
     }
 
@@ -992,6 +992,10 @@ class TelnyxClient private constructor(
         cancelAcceptCallJob(callId)
         calls.remove(callId)
         appCallIdBySocketCallId.remove(callId)?.let { socketCallIdByAppCallId.remove(it) }
+        socketCallIdByAppCallId.remove(callId)?.let { appCallIdBySocketCallId.remove(it) }
+        if (calls.isEmpty()) {
+            clearPendingPushCall()
+        }
         
         // Clean up latency tracking for this call
         latencyTracker.cancelCallTracking(callId)
@@ -3672,7 +3676,14 @@ class TelnyxClient private constructor(
         cancelSocketConnectJob()
         cancelAcceptCallJobs()
         socket.destroy()
+        clearPendingPushCall()
         clearTransientDeclinePushMode()
+    }
+
+    private fun clearPendingPushCall() {
+        isCallPendingFromPush = false
+        pendingPushAppCallId = null
+        pushMetaData = null
     }
 
     /**

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -348,7 +348,7 @@ class TelnyxClient private constructor(
         Logger.d("processCallFromPush PushMetaData", metaData.toJson())
         isCallPendingFromPush = true
         this.pushMetaData = metaData
-        // Push path: app-provided FCM metadata can seed UI with parent_call_id before the INVITE arrives.
+        // Push path: use the app-visible push call_id and remap it to the socket callID when INVITE arrives.
         pendingPushAppCallId = pushAppCallId(metaData)
     }
 
@@ -716,7 +716,7 @@ class TelnyxClient private constructor(
 
     private fun pushAppCallId(metaData: PushMetaData): UUID? {
         if (!pushWhenActiveEnabled()) return null
-        return metaData.parentCallId.toUuidOrNull() ?: metaData.callId.toUuidOrNull()
+        return metaData.callId.toUuidOrNull()
     }
 
     private fun inviteVariables(params: JsonObject): Map<String, String> {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -32,8 +32,6 @@ import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
 import com.telnyx.webrtc.sdk.utilities.CallTimingBenchmark
 import com.telnyx.webrtc.sdk.utilities.CandidateUtils
 import com.telnyx.webrtc.sdk.utilities.LatencyTracker
-import com.telnyx.webrtc.sdk.model.LatencyMetrics
-import com.telnyx.webrtc.sdk.model.LatencyMetricsListener
 import com.telnyx.webrtc.sdk.utilities.ConnectivityHelper
 import com.telnyx.webrtc.sdk.utilities.Logger
 import com.telnyx.webrtc.sdk.utilities.TxLogger
@@ -439,7 +437,6 @@ class TelnyxClient private constructor(
             )
         }
 
-        val callDebug = debug
         val socketPortalDebug = isSocketDebug
 
         // Set trickle ICE for this call
@@ -545,7 +542,7 @@ class TelnyxClient private constructor(
                             callId,
                             getTelnyxLegId()?.toString(),
                             peerConnection!!,
-                            callDebug,
+                            debug,
                             socketPortalDebug,
                             debugDataCollector
                         )
@@ -646,7 +643,7 @@ class TelnyxClient private constructor(
                                         callId,
                                         getTelnyxLegId()?.toString(),
                                         peerConnection!!,
-                                        callDebug,
+                                        debug,
                                         socketPortalDebug,
                                         debugDataCollector
                                     )
@@ -728,11 +725,10 @@ class TelnyxClient private constructor(
         }.toMap()
     }
 
-    private fun inviteAppCallId(variables: Map<String, String>, socketCallId: UUID): UUID? {
+    private fun inviteAppCallId(socketCallId: UUID): UUID? {
         if (!pushWhenActiveEnabled()) return null
-        // Socket path: already-connected clients get the parent ID from INVITE variables instead of push metadata.
-        return variables["telnyx_rtc_svar_parent_call_id"].toUuidOrNull()
-            ?: pendingPushAppCallId.takeIf { isCallPendingFromPush }
+        // Only remap when the SDK already learned the app-facing ID from the push path.
+        return pendingPushAppCallId.takeIf { isCallPendingFromPush }
             ?: appCallIdBySocketCallId[socketCallId]
     }
 
@@ -967,7 +963,7 @@ class TelnyxClient private constructor(
      * @param call, and instance of [Call]
      */
     internal fun addToCalls(call: Call) {
-        calls[call.callId] = call
+        calls[call.currentSignalingCallId()] = call
     }
 
     internal fun registerCallIdAlias(appCallId: UUID, socketCallId: UUID) {
@@ -3042,7 +3038,7 @@ class TelnyxClient private constructor(
                     client.debugDataCollector.addCallTimingsLogs(UUID.fromString(callId), client.latencyTracker.completeCallTracking(UUID.fromString(callId)))
 
                     val answerResponse = AnswerResponse(
-                        UUID.fromString(callId),
+                        appCallId(UUID.fromString(callId)),
                         stringSdp,
                         customHeaders?.toCustomHeaders() ?: arrayListOf(),
                         callControlId
@@ -3062,7 +3058,7 @@ class TelnyxClient private constructor(
                     updateCallState(CallState.CONNECTING)
                     val stringSdp = peerConnection?.getLocalDescription()?.description
                     val answerResponse = AnswerResponse(
-                        UUID.fromString(callId),
+                        appCallId(UUID.fromString(callId)),
                         stringSdp!!,
                         customHeaders?.toCustomHeaders() ?: arrayListOf(),
                         callControlId
@@ -3180,7 +3176,7 @@ class TelnyxClient private constructor(
                     if (params.has("caller_id_number")) params.get("caller_id_number").asString else ""
 
                 val mediaResponse = MediaResponse(
-                    UUID.fromString(callId),
+                    appCallId(UUID.fromString(callId)),
                     callerIDName,
                     callerNumber,
                     sessionId,
@@ -3236,7 +3232,7 @@ class TelnyxClient private constructor(
                 val params = jsonObject.getAsJsonObject("params")
                 val offerCallId = UUID.fromString(params.get("callID").asString)
                 val variables = inviteVariables(params)
-                val appCallId = inviteAppCallId(variables, offerCallId) ?: offerCallId
+                val appCallId = inviteAppCallId(offerCallId) ?: offerCallId
                 registerCallIdAlias(appCallId, offerCallId)
                 val remoteSdp = params.get("sdp").asString
 
@@ -3274,8 +3270,9 @@ class TelnyxClient private constructor(
                 telnyxSessionId = UUID.fromString(params.get("telnyx_session_id").asString)
                 telnyxLegId = UUID.fromString(params.get("telnyx_leg_id").asString)
 
-                // Set global callID
-                callId = offerCallId
+                // Expose the app-facing ID while keeping the signaling ID for socket operations.
+                callId = appCallId
+                signalingCallId = offerCallId
                 
                 // Start latency tracking when invite is received (for answer delay calculation)
                 client.latencyTracker.startCallTracking(offerCallId, isOutbound = false, useTrickleIce = useTrickleIce)
@@ -3417,7 +3414,7 @@ class TelnyxClient private constructor(
                 params.get("dialogParams")?.asJsonObject?.get("custom_headers")?.asJsonArray
 
             val ringingResponse = RingingResponse(
-                UUID.fromString(callId),
+                appCallId(callUuid),
                 params.get("caller_id_name").asString,
                 params.get("caller_id_number").asString,
                 sessionId,
@@ -3504,8 +3501,9 @@ class TelnyxClient private constructor(
             telnyxSessionId = UUID.fromString(params.get("telnyx_session_id").asString)
             telnyxLegId = UUID.fromString(params.get("telnyx_leg_id").asString)
 
-            // Set global callID
-            callId = offerCallId
+            // Preserve the app-facing ID across reattach while continuing to signal with callID.
+            callId = appCallId(offerCallId)
+            signalingCallId = offerCallId
 
             // Notify debug data collector that a new call has started (push notification reattach)
             client.debugDataCollector.onCallStarted(offerCallId, telnyxSessionId, telnyxLegId)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/PushMetaData.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/PushMetaData.kt
@@ -16,6 +16,8 @@ data class PushMetaData(
     val rtcIP: String? = null,
     @SerializedName("rtc_port")
     val rtcPort: Int? = null,
+    @SerializedName("parent_call_id")
+    val parentCallId: String? = null,
     ) {
     fun toJson() : String {
       return   Gson() .toJson(this)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/receive/ReceivedResult.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/receive/ReceivedResult.kt
@@ -95,7 +95,9 @@ data class InviteResponse(
     @SerializedName("sessid")
     val sessid: String,
     @SerializedName("custom_headers")
-    val customHeaders: ArrayList<CustomHeaders> = arrayListOf()
+    val customHeaders: ArrayList<CustomHeaders> = arrayListOf(),
+    @SerializedName("variables")
+    val variables: Map<String, String> = emptyMap()
 ) : ReceivedResult()
 
 data class RingingResponse(

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -908,6 +908,29 @@ class TelnyxClientTest : BaseTest() {
         assertEquals(client.getActiveCalls(), mutableMapOf())
     }
 
+    @Test
+    fun `call id alias resolves app id to socket id`() {
+        val appCallId = UUID.randomUUID()
+        val socketCallId = UUID.randomUUID()
+
+        client.registerCallIdAlias(appCallId, socketCallId)
+
+        assertEquals(socketCallId, client.signalingCallId(appCallId))
+        assertEquals(appCallId, client.appCallId(socketCallId))
+    }
+
+    @Test
+    fun `remove from calls clears call id alias`() {
+        val appCallId = UUID.randomUUID()
+        val socketCallId = UUID.randomUUID()
+
+        client.registerCallIdAlias(appCallId, socketCallId)
+        client.removeFromCalls(socketCallId)
+
+        assertEquals(appCallId, client.signalingCallId(appCallId))
+        assertEquals(socketCallId, client.appCallId(socketCallId))
+    }
+
     // Extension function for getOrAwaitValue for unit tests
     fun <T> LiveData<T>.getOrAwaitValue(
         time: Long = 10,

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -931,6 +931,62 @@ class TelnyxClientTest : BaseTest() {
         assertEquals(socketCallId, client.appCallId(socketCallId))
     }
 
+    @Test
+    fun `remove from calls clears call id alias when app id is removed`() {
+        val appCallId = UUID.randomUUID()
+        val socketCallId = UUID.randomUUID()
+
+        client.registerCallIdAlias(appCallId, socketCallId)
+        client.removeFromCalls(appCallId)
+
+        assertEquals(appCallId, client.signalingCallId(appCallId))
+        assertEquals(socketCallId, client.appCallId(socketCallId))
+    }
+
+    @Test
+    fun `invite app call id ignores stale pending push id when push is not pending`() {
+        val stalePendingPushCallId = UUID.randomUUID()
+        val socketCallId = UUID.randomUUID()
+        val config = CredentialConfig(
+            sipUser = MOCK_USERNAME_TEST,
+            sipPassword = MOCK_PASSWORD,
+            sipCallerIDName = "Test",
+            sipCallerIDNumber = "000000000",
+            fcmToken = "fcm-token",
+            ringtone = null,
+            ringBackTone = null,
+            pushWhenActive = true
+        )
+
+        setPrivateField("credentialSessionConfig", config)
+        setPrivateField("tokenSessionConfig", null)
+        setPrivateField("pendingPushAppCallId", stalePendingPushCallId)
+        setPrivateField("isCallPendingFromPush", false)
+
+        val resolved = invokeInviteAppCallId(emptyMap(), socketCallId)
+
+        assertEquals(null, resolved)
+    }
+
+    private fun setPrivateField(name: String, value: Any?) {
+        val field = TelnyxClient::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        field.set(client, value)
+    }
+
+    private fun invokeInviteAppCallId(
+        variables: Map<String, String>,
+        socketCallId: UUID
+    ): UUID? {
+        val method = TelnyxClient::class.java.getDeclaredMethod(
+            "inviteAppCallId",
+            Map::class.java,
+            UUID::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(client, variables, socketCallId) as UUID?
+    }
+
     // Extension function for getOrAwaitValue for unit tests
     fun <T> LiveData<T>.getOrAwaitValue(
         time: Long = 10,

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -26,6 +26,7 @@ import com.telnyx.webrtc.sdk.testhelpers.extensions.CoroutinesTestExtension
 import com.telnyx.webrtc.sdk.testhelpers.extensions.InstantExecutorExtension
 import com.telnyx.webrtc.sdk.utilities.ConnectivityHelper
 import com.telnyx.webrtc.sdk.verto.receive.SocketResponse
+import com.telnyx.webrtc.sdk.verto.receive.ReceivedMessageBody
 import com.telnyx.webrtc.sdk.verto.send.LoginParam
 import com.telnyx.webrtc.sdk.verto.send.SendingMessageBody
 import io.mockk.*
@@ -995,9 +996,104 @@ class TelnyxClientTest : BaseTest() {
         setPrivateField("pendingPushAppCallId", stalePendingPushCallId)
         setPrivateField("isCallPendingFromPush", false)
 
-        val resolved = invokeInviteAppCallId(emptyMap(), socketCallId)
+        val resolved = invokeInviteAppCallId(socketCallId)
 
         assertEquals(null, resolved)
+    }
+
+    @Test
+    fun `invite app call id uses pending push app call id before alias map`() {
+        val pendingPushCallId = UUID.randomUUID()
+        val socketCallId = UUID.randomUUID()
+        val config = CredentialConfig(
+            sipUser = MOCK_USERNAME_TEST,
+            sipPassword = MOCK_PASSWORD,
+            sipCallerIDName = "Test",
+            sipCallerIDNumber = "000000000",
+            fcmToken = "fcm-token",
+            ringtone = null,
+            ringBackTone = null,
+            pushWhenActive = true
+        )
+
+        setPrivateField("credentialSessionConfig", config)
+        setPrivateField("tokenSessionConfig", null)
+        setPrivateField("pendingPushAppCallId", pendingPushCallId)
+        setPrivateField("isCallPendingFromPush", true)
+
+        val resolved = invokeInviteAppCallId(socketCallId)
+
+        assertEquals(pendingPushCallId, resolved)
+    }
+
+    @Test
+    fun `invite app call id falls back to stored alias when push is no longer pending`() {
+        val appCallId = UUID.randomUUID()
+        val socketCallId = UUID.randomUUID()
+        val config = CredentialConfig(
+            sipUser = MOCK_USERNAME_TEST,
+            sipPassword = MOCK_PASSWORD,
+            sipCallerIDName = "Test",
+            sipCallerIDNumber = "000000000",
+            fcmToken = "fcm-token",
+            ringtone = null,
+            ringBackTone = null,
+            pushWhenActive = true
+        )
+
+        setPrivateField("credentialSessionConfig", config)
+        setPrivateField("tokenSessionConfig", null)
+        client.registerCallIdAlias(appCallId, socketCallId)
+
+        val resolved = invokeInviteAppCallId(socketCallId)
+
+        assertEquals(appCallId, resolved)
+    }
+
+    @Test
+    fun `add to calls keeps app facing call id while indexing by signaling call id`() {
+        client = Mockito.spy(TelnyxClient(mockContext))
+        client.socket = Mockito.mock(TxSocket::class.java)
+
+        val appCallId = UUID.randomUUID()
+        val socketCallId = UUID.randomUUID()
+        val fakeCall = Mockito.spy(Call(mockContext, client, client.socket, "", audioManager))
+        fakeCall.callId = appCallId
+        fakeCall.signalingCallId = socketCallId
+
+        client.addToCalls(fakeCall)
+
+        assertEquals(fakeCall, client.calls[socketCallId])
+        assertEquals(appCallId, client.calls[socketCallId]?.callId)
+        assertEquals(socketCallId, client.calls[socketCallId]?.signalingCallId)
+    }
+
+    @Test
+    fun `on bye received emits app facing call id for aliased call`() {
+        client = Mockito.spy(TelnyxClient(mockContext))
+        client.socket = Mockito.mock(TxSocket::class.java)
+
+        val appCallId = UUID.randomUUID()
+        val socketCallId = UUID.randomUUID()
+        client.registerCallIdAlias(appCallId, socketCallId)
+
+        val fakeCall = Mockito.spy(Call(mockContext, client, client.socket, "", audioManager))
+        fakeCall.callId = appCallId
+        fakeCall.signalingCallId = socketCallId
+        client.addToCalls(fakeCall)
+
+        val byeJsonObject = JsonObject()
+        byeJsonObject.add("params", JsonObject().apply {
+            addProperty("callID", socketCallId.toString())
+            addProperty("cause", "PICKED_OFF")
+        })
+
+        client.onByeReceived(byeJsonObject)
+
+        val message = client.socketResponseLiveData.getOrAwaitValue()
+        val body = message.data as ReceivedMessageBody
+        val bye = body.result as com.telnyx.webrtc.sdk.verto.receive.ByeResponse
+        assertEquals(appCallId, bye.callId)
     }
 
     private fun setPrivateField(name: String, value: Any?) {
@@ -1016,16 +1112,14 @@ class TelnyxClientTest : BaseTest() {
     }
 
     private fun invokeInviteAppCallId(
-        variables: Map<String, String>,
         socketCallId: UUID
     ): UUID? {
         val method = TelnyxClient::class.java.getDeclaredMethod(
             "inviteAppCallId",
-            Map::class.java,
             UUID::class.java
         )
         method.isAccessible = true
-        return method.invoke(client, variables, socketCallId) as UUID?
+        return method.invoke(client, socketCallId) as UUID?
     }
 
     // Extension function for getOrAwaitValue for unit tests

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -17,6 +17,7 @@ import com.google.gson.JsonObject
 import com.telnyx.webrtc.sdk.model.AudioDevice
 import com.telnyx.webrtc.sdk.model.GatewayState
 import com.telnyx.webrtc.sdk.model.LogLevel
+import com.telnyx.webrtc.sdk.model.PushMetaData
 import com.telnyx.webrtc.sdk.model.SocketError
 import com.telnyx.webrtc.sdk.socket.TxSocket
 import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
@@ -944,6 +945,37 @@ class TelnyxClientTest : BaseTest() {
     }
 
     @Test
+    fun `push app call id uses push call id instead of parent call id`() {
+        val parentCallId = UUID.randomUUID()
+        val pushCallId = UUID.randomUUID()
+        val config = CredentialConfig(
+            sipUser = MOCK_USERNAME_TEST,
+            sipPassword = MOCK_PASSWORD,
+            sipCallerIDName = "Test",
+            sipCallerIDNumber = "000000000",
+            fcmToken = "fcm-token",
+            ringtone = null,
+            ringBackTone = null,
+            pushWhenActive = true
+        )
+
+        setPrivateField("credentialSessionConfig", config)
+        setPrivateField("tokenSessionConfig", null)
+
+        val resolved = invokePushAppCallId(
+            PushMetaData(
+                callerName = "Alice",
+                callerNumber = "1001",
+                callId = pushCallId.toString(),
+                voiceSdkId = "voice-sdk-id",
+                parentCallId = parentCallId.toString()
+            )
+        )
+
+        assertEquals(pushCallId, resolved)
+    }
+
+    @Test
     fun `invite app call id ignores stale pending push id when push is not pending`() {
         val stalePendingPushCallId = UUID.randomUUID()
         val socketCallId = UUID.randomUUID()
@@ -972,6 +1004,15 @@ class TelnyxClientTest : BaseTest() {
         val field = TelnyxClient::class.java.getDeclaredField(name)
         field.isAccessible = true
         field.set(client, value)
+    }
+
+    private fun invokePushAppCallId(metaData: PushMetaData): UUID? {
+        val method = TelnyxClient::class.java.getDeclaredMethod(
+            "pushAppCallId",
+            PushMetaData::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(client, metaData) as UUID?
     }
 
     private fun invokeInviteAppCallId(


### PR DESCRIPTION
[WEBRTC-XXX - Push payload call ID remap](https://telnyx.atlassian.net/browse/WEBRTC-XXX)

---
This PR handles push-when-active incoming calls where the push payload `call_id` can differ from the socket INVITE `callID`.

The final rule in this PR is:
- the push payload `call_id` is the single source of truth for the app-facing ID in the mismatch case
- the socket `callID` remains the internal signaling ID
- the SDK no longer creates a new app-facing alias from `parent_call_id`, `telnyx_rtc_svar_parent_call_id`, or `telnyx_rtc_svar_push_call_id`

Implementation details:
- add an app-facing/signaling ID split to the Android `Call` model
- keep the internal `calls` map keyed by signaling ID
- keep `acceptCall(...)`, `endCall(...)`, hold, DTMF, BYE, and media handling on the socket signaling ID
- surface the app-facing ID on SDK responses and callbacks
- only remap an incoming socket call when the SDK already learned that app-facing ID from the push payload
- preserve previously learned aliases for later socket events on the same call
- keep socket-only flows unchanged: if no push was processed first, the app-facing ID is simply the socket `callID`

## :older_man: :baby: Behaviors
### Before changes
- Android could derive the app-facing alias from `parent_call_id` / socket variables.
- The app-facing versus signaling split was inconsistent across incoming call creation and later socket events.

### After changes
- Push flow:
  - app-facing ID comes from push payload `call_id`
  - signaling uses socket `callID`
- Later socket events for that same call can resolve through the stored alias map.
- Socket-only flow:
  - app-facing ID stays as socket `callID`
- No new alias is created from `telnyx_rtc_svar_parent_call_id` or `telnyx_rtc_svar_push_call_id`.

## ✋ Manual testing
1. Ran `./gradlew :telnyx_rtc:testDebugUnitTest --tests com.telnyx.webrtc.sdk.TelnyxClientTest`
2. Verified app-facing/signaling ID split behavior for aliased calls
3. Verified BYE emits the app-facing ID
4. Verified invite remap now comes only from push-derived state and stored aliases
