### PR TITLE
Expose active calls by app-facing call ID

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1826,7 +1826,7 @@ class TelnyxClient private constructor(
      * @see [calls]
      */
     fun getActiveCalls(): Map<UUID, Call> {
-        return calls.toMap()
+        return calls.values.associateBy { it.callId }
     }
     
     /**

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -1131,6 +1131,25 @@ class TelnyxClientTest : BaseTest() {
     }
 
     @Test
+    fun `get active calls exposes app facing call id keys`() {
+        client = Mockito.spy(TelnyxClient(mockContext))
+        client.socket = Mockito.mock(TxSocket::class.java)
+
+        val appCallId = UUID.randomUUID()
+        val socketCallId = UUID.randomUUID()
+        val fakeCall = Mockito.spy(Call(mockContext, client, client.socket, "", audioManager))
+        fakeCall.callId = appCallId
+        fakeCall.signalingCallId = socketCallId
+
+        client.addToCalls(fakeCall)
+
+        val activeCalls = client.getActiveCalls()
+
+        assertEquals(fakeCall, activeCalls[appCallId])
+        assertEquals(null, activeCalls[socketCallId])
+    }
+
+    @Test
     fun `on bye received emits app facing call id for aliased call`() {
         client = Mockito.spy(TelnyxClient(mockContext))
         client.socket = Mockito.mock(TxSocket::class.java)


### PR DESCRIPTION
## Summary
- return getActiveCalls() keyed by Call.callId instead of the internal signaling/socket ID
- keep the internal calls map signaling-keyed for socket routing
- add a regression test for remapped push call IDs

## Test
- ./gradlew :telnyx_rtc:testDebugUnitTest --tests "com.telnyx.webrtc.sdk.TelnyxClientTest.get active calls exposes app facing call id keys"

Note: full TelnyxClientTest was not used for validation because it currently has unrelated failures in login with invalid credentials - login sent to socket and json received and Test calls map is thread-safe under concurrent put remove and iteration.