### PR TITLE
SEC-279: Migrate to EncryptedSharedPreferences and restrict backup extraction

### DIFF
--- a/samples/compose_app/src/main/AndroidManifest.xml
+++ b/samples/compose_app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:maxSdkVersion="28" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:name=".App"

--- a/samples/connection_service_app/src/main/AndroidManifest.xml
+++ b/samples/connection_service_app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
     <uses-permission android:name="android.permission.MANAGE_OWN_CALLS"/>
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_app_icon"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_app_icon_round"

--- a/samples/xml_app/src/main/AndroidManifest.xml
+++ b/samples/xml_app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:required="false" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/telnyx_common/build.gradle
+++ b/telnyx_common/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     implementation 'com.jakewharton.timber:timber:4.5.1'
     api 'com.google.firebase:firebase-messaging-ktx:24.1.0'
 
+    // EncryptedSharedPreferences for secure credential storage (SEC-279)
+    implementation 'androidx.security:security-crypto:1.1.0-alpha06'
+
     // Room database
     implementation 'androidx.room:room-runtime:2.6.1'
     implementation 'androidx.room:room-ktx:2.6.1'

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxCommon.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxCommon.kt
@@ -3,6 +3,8 @@ package com.telnyx.webrtc.common
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.lifecycle.Observer
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import com.telnyx.webrtc.common.service.CallForegroundService
 import com.telnyx.webrtc.sdk.Call
 import com.telnyx.webrtc.sdk.TelnyxClient
