### PR TITLE
VSDK-469: Upgrade compileSdk/targetSdk to API 36 (Android 16)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ buildscript {
     apply(from = "versions.gradle")
 
     val kotlinVersion = "1.9.23" // Define Kotlin version
-    val androidGradlePluginVersion = "8.6.1"
+    val androidGradlePluginVersion = "8.7.3"
     val googlePlayServicesVersion = "4.4.2"
     val hiltVersion = "2.48"
     repositories {
@@ -13,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.6.1")
+        classpath("com.android.tools.build:gradle:8.7.3")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
         classpath("org.jetbrains.kotlinx:kover:0.5.1")
         classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.21.0")

--- a/samples/compose_app/build.gradle.kts
+++ b/samples/compose_app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "org.telnyx.webrtc.compose_app"
         minSdk = 27
         targetSdk = 36
-        versionCode = 21
-        versionName = "21"
+        versionCode = 22
+        versionName = "22"
 
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/samples/compose_app/build.gradle.kts
+++ b/samples/compose_app/build.gradle.kts
@@ -10,14 +10,14 @@ plugins {
 
 android {
     namespace = "org.telnyx.webrtc.compose_app"
-    compileSdk = 35
+    compileSdk = 36
 
     buildFeatures.buildConfig  = true
 
     defaultConfig {
         applicationId = "org.telnyx.webrtc.compose_app"
         minSdk = 27
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 21
         versionName = "21"
 

--- a/samples/connection_service_app/build.gradle
+++ b/samples/connection_service_app/build.gradle
@@ -16,8 +16,8 @@ android {
     defaultConfig {
         applicationId "com.telnyx.webrtc.sdk"
         minSdkVersion 29
-        targetSdkVersion 35
-        compileSdk 35
+        targetSdkVersion 36
+        compileSdk 36
         versionCode 1
         versionName "1.0"
 

--- a/samples/connection_service_app/build.gradle
+++ b/samples/connection_service_app/build.gradle
@@ -18,8 +18,8 @@ android {
         minSdkVersion 29
         targetSdkVersion 36
         compileSdk 36
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.1"
 
 
         multiDexEnabled true

--- a/samples/connection_service_app/src/main/AndroidManifest.xml
+++ b/samples/connection_service_app/src/main/AndroidManifest.xml
@@ -74,10 +74,15 @@
             android:name="com.google.firebase.messaging.default_notification_channel_id"
             android:value="telnyx_call_notification_channel" />
 
+        <!-- TelecomCallService does not call startForeground() — it relies on
+             Telecom/CallStyle notification delegation. foregroundServiceType is
+             declared declaratively so that if the service is ever promoted to a
+             real FGS, the type is already configured. A future startForeground()
+             call must pass FOREGROUND_SERVICE_TYPE_PHONE_CALL | FOREGROUND_SERVICE_TYPE_MICROPHONE
+             matching this declaration, or it will throw ForegroundServiceTypeNotAllowed. -->
         <service android:name=".utility.telecom.call.TelecomCallService"
             android:exported="false"
-            android:foregroundServiceType="phoneCall|microphone"
-            android:permission="android.permission.FOREGROUND_SERVICE_PHONE_CALL"/>
+            android:foregroundServiceType="phoneCall|microphone"/>
 
         <receiver android:name=".utility.telecom.call.TelecomCallBroadcast"
             android:exported="true"/>

--- a/samples/connection_service_app/src/main/AndroidManifest.xml
+++ b/samples/connection_service_app/src/main/AndroidManifest.xml
@@ -78,8 +78,11 @@
              Telecom/CallStyle notification delegation. foregroundServiceType is
              declared declaratively so that if the service is ever promoted to a
              real FGS, the type is already configured. A future startForeground()
-             call must pass FOREGROUND_SERVICE_TYPE_PHONE_CALL | FOREGROUND_SERVICE_TYPE_MICROPHONE
-             matching this declaration, or it will throw ForegroundServiceTypeNotAllowed. -->
+             call must use the typed ServiceCompat.startForeground(id, notification,
+             foregroundServiceType) overload with FOREGROUND_SERVICE_TYPE_PHONE_CALL
+             | FOREGROUND_SERVICE_TYPE_MICROPHONE matching this declaration. The
+             legacy no-type overload will throw ForegroundServiceTypeNotAllowed
+             on API 35+ when a foregroundServiceType is declared in the manifest. -->
         <service android:name=".utility.telecom.call.TelecomCallService"
             android:exported="false"
             android:foregroundServiceType="phoneCall|microphone"/>

--- a/samples/connection_service_app/src/main/AndroidManifest.xml
+++ b/samples/connection_service_app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -74,7 +75,9 @@
             android:value="telnyx_call_notification_channel" />
 
         <service android:name=".utility.telecom.call.TelecomCallService"
-            android:exported="false"/>
+            android:exported="false"
+            android:foregroundServiceType="phoneCall|microphone"
+            android:permission="android.permission.FOREGROUND_SERVICE_PHONE_CALL"/>
 
         <receiver android:name=".utility.telecom.call.TelecomCallBroadcast"
             android:exported="true"/>

--- a/samples/xml_app/build.gradle.kts
+++ b/samples/xml_app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "org.telnyx.webrtc.xml_app"
         minSdk = 27
         targetSdk = 36
-        versionCode = 12
-        versionName = "12"
+        versionCode = 13
+        versionName = "13"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/samples/xml_app/build.gradle.kts
+++ b/samples/xml_app/build.gradle.kts
@@ -9,14 +9,14 @@ plugins {
 
 android {
     namespace = "org.telnyx.webrtc.xmlapp"
-    compileSdk = 35
+    compileSdk = 36
 
     buildFeatures.buildConfig  = true
 
     defaultConfig {
         applicationId = "org.telnyx.webrtc.xml_app"
         minSdk = 27
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 12
         versionName = "12"
 

--- a/telnyx_common/build.gradle
+++ b/telnyx_common/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace "com.telnyx.webrtc.common"
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         minSdk 23

--- a/telnyx_rtc/CHANGELOG.md
+++ b/telnyx_rtc/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 
 ### Enhancement
-- Upgrade `compileSdk` to 36 (Android 16) and `targetSdk` to 36 for all sample apps to meet Google Play deadline (31 August 2026). Update AGP from 8.6.1 to 8.7.3 (VSDK-469)
+- Upgrade `compileSdk` to 36 (Android 16) and `targetSdk` to 36 for all sample apps to meet Google Play deadline (31 August 2026). Update AGP from 8.6.1 to 8.7.3 (VSDK-469). Library modules (`telnyx_rtc`, `telnyx_common`) intentionally keep `targetSdkVersion 34` so SDK consumers are not forced onto the API 36 behavior band.
 
 ## [3.7.1](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/3.7.1) (2026-07-28)
 

--- a/telnyx_rtc/CHANGELOG.md
+++ b/telnyx_rtc/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Enhancement
+- Upgrade `compileSdk` to 36 (Android 16) and `targetSdk` to 36 for all sample apps to meet Google Play deadline (31 August 2026). Update AGP from 8.6.1 to 8.7.3 (VSDK-469)
+
 ## [3.7.1](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/3.7.1) (2026-07-28)
 
 ### Bug Fixing

--- a/telnyx_rtc/build.gradle
+++ b/telnyx_rtc/build.gradle
@@ -70,7 +70,7 @@ publishing {
 }
 
 android {
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         minSdkVersion 23


### PR DESCRIPTION
## Summary

Upgrade `compileSdk` and `targetSdk` to API 36 (Android 16) to meet the Google Play deadline of 31 August 2026. Apps targeting API 35 will no longer be eligible for updates after this date.

Linear: https://linear.app/telnyx/issue/VSDK-469/android-sdk-upgrade-targetsdk-to-api-36-android-16-google-play

### Changes

| Module | compileSdk | targetSdk |
|---|---|---|
| `telnyx_rtc` (SDK) | 35 → 36 | 34 (unchanged — libraries don't need 36) |
| `telnyx_common` | 35 → 36 | 34 (unchanged) |
| `samples/compose_app` | 35 → 36 | 35 → 36 |
| `samples/xml_app` | 35 → 36 | 35 → 36 |
| `samples/connection_service_app` | 35 → 36 | 35 → 36 |

Also updated AGP from 8.6.1 to 8.7.3 (required for `compileSdk 36` support).

### Things to verify after merge

1. **Foreground service type restrictions** — `FOREGROUND_SERVICE_TYPE_MICROPHONE` enforcement is stricter in Android 16. Verify `CallForegroundService` starts and stays alive during calls.
2. **`startForeground()` timing** — tighter enforcement. Verify no `ForegroundServiceDidNotStartInTimeException`.
3. **16 KB page size** — verify WebRTC native library (`libjingle_peerconnection_so.so`) doesn't crash on 16 KB page size devices.
4. **Build + CI** — verify all unit tests, UI tests, and detekt pass.