### PR TITLE
Add optional canary websocket query

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -174,6 +174,7 @@ class TelnyxClient private constructor(
     private var providedPort: Int? = null
     internal var providedTurn: String? = null
     internal var providedStun: String? = null
+    private var providedCanary: Boolean? = null
     private var voiceSDKID: String? = null
     private var callReportId: String? = null
 
@@ -1162,6 +1163,7 @@ class TelnyxClient private constructor(
                 providedHostAddress,
                 providedPort,
                 pushMetaData,
+                providedCanary,
                 isCurrentConnection = { isCurrentConnectionGeneration(generation, reconnectSocket) }
             ) socketConnect@ {
                 if (!isCurrentConnectionGeneration(generation, reconnectSocket)) {
@@ -1333,6 +1335,7 @@ class TelnyxClient private constructor(
         providedPort = providedServerConfig.port
         providedTurn = providedServerConfig.turn
         providedStun = providedServerConfig.stun
+        providedCanary = providedServerConfig.canary
         if (ConnectivityHelper.isNetworkEnabled(context)) {
             Logger.d(message = "Provided Host Address: $providedHostAddress")
             launchSocketConnect {
@@ -1341,6 +1344,7 @@ class TelnyxClient private constructor(
                     providedHostAddress,
                     providedPort,
                     pushMetaData,
+                    providedServerConfig.canary,
                     isCurrentConnection = { isCurrentConnectionGeneration(generation, connectSocket) }
                 ) socketConnect@ {
                     if (!isCurrentConnectionGeneration(generation, connectSocket)) {
@@ -1406,6 +1410,7 @@ class TelnyxClient private constructor(
         providedPort = providedServerConfig.port
         providedTurn = providedServerConfig.turn
         providedStun = providedServerConfig.stun
+        providedCanary = providedServerConfig.canary
         if (ConnectivityHelper.isNetworkEnabled(context)) {
             Logger.d(message = "Provided Host Address: $providedHostAddress")
 
@@ -1444,6 +1449,7 @@ class TelnyxClient private constructor(
                     providedHostAddress,
                     providedPort,
                     pushMetaData,
+                    providedServerConfig.canary,
                     isCurrentConnection = { isCurrentConnectionGeneration(generation, connectSocket) }
                 ) {
                     if (autoLogin && isCurrentConnectionGeneration(generation, connectSocket)) {
@@ -1548,6 +1554,7 @@ class TelnyxClient private constructor(
                     providedHostAddress,
                     providedPort,
                     pushMetaData,
+                    providedServerConfig.canary,
                     isCurrentConnection = { isCurrentConnectionGeneration(generation, connectSocket) }
                 ) {
                     if (autoLogin && isCurrentConnectionGeneration(generation, connectSocket)) {
@@ -1607,6 +1614,7 @@ class TelnyxClient private constructor(
         providedPort = providedServerConfig.port
         providedTurn = providedServerConfig.turn
         providedStun = providedServerConfig.stun
+        providedCanary = providedServerConfig.canary
 
         if (ConnectivityHelper.isNetworkEnabled(context)) {
             Logger.d(message = "Provided Host Address: $providedHostAddress")
@@ -1622,6 +1630,7 @@ class TelnyxClient private constructor(
                     providedHostAddress,
                     providedPort,
                     null,
+                    providedServerConfig.canary,
                     isCurrentConnection = { isCurrentConnectionGeneration(generation, connectSocket) }
                 ) socketConnect@ {
                     if (!isCurrentConnectionGeneration(generation, connectSocket)) {
@@ -1692,6 +1701,7 @@ class TelnyxClient private constructor(
             providedPort = providedServerConfig.port
             providedTurn = providedServerConfig.turn
             providedStun = providedServerConfig.stun
+            providedCanary = providedServerConfig.canary
 
             if (ConnectivityHelper.isNetworkEnabled(context)) {
                 Logger.d(message = "Provided Host Address: $providedHostAddress")
@@ -1712,6 +1722,7 @@ class TelnyxClient private constructor(
                         providedHostAddress,
                         providedPort,
                         pushMetaData,
+                        providedServerConfig.canary,
                         isCurrentConnection = { isCurrentConnectionGeneration(generation, connectSocket) }
                     ) socketConnect@ {
                         if (!isCurrentConnectionGeneration(generation, connectSocket)) {

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/TxServerConfiguration.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/TxServerConfiguration.kt
@@ -6,7 +6,8 @@ data class TxServerConfiguration(
     val host: String = Config.TELNYX_PROD_HOST_ADDRESS,
     val port: Int = Config.TELNYX_PORT,
     val turn: String = Config.DEFAULT_TURN,
-    val stun: String = Config.DEFAULT_STUN
+    val stun: String = Config.DEFAULT_STUN,
+    val canary: Boolean? = null
 ) {
     companion object {
         /**
@@ -16,7 +17,8 @@ data class TxServerConfiguration(
             host = Config.TELNYX_PROD_HOST_ADDRESS,
             port = Config.TELNYX_PORT,
             turn = Config.DEFAULT_TURN,
-            stun = Config.DEFAULT_STUN
+            stun = Config.DEFAULT_STUN,
+            canary = null
         )
 
         /**
@@ -26,7 +28,8 @@ data class TxServerConfiguration(
             host = Config.TELNYX_DEV_HOST_ADDRESS,
             port = Config.TELNYX_PORT,
             turn = Config.DEV_TURN,
-            stun = Config.DEV_STUN
+            stun = Config.DEV_STUN,
+            canary = null
         )
     }
 }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -74,12 +74,14 @@ class TxSocket(
         providedHostAddress: String? = Config.TELNYX_PROD_HOST_ADDRESS,
         providedPort: Int? = Config.TELNYX_PORT,
         pushmetaData: PushMetaData? = null,
+        canary: Boolean? = null,
         onConnected:(Boolean) -> Unit = {}
     ): Job = connectWithConnectionGuard(
         listener,
         providedHostAddress,
         providedPort,
         pushmetaData,
+        canary,
         isCurrentConnection = { true },
         onConnected = onConnected
     )
@@ -89,6 +91,7 @@ class TxSocket(
         providedHostAddress: String? = Config.TELNYX_PROD_HOST_ADDRESS,
         providedPort: Int? = Config.TELNYX_PORT,
         pushmetaData: PushMetaData? = null,
+        canary: Boolean? = null,
         isCurrentConnection: () -> Boolean = { true },
         onConnected:(Boolean) -> Unit = {}
     ): Job {
@@ -127,19 +130,7 @@ class TxSocket(
             port = it
         }
 
-        val requestUrl = if (pushmetaData != null) {
-            HttpUrl.Builder()
-                .scheme("https")
-                .host(host_address)
-                .addQueryParameter("voice_sdk_id", pushmetaData.voiceSdkId ?: "")
-                .build()
-        } else {
-            HttpUrl.Builder()
-                .scheme("https")
-                .port(port)
-                .host(host_address)
-                .build()
-        }
+        val requestUrl = buildRequestUrl(host_address, port, pushmetaData, canary)
         Logger.d(message = "request: $client.")
 
         val request: Request =
@@ -403,6 +394,27 @@ class TxSocket(
             createdWebSocket.close(WEBSOCKET_NORMAL_CLOSURE, "Websocket connection closed")
         }
         }
+    }
+
+    internal fun buildRequestUrl(
+        hostAddress: String,
+        port: Int,
+        pushmetaData: PushMetaData? = null,
+        canary: Boolean? = null
+    ): HttpUrl {
+        val builder = HttpUrl.Builder()
+            .scheme("https")
+            .host(hostAddress)
+
+        if (pushmetaData != null) {
+            builder.addQueryParameter("voice_sdk_id", pushmetaData.voiceSdkId ?: "")
+        } else {
+            builder.port(port)
+        }
+
+        canary?.let { builder.addQueryParameter("canary", it.toString()) }
+
+        return builder.build()
     }
 
     private fun shouldIgnoreSocketCallback(isCurrentConnection: () -> Boolean = { true }): Boolean {

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/socket/TxSocketTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/socket/TxSocketTest.kt
@@ -9,6 +9,7 @@ import android.net.NetworkRequest
 import androidx.appcompat.app.AppCompatActivity
 import com.google.gson.JsonObject
 import com.telnyx.webrtc.sdk.TelnyxClient
+import com.telnyx.webrtc.sdk.model.PushMetaData
 import com.telnyx.webrtc.sdk.telnyx_rtc.BuildConfig
 import com.telnyx.webrtc.sdk.testhelpers.BaseTest
 import com.telnyx.webrtc.sdk.utilities.ConnectivityHelper
@@ -149,6 +150,60 @@ class TxSocketTest : BaseTest() {
         client.onDisconnect()
         Thread.sleep(1000)
         verify(atLeast = 1) { testSocket.destroy() }
+    }
+
+    @Test
+    fun `build request url omits canary query by default`() {
+        socket = TxSocket(
+            host_address = "rtc.telnyx.com",
+            port = 14938,
+        )
+
+        val requestUrl = socket.buildRequestUrl(
+            hostAddress = "rtc.telnyx.com",
+            port = 14938,
+        )
+
+        assertEquals(null, requestUrl.queryParameter("canary"))
+    }
+
+    @Test
+    fun `build request url includes canary query when enabled`() {
+        socket = TxSocket(
+            host_address = "rtc.telnyx.com",
+            port = 14938,
+        )
+
+        val requestUrl = socket.buildRequestUrl(
+            hostAddress = "rtc.telnyx.com",
+            port = 14938,
+            canary = true,
+        )
+
+        assertEquals("true", requestUrl.queryParameter("canary"))
+    }
+
+    @Test
+    fun `build request url includes push voice sdk id and canary query`() {
+        socket = TxSocket(
+            host_address = "rtc.telnyx.com",
+            port = 14938,
+        )
+
+        val requestUrl = socket.buildRequestUrl(
+            hostAddress = "rtc.telnyx.com",
+            port = 14938,
+            pushmetaData = PushMetaData(
+                callerName = "",
+                callerNumber = "",
+                callId = "",
+                voiceSdkId = "voice-sdk-id",
+            ),
+            canary = false,
+        )
+
+        assertEquals("voice-sdk-id", requestUrl.queryParameter("voice_sdk_id"))
+        assertEquals("false", requestUrl.queryParameter("canary"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add an optional `canary` flag to `TxServerConfiguration`
- append `canary=true|false` to the websocket URL only when the flag is set
- preserve existing push `voice_sdk_id` query handling and add focused socket tests

## Behavior
- default: no `canary` query parameter
- `canary = true`: send `?canary=true`
- `canary = false`: send `?canary=false`

## Validation
- `./gradlew :telnyx_rtc:testDebugUnitTest --tests com.telnyx.webrtc.sdk.socket.TxSocketTest`