@@ -31,7 +33,9 @@ import java.util.*
  */
 class TelnyxCommon private constructor() {
     private var sharedPreferences: SharedPreferences? = null
-    private val sharedPreferencesKey = "TelnyxCommonSharedPreferences"
+    private val sharedPreferencesKey = "telnyx_prefs_v2"
+    private val legacySharedPreferencesKey = "TelnyxCommonSharedPreferences"
+    private val migrationCompleteKey = "migrated_to_encrypted"
 
     private var _telnyxClient: TelnyxClient? = null
     val telnyxClient
@@ -231,17 +235,73 @@ class TelnyxCommon private constructor() {
 
 
     /**
-     * Retrieves the singleton `SharedPreferences` instance for TelnyxCommon, creating it if necessary.
+     * Retrieves the singleton encrypted `SharedPreferences` instance for TelnyxCommon.
+     * Uses EncryptedSharedPreferences (AES-256) to protect SIP credentials at rest.
+     *
+     * On first call after upgrade from a previous version, migrates any existing
+     * plaintext preferences to the encrypted store and deletes the old file.
      *
      * @param context The application context, needed for accessing SharedPreferences.
-     * @return The singleton `SharedPreferences` instance.
+     * @return The singleton encrypted `SharedPreferences` instance.
      */
     internal fun getSharedPreferences(context: Context): SharedPreferences {
         return sharedPreferences ?: synchronized(this) {
-            sharedPreferences ?: context.getSharedPreferences(
-                sharedPreferencesKey,
-                Context.MODE_PRIVATE
-            ).also { sharedPreferences = it }
+            sharedPreferences ?: buildEncryptedPrefs(context).also { prefs ->
+                sharedPreferences = prefs
+                migrateFromLegacyPrefs(context, prefs)
+            }
+        }
+    }
+
+    /**
+     * Creates an EncryptedSharedPreferences instance backed by the Android Keystore.
+     */
+    private fun buildEncryptedPrefs(context: Context): SharedPreferences {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        return EncryptedSharedPreferences.create(
+            context,
+            sharedPreferencesKey,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    /**
+     * One-time migration from the old plaintext SharedPreferences to the new encrypted store.
+     * Reads all key-value pairs from the legacy store, writes them to the encrypted store,
+     * then deletes the legacy file so the data only exists in encrypted form.
+     */
+    private fun migrateFromLegacyPrefs(context: Context, encryptedPrefs: SharedPreferences) {
+        if (encryptedPrefs.getBoolean(migrationCompleteKey, false)) return
+
+        val legacyPrefs = context.getSharedPreferences(legacySharedPreferencesKey, Context.MODE_PRIVATE)
+        val allEntries = legacyPrefs.all
+
+        if (allEntries.isNotEmpty()) {
+            val editor = encryptedPrefs.edit()
+            for ((key, value) in allEntries) {
+                when (value) {
+                    is String -> editor.putString(key, value)
+                    is Int -> editor.putInt(key, value)
+                    is Long -> editor.putLong(key, value)
+                    is Float -> editor.putFloat(key, value)
+                    is Boolean -> editor.putBoolean(key, value)
+                    is Set<*> -> @Suppress("UNCHECKED_CAST")
+                    (value as Set<String>).let { editor.putStringSet(key, it) }
+                }
+            }
+            editor.putBoolean(migrationCompleteKey, true)
+            editor.apply()
+
+            // Delete the legacy plaintext preferences file
+            val legacyFile = context.deleteSharedPreferences(legacySharedPreferencesKey)
+            Timber.i("Migrated ${allEntries.size} entries from legacy plaintext SharedPreferences to encrypted store")
+        } else {
+            // No legacy data — just mark migration as complete
+            encryptedPrefs.edit().putBoolean(migrationCompleteKey, true).apply()
         }
     }
 

--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxCommon.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxCommon.kt
@@ -297,7 +297,7 @@ class TelnyxCommon private constructor() {
             editor.apply()
 
             // Delete the legacy plaintext preferences file
-            val legacyFile = context.deleteSharedPreferences(legacySharedPreferencesKey)
+            context.deleteSharedPreferences(legacySharedPreferencesKey)
             Timber.i("Migrated ${allEntries.size} entries from legacy plaintext SharedPreferences to encrypted store")
         } else {
             // No legacy data — just mark migration as complete

--- a/telnyx_rtc/CHANGELOG.md
+++ b/telnyx_rtc/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Security
+- Migrate SharedPreferences to EncryptedSharedPreferences (AES-256) to protect SIP credentials at rest. Includes one-time migration from legacy plaintext store for existing installs. Disable `allowBackup` in all sample app manifests to prevent credential extraction via `adb backup` (SEC-279)
+
 ## [3.7.0](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/3.7.0) (2026-07-24)
 
 ### Enhancement


### PR DESCRIPTION
## Summary

Remediate SEC-279: SIP credentials (username, password, JWT token) were stored in plaintext `SharedPreferences`, extractable via `adb backup` without root.

### Changes

**1. Encrypt at rest — `TelnyxCommon.kt`**
- Replace `context.getSharedPreferences(...)` with `EncryptedSharedPreferences` using `MasterKey` (AES-256 GCM, Android Keystore-backed)
- New prefs file name: `telnyx_prefs_v2`
- Added `buildEncryptedPrefs()` helper and `migrateFromLegacyPrefs()` method

**2. Migration for existing installs**
- One-time: reads all key-value pairs from the old plaintext store (`TelnyxCommonSharedPreferences`), writes them to the encrypted store (`telnyx_prefs_v2`), then deletes the old file
- Guarded by `migrated_to_encrypted` flag so it only runs once
- Existing users keep their saved profiles on upgrade

**3. Disable backup — sample app manifests**
- Set `android:allowBackup="false"` in all 3 sample apps (compose_app, xml_app, connection_service_app)

### What doesn't change
- `Profile.kt` — data model unchanged
- `ProfileManager.kt` — already calls `TelnyxCommon.getInstance().getSharedPreferences(context)` which now returns encrypted prefs
- Login flow — credential and token login work the same
- Push notification flow — silent reconnection still works (password stored, just encrypted)

### Test plan
1. Fresh install → create profile → verify saved in `telnyx_prefs_v2` (encrypted)
2. Upgrade from old version (with plaintext prefs) → verify migration runs, profiles preserved, old prefs file deleted
3. `adb backup` → verify prefs file not included in backup
4. Credential login → disconnect → reconnect → verify password read from encrypted store
5. Kill app → incoming push → verify silent reconnection works

Refs: SEC-279, SEC-263