### PR TITLE
docs: add missing CHANGELOG entries for 3.5.0–3.6.1

### DIFF
--- a/telnyx_rtc/CHANGELOG.md
+++ b/telnyx_rtc/CHANGELOG.md
@@ -2,14 +2,22 @@
 
 ### Enhancement
 - Auto-include `pn_late_fanout` alongside `push_when_active` in login `userVariables` for push-when-active multi-device routing
+- Expose Compose test tags as resource IDs for Maestro/UiAutomator E2E test automation
 
 ### Bug Fixing
 - Use the push payload `call_id` as the stable app-facing ID for push-when-active remaps while keeping the socket `callID` for answer/end signaling.
+- Cancel decline service scope per startId and isolate decline-push client from main SDK client (VSDK-332)
 
 ## [3.6.0](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/3.6.0) (2026-07-16)
 
 ### Enhancement
 - Auto-include `answered_device_token` in `telnyx_rtc.answer` from the configured `fcmToken` for push-when-active flows (VSDK-431)
+
+### Bug Fixing
+- Store parent scope for discarded coroutine jobs in TelnyxClient to prevent coroutine leaks (VSDK-333)
+- Bound cancellable scope in TelnyxCommon.observeConnectionMetrics to prevent connectivity subscription leak (VSDK-331)
+- Fix MediaPlayer leak in playRingtone and uncaught NPE in playRingBackTone (VSDK-330)
+- Fix CallTimings portal parsing (VSDK-170)
 
 ## [3.5.0](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/3.5.0) (2026-03-20)
 
@@ -19,6 +27,7 @@
 - Add transport stats (dtlsState, iceState, srtpCipher, tlsVersion) to call report intervals (WEBRTC-3415)
 - Add audioLevelAvg for inbound/outbound audio per stats interval (WEBRTC-3414)
 - Add SDK latency measurement for WebRTC call establishment with milestone tracking (WEBRTC-3276)
+- Add missing latency measurement milestones (WEBRTC-3426)
 - Handle telnyx_call_control_id in answer for Call Control integration (WEBRTC-3341)
 
 ### Bug Fixing

--- a/telnyx_rtc/CHANGELOG.md
+++ b/telnyx_rtc/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Enhancement
 - Auto-include `answered_device_token` in `telnyx_rtc.answer` from the configured `fcmToken` for push-when-active flows (VSDK-431)
+- Add missing latency measurement milestones (WEBRTC-3426)
 
 ### Bug Fixing
 - Store parent scope for discarded coroutine jobs in TelnyxClient to prevent coroutine leaks (VSDK-333)
@@ -27,7 +28,6 @@
 - Add transport stats (dtlsState, iceState, srtpCipher, tlsVersion) to call report intervals (WEBRTC-3415)
 - Add audioLevelAvg for inbound/outbound audio per stats interval (WEBRTC-3414)
 - Add SDK latency measurement for WebRTC call establishment with milestone tracking (WEBRTC-3276)
-- Add missing latency measurement milestones (WEBRTC-3426)
 - Handle telnyx_call_control_id in answer for Call Control integration (WEBRTC-3341)
 
 ### Bug Fixing


### PR DESCRIPTION
## Summary

7 PRs were merged to `main` between the 3.5.0 and 3.6.1 releases but were missing from the CHANGELOG. This PR adds them.

### Added entries

**3.5.0 — Enhancement**
- WEBRTC-3426: Add missing latency measurement milestones (#802)

**3.6.0 — Bug Fixing**
- VSDK-333: Store parent scope for discarded coroutine jobs in TelnyxClient (#807)
- VSDK-331: Bound cancellable scope in TelnyxCommon.observeConnectionMetrics (#808)
- VSDK-330: Fix MediaPlayer leak in playRingtone / NPE in playRingBackTone (#809)
- VSDK-170: Fix CallTimings portal parsing (#805)

**3.6.1 — Enhancement + Bug Fixing**
- Expose Compose test tags as resource IDs for E2E test automation (#812)
- VSDK-332: Cancel decline service scope per startId (#813)

## Test plan

Docs-only change — no code or test impact.