### PR TITLE
Release 3.7.1

### DIFF
--- a/telnyx_rtc/CHANGELOG.md
+++ b/telnyx_rtc/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.7.1](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/3.7.1) (2026-07-28)
+
+### Bug Fixing
+- Fix pushWhenActive timing race: pass config's `pushWhenActive` directly to `processCallFromPush()` instead of relying on session config that hasn't been saved yet, so call ID remapping works on the push-when-active path
+
 ## [3.7.0](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/3.7.0) (2026-07-24)
 
 ### Enhancement

--- a/telnyx_rtc/build.gradle
+++ b/telnyx_rtc/build.gradle
@@ -15,7 +15,7 @@ android {
 }
 
 def getVersionName = { ->
-    return "3.7.0"
+    return "3.7.1"
 }
 
 def getArtifactId = { ->


### PR DESCRIPTION
## Android WebRTC SDK 3.7.1 Release

### Bug Fixing
- Fix pushWhenActive timing race: pass config's `pushWhenActive` directly to `processCallFromPush()` instead of relying on session config that hasn't been saved yet, so call ID remapping works on the push-when-active path (PR #849)

Version bump from 3.7.0 to 3.7.1.