### PR TITLE
[VSDK-352] Show disconnect button during connecting phase in Android demo

### DIFF
--- a/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/CallScreen.kt
+++ b/samples/compose_app/src/main/java/org/telnyx/webrtc/compose_app/ui/screens/CallScreen.kt
@@ -1,5 +1,6 @@
 package org.telnyx.webrtc.compose_app.ui.screens
 
+import com.telnyx.webrtc.sdk.model.CallState
 import android.media.AudioManager
 import android.media.ToneGenerator
 import android.media.ToneGenerator.*
@@ -103,6 +104,8 @@ fun CallScreen(telnyxViewModel: TelnyxViewModel) {
 
     val uiState by telnyxViewModel.uiState.collectAsState()
     var callUIState by remember { mutableStateOf(CallUIState.IDLE) }
+    val sdkCallState by telnyxViewModel.currentCall?.callStateFlow?.collectAsState()
+        ?: remember { mutableStateOf<CallState>(CallState.DONE()) }
     val loudSpeakerOn =
         telnyxViewModel.currentCall?.getIsOnLoudSpeakerStatus()?.observeAsState(initial = false)
     val isMuted = telnyxViewModel.currentCall?.getIsMuteStatus()?.observeAsState(initial = false)
@@ -152,7 +155,12 @@ fun CallScreen(telnyxViewModel: TelnyxViewModel) {
             }
 
             else -> {
-                CallUIState.IDLE
+                // Check if SDK reports CONNECTING state (outbound call in progress)
+                if (sdkCallState is CallState.CONNECTING || sdkCallState is CallState.NEW) {
+                    CallUIState.CONNECTING
+                } else {
+                    CallUIState.IDLE
+                }
             }
         }
     }
@@ -244,6 +252,34 @@ fun CallScreen(telnyxViewModel: TelnyxViewModel) {
                                 backgroundColor = MaterialTheme.colorScheme.background
                             ) {
                                 showCallHistoryBottomSheet = true
+                            }
+                        }
+                    }
+
+                    CallUIState.CONNECTING -> {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(Dimens.smallSpacing),
+                            modifier = Modifier.testTag("callConnectingView")
+                        ) {
+                            Text(
+                                text = stringResource(R.string.call_state_connecting),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(Dimens.smallSpacing),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                HomeIconButton(
+                                    Modifier.testTag("endCall"),
+                                    icon = R.drawable.baseline_call_end_24,
+                                    backGroundColor = callRed,
+                                    contentColor = Color.White,
+                                    stringResource(R.string.end)
+                                ) {
+                                    telnyxViewModel.endCall(context)
+                                }
                             }
                         }
                     }
@@ -784,6 +820,7 @@ fun DestinationTypeSwitcher(isPhoneNumber: Boolean, onCheckedChange: (Boolean) -
 
 private enum class CallUIState {
     IDLE,
+    CONNECTING,
     INCOMING,
     ACTIVE
 }


### PR DESCRIPTION
## VSDK-352 (AND-B1) — Outbound call end-call/disconnect button missing during connecting phase

**Linear:** https://linear.app/telnyx/issue/VSDK-352/and-b1-android-outbound-call-end-calldisconnect-button-missing-during

## Problem
When a user initiates an outbound call, the demo app shows no end-call button during the connecting phase. The `CallUIState` enum only had `IDLE`, `INCOMING`, and `ACTIVE` — no `CONNECTING` state. The SDK's `CallState.CONNECTING` was logged but never surfaced to the UI, leaving users unable to cancel a call that's still connecting.

## Fix
- Added `CONNECTING` state to the demo's `CallUIState` enum
- Observe the SDK's `callStateFlow` to detect `CONNECTING` / `NEW` states
- Show a 'Connecting' label + red end-call button during the connecting phase
- Tapping end-call calls `telnyxViewModel.endCall(context)` as usual

## Changes
- 1 file modified: `CallScreen.kt` (+38 lines, -1)
- Demo app only — no SDK core changes

## Testing
⚠️ Could not build locally (no JDK on this machine). Needs CI to verify compilation. The change is straightforward — new enum value + a new `when` branch using existing composables (`HomeIconButton`, `Text`, `stringResource`).