### PR TITLE
Add pn_late_fanout for push-when-active

### DIFF
--- a/docs-markdown/push-notification/app-setup.md
+++ b/docs-markdown/push-notification/app-setup.md
@@ -28,7 +28,7 @@ telnyxClient.connect(
 
 When `pushWhenActive` is `true`:
 
-1. The login payload includes `push_when_active = true` in `userVariables` so the backend treats this device as active for push routing.
+1. The login payload includes `push_when_active = true` and `pn_late_fanout = true` in `userVariables` so the backend keeps the push-when-active call on the push/on-hold route and allows late fan-out to additional active sockets.
 2. When `acceptCall(...)` is invoked, the SDK sends `answered_device_token` inside the `telnyx_rtc.answer` payload. The value is the same FCM token supplied through `CredentialConfig(fcmToken = ...)` or `TokenConfig(fcmToken = ...)`, so apps do not need to pass it again at answer time.
 3. If no `fcmToken` is configured, or it is empty or whitespace-only, the `answered_device_token` field is omitted.
 

--- a/telnyx_rtc/CHANGELOG.md
+++ b/telnyx_rtc/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.6.1](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/3.6.1) (2026-07-17)
+
+### Enhancement
+- Auto-include `pn_late_fanout` alongside `push_when_active` in login `userVariables` for push-when-active multi-device routing
+
 ## [3.6.0](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/3.6.0) (2026-07-16)
 
 ### Enhancement

--- a/telnyx_rtc/build.gradle
+++ b/telnyx_rtc/build.gradle
@@ -15,7 +15,7 @@ android {
 }
 
 def getVersionName = { ->
-    return "3.5.0"
+    return "3.6.1"
 }
 
 def getArtifactId = { ->

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1818,6 +1818,7 @@ class TelnyxClient private constructor(
         notificationJsonObject.addProperty("push_notification_provider", "android")
         if (config.pushWhenActive) {
             notificationJsonObject.addProperty("push_when_active", true)
+            notificationJsonObject.addProperty("pn_late_fanout", true)
         }
 
         val loginMessage = SendingMessageBody(
@@ -1954,6 +1955,7 @@ class TelnyxClient private constructor(
         notificationJsonObject.addProperty("push_notification_provider", "android")
         if (config.pushWhenActive) {
             notificationJsonObject.addProperty("push_when_active", true)
+            notificationJsonObject.addProperty("pn_late_fanout", true)
         }
 
         val loginMessage = SendingMessageBody(
@@ -2173,6 +2175,7 @@ class TelnyxClient private constructor(
         notificationJsonObject.addProperty("push_notification_provider", "android")
         if (config.pushWhenActive) {
             notificationJsonObject.addProperty("push_when_active", true)
+            notificationJsonObject.addProperty("pn_late_fanout", true)
         }
 
         val loginMessage = SendingMessageBody(
@@ -2233,6 +2236,7 @@ class TelnyxClient private constructor(
         notificationJsonObject.addProperty("push_notification_provider", "android")
         if (config.pushWhenActive) {
             notificationJsonObject.addProperty("push_when_active", true)
+            notificationJsonObject.addProperty("pn_late_fanout", true)
         }
 
         val loginMessage = SendingMessageBody(

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -336,6 +336,7 @@ class TelnyxClientTest : BaseTest() {
         Mockito.verify(client.socket).send(captor.capture())
         val loginParam = captor.value.params as LoginParam
         assertEquals(true, loginParam.userVariables["push_when_active"].asBoolean)
+        assertEquals(true, loginParam.userVariables["pn_late_fanout"].asBoolean)
         assertEquals("fcm-token", loginParam.userVariables["push_device_token"].asString)
         assertEquals(false, loginParam.loginParams?.containsKey("push_when_active"))
     }
@@ -361,6 +362,7 @@ class TelnyxClientTest : BaseTest() {
         Mockito.verify(client.socket).send(captor.capture())
         val loginParam = captor.value.params as LoginParam
         assertEquals(true, loginParam.userVariables["push_when_active"].asBoolean)
+        assertEquals(true, loginParam.userVariables["pn_late_fanout"].asBoolean)
         assertEquals("fcm-token", loginParam.userVariables["push_device_token"].asString)
         assertEquals(false, loginParam.loginParams?.containsKey("push_when_active"))
     }


### PR DESCRIPTION
[VSDK-XXX - Add pn_late_fanout for push-when-active routing.](https://telnyx.atlassian.net/browse/VSDK-XXX)

---
This PR makes the Android SDK include `pn_late_fanout = true` anywhere it already includes `push_when_active = true` in login `userVariables`.

That keeps the backend behavior aligned with the iOS change and with the intended push-when-active flow:
- `push_when_active` keeps already-online users on the push/on-hold path
- `pn_late_fanout` allows late fan-out for that same parked push call so additional active sockets can still receive the invite

Scope in this PR:
- add `pn_late_fanout` to credential login user variables when `pushWhenActive` is enabled
- add `pn_late_fanout` to token login user variables when `pushWhenActive` is enabled
- add the same flag to the decline-push login variants so the behavior stays consistent across background cleanup flows
- assert the new flag in the existing credential/token login unit tests
- document the backend behavior in the push notification app setup guide
- bump Android SDK version metadata to `3.6.1` and add the changelog entry

## :older_man: :baby: Behaviors
### Before changes
When `pushWhenActive = true`, Android login payloads only set `push_when_active = true`.

### After changes
When `pushWhenActive = true`, Android login payloads set both `push_when_active = true` and `pn_late_fanout = true`.

## ✋ Manual testing
1. Ran `./gradlew :telnyx_rtc:testDebugUnitTest --tests com.telnyx.webrtc.sdk.TelnyxClientTest`
2. Verified credential login test asserts both `push_when_active` and `pn_late_fanout`
3. Verified token login test asserts both `push_when_active` and `pn_late_fanout`
