### PR TITLE
Fix: pushWhenActive timing race in processCallFromPush

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -357,12 +357,14 @@ class TelnyxClient private constructor(
      *
      * @param metaData The push notification metadata containing call information
      */
-    private fun processCallFromPush(metaData: PushMetaData) {
+    private fun processCallFromPush(metaData: PushMetaData, pushWhenActive: Boolean = false) {
         Logger.d("processCallFromPush PushMetaData", metaData.toJson())
         isCallPendingFromPush = true
         this.pushMetaData = metaData
         // Push path: use the app-visible push call_id and remap it to the socket callID when INVITE arrives.
-        pendingPushAppCallId = pushAppCallId(metaData)
+        // Pass the config's pushWhenActive directly because the session config may not be saved yet
+        // (tokenLogin/credentialLogin runs after processCallFromPush in the connect() flow).
+        pendingPushAppCallId = pushAppCallId(metaData, pushWhenActive)
     }
 
     /**
@@ -726,8 +728,8 @@ class TelnyxClient private constructor(
     private fun String?.toUuidOrNull(): UUID? =
         this?.let { runCatching { UUID.fromString(it) }.getOrNull() }
 
-    private fun pushAppCallId(metaData: PushMetaData): UUID? {
-        if (!pushWhenActiveEnabled()) return null
+    private fun pushAppCallId(metaData: PushMetaData, pushWhenActive: Boolean = false): UUID? {
+        if (!pushWhenActive && !pushWhenActiveEnabled()) return null
         return metaData.callId.toUuidOrNull()
     }
 
@@ -1401,7 +1403,7 @@ class TelnyxClient private constructor(
 
         providedHostAddress = if (txPushMetaData != null) {
             val metadata = Gson().fromJson(txPushMetaData, PushMetaData::class.java)
-            processCallFromPush(metadata)
+            processCallFromPush(metadata, credentialConfig.pushWhenActive)
             providedServerConfig.host
         } else {
             providedServerConfig.host
@@ -1505,7 +1507,7 @@ class TelnyxClient private constructor(
 
         providedHostAddress = if (txPushMetaData != null) {
             val metadata = Gson().fromJson(txPushMetaData, PushMetaData::class.java)
-            processCallFromPush(metadata)
+            processCallFromPush(metadata, tokenConfig.pushWhenActive)
             providedServerConfig.host
         } else {
             providedServerConfig.host


### PR DESCRIPTION
## Summary

Fix a timing race condition in the push-when-active call ID reconciliation flow.

**Bug:** When calling `connect()` with push metadata and a `TokenConfig` or `CredentialConfig`, `processCallFromPush()` is called to set `pendingPushAppCallId`. This calls `pushAppCallId()` which checks `pushWhenActiveEnabled()` — but `pushWhenActiveEnabled()` reads `tokenSessionConfig` / `credentialSessionConfig`, which haven't been saved yet (they're set later in `tokenLogin()` / `credentialLogin()`). This means `pushWhenActiveEnabled()` always returns `false` on the push path, so `pendingPushAppCallId` is never set, and the call ID remapping fails.

**Fix:** Pass the config's `pushWhenActive` value directly from the `connect()` overloads that have a config parameter:

- `connect(serverConfig, credentialConfig, txPushMetaData)` → `processCallFromPush(metadata, credentialConfig.pushWhenActive)`
- `connect(serverConfig, tokenConfig, txPushMetaData)` → `processCallFromPush(metadata, tokenConfig.pushWhenActive)`
- `connect(serverConfig, txPushMetaData)` (no config) → still uses `pushWhenActiveEnabled()` as fallback

`pushAppCallId()` now accepts an optional `pushWhenActive` parameter. If `true`, it skips the stored session config check. If `false` (default), it falls back to `pushWhenActiveEnabled()` for backward compatibility.

**Reported by:** Guillaume Béranger (customer)