### PR TITLE
VSDK-349: untrack google-services.json, add templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,10 @@ captures/
 .cxx/
 
 # Google Services (e.g. APIs or Firebase)
-# google-services.json
+# google-services.json is untracked to prevent leaking Firebase credentials.
+# Copy google-services.json.template to google-services.json and fill in your
+# project's Firebase configuration before building the sample apps.
+**/google-services.json
 
 # Freeline
 freeline.py
@@ -85,10 +88,6 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 # lint/reports/
-app/google-services.json
-xmlapp/google-services.json
-compose_app/google-services.json
-connection_service_app/google-services.json
 
 # system
 .DS_Store

--- a/samples/compose_app/google-services.json.template
+++ b/samples/compose_app/google-services.json.template
@@ -1,3 +1,6 @@
+// Copy this file to google-services.json and replace the empty API key with your Firebase project's API key.
+// See: https://developers.telnyx.com/docs/voice/webrtc/android-sdk/push-notification/portal-setup
+
 // Note the contents of this file are intentially invalid and should not be used in a production environment
 {
   "project_info": {

--- a/samples/connection_service_app/google-services.json.template
+++ b/samples/connection_service_app/google-services.json.template
@@ -1,3 +1,7 @@
+// Copy this file to google-services.json and replace the empty API key with your Firebase project's API key.
+// See: https://developers.telnyx.com/docs/voice/webrtc/android-sdk/push-notification/portal-setup
+
+// Note the contents of this file are intentially invalid and should not be used in a production environment
 {
   "project_info": {
     "project_number": "894569387136",
@@ -20,7 +24,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyA90_8C7Yv5JGxNOqKdQo242Y2XLfm_sb8"
+          "current_key": ""
         }
       ],
       "services": {
@@ -49,7 +53,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyA90_8C7Yv5JGxNOqKdQo242Y2XLfm_sb8"
+          "current_key": ""
         }
       ],
       "services": {
@@ -78,7 +82,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyA90_8C7Yv5JGxNOqKdQo242Y2XLfm_sb8"
+          "current_key": ""
         }
       ],
       "services": {
@@ -107,36 +111,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyA90_8C7Yv5JGxNOqKdQo242Y2XLfm_sb8"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "894569387136-sfen79l81ptf6b884d8qma14r34uhred.apps.googleusercontent.com",
-              "client_type": 3
-            }
-          ]
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:894569387136:android:0f40f0c9dc339ee1c18265",
-        "android_client_info": {
-          "package_name": "org.telnyx.webrtc.xml_app"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "894569387136-sfen79l81ptf6b884d8qma14r34uhred.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyA90_8C7Yv5JGxNOqKdQo242Y2XLfm_sb8"
+          "current_key": ""
         }
       ],
       "services": {
@@ -151,5 +126,5 @@
       }
     }
   ],
-  "configuration_version": "1"
+  "configuration_version": "2"
 }

--- a/samples/xml_app/google-services.json.template
+++ b/samples/xml_app/google-services.json.template
@@ -1,3 +1,7 @@
+// Copy this file to google-services.json and replace the empty API key with your Firebase project's API key.
+// See: https://developers.telnyx.com/docs/voice/webrtc/android-sdk/push-notification/portal-setup
+
+// Note the contents of this file are intentially invalid and should not be used in a production environment
 {
   "project_info": {
     "project_number": "894569387136",
@@ -20,7 +24,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyA90_8C7Yv5JGxNOqKdQo242Y2XLfm_sb8"
+          "current_key": ""
         }
       ],
       "services": {
@@ -49,7 +53,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyA90_8C7Yv5JGxNOqKdQo242Y2XLfm_sb8"
+          "current_key": ""
         }
       ],
       "services": {
@@ -78,7 +82,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyA90_8C7Yv5JGxNOqKdQo242Y2XLfm_sb8"
+          "current_key": ""
         }
       ],
       "services": {
@@ -107,7 +111,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyA90_8C7Yv5JGxNOqKdQo242Y2XLfm_sb8"
+          "current_key": ""
         }
       ],
       "services": {
@@ -122,5 +126,5 @@
       }
     }
   ],
-  "configuration_version": "1"
+  "configuration_version": "2"
 }


### PR DESCRIPTION
## Summary

Untrack `google-services.json` from all 3 sample apps to prevent leaking Firebase API keys. The `compose_app` and `xml_app` files contained **real Firebase API keys** that were committed to the repository.

## Changes

- **Untrack** `google-services.json` from `samples/compose_app/`, `samples/xml_app/`, and `samples/connection_service_app/` (files remain locally, just removed from git tracking)
- **Add** `google-services.json.template` for each sample app — contains the correct Firebase project structure but with **empty API keys**
- **Update `.gitignore`** — uncomment the `google-services.json` entry, use `**/google-services.json` glob pattern, remove outdated hardcoded paths (`app/`, `xmlapp/`, etc.)

## What developers need to do

Before building a sample app, copy the template and fill in your Firebase API key:

```bash
cp samples/compose_app/google-services.json.template samples/compose_app/google-services.json
# Edit google-services.json and replace the empty "current_key" with your Firebase API key
```

See: https://developers.telnyx.com/docs/voice/webrtc/android-sdk/push-notification/portal-setup

## Test plan

- Verify `google-services.json` is no longer tracked: `git ls-files | grep google-services` should return nothing
- Verify templates have empty API keys (already confirmed)
- Verify `.gitignore` now blocks `google-services.json` in all sample directories
- Build a sample app with a local `google-services.json` copy to confirm the build still works

## Related

- Linear: VSDK-349