### PR TITLE
fix: JitPack google-services.json + Release workflow runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,15 @@ on:
 jobs:
   build:
     name: "🚀 Release"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: "📥 Check-out"
-        uses: actions/checkout@v3.0.2
-      - name: set up JDK 1.8
-        uses: actions/setup-java@v3.5.0
+        uses: actions/checkout@v4
+      - name: set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
-          java-version: '11'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,3 +41,25 @@ allprojects {
 tasks.register("clean", Delete::class) {
     delete(rootProject.buildDir)
 }
+
+// Copy google-services.json from templates if missing (e.g. JitPack build).
+// The file is untracked to prevent leaking Firebase credentials, but the
+// google-services Gradle plugin requires it at build time.
+tasks.register<Copy>("restoreGoogleServicesTemplates") {
+    description = "Restores google-services.json from templates if the file is missing."
+    val sampleApps = listOf("compose_app", "xml_app", "connection_service_app")
+    sampleApps.forEach { app ->
+        val target = file("samples/$app/google-services.json")
+        val template = file("samples/$app/google-services.json.template")
+        if (!target.exists() && template.exists()) {
+            from(template)
+            into("samples/$app")
+            rename { "google-services.json" }
+        }
+    }
+}
+
+// Run before any build task that needs google-services.json
+tasks.matching { it.name.startsWith("assemble") || it.name.startsWith("build") || it.name == "clean" }.configureEach {
+    dependsOn("restoreGoogleServicesTemplates")
+}


### PR DESCRIPTION
## Summary

Two CI/build fixes needed after the 3.7.0 release:

### 1. JitPack build failure — `google-services.json` missing

JitPack builds the entire project including sample apps, which require `google-services.json` for the Google Services Gradle plugin. Since the file was untracked in PR #826 (to prevent leaking Firebase credentials), JitPack fails with:

```
Execution failed for task ':samples:compose_app:processDebugGoogleServices'.
> File google-services.json is missing.
```

**Fix:** Add a Gradle task `restoreGoogleServicesTemplates` to the root `build.gradle.kts` that copies `google-services.json.template` → `google-services.json` for each sample app if the file is missing. Runs automatically before `assemble`/`build` tasks — works on JitPack, local, and CI.

### 2. Release workflow stuck — `ubuntu-18.04` deprecated

The Release workflow runs on `ubuntu-18.04` which was removed by GitHub Actions. Both Release runs are stuck in `queued` with no runner available.

**Fix:** Update `ubuntu-18.04` → `ubuntu-latest`, JDK 11 → 17, `actions/checkout@v3` → `@v4`, `actions/setup-java@v3` → `@v4`.