### PR TITLE
[VSDK-502] Align production TURNS defaults with JS SDK

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Config.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Config.kt
@@ -17,18 +17,16 @@ internal object Config {
      * Production TURNS server (TLS over TCP on port 443).
      * Last-resort fallback for restrictive firewalls that block non-443 traffic.
      *
-     * Note: The JS SDK uses `turn2.telnyx.com` for TURNS 443. Android and Flutter
-     * use `turn.telnyx.com`. This is intentional — the TURNS endpoint is
-     * served by different infrastructure. If alignment is needed, coordinate
-     * with the platform team.
+     * TURNS URLs intentionally omit the transport parameter, matching the JS SDK.
      */
-    const val DEFAULT_TURNS_443 = "turns:turn.telnyx.com:443?transport=tcp"
+    const val DEFAULT_TURNS_443 = "turns:turn.telnyx.com:443"
+    const val SECONDARY_TURNS_443 = "turns:turn2.telnyx.com:443"
 
     // Development ICE servers
     const val DEV_STUN = "stun:stundev.telnyx.com:3478"
     const val DEV_TURN_UDP = "turn:turndev.telnyx.com:3478?transport=udp"
     const val DEV_TURN = "turn:turndev.telnyx.com:3478?transport=tcp"
-    const val DEV_TURNS_443 = "turns:turndev.telnyx.com:443?transport=tcp"
+    const val DEV_TURNS_443 = "turns:turndev.telnyx.com:443"
 
     // Google STUN server for redundancy
     const val GOOGLE_STUN = "stun:stun.l.google.com:19302"

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
@@ -14,6 +14,7 @@ import com.telnyx.webrtc.sdk.Config.DEV_TURN_UDP
 import com.telnyx.webrtc.sdk.Config.DEV_TURNS_443
 import com.telnyx.webrtc.sdk.Config.GOOGLE_STUN
 import com.telnyx.webrtc.sdk.Config.PASSWORD
+import com.telnyx.webrtc.sdk.Config.SECONDARY_TURNS_443
 import com.telnyx.webrtc.sdk.Config.USERNAME
 import com.telnyx.webrtc.sdk.TelnyxClient
 import com.telnyx.webrtc.sdk.model.CallState
@@ -254,7 +255,8 @@ internal class Peer(
      * 2. Google STUN - Redundancy fallback
      * 3. TURN UDP - Lower latency, preferred for real-time media
      * 4. TURN TCP - Fallback for restrictive firewalls
-     * 5. TURNS 443 - Last-resort fallback for highly restrictive firewalls
+     * 5. Primary TURNS 443 - Last-resort fallback for restrictive firewalls
+     * 6. Secondary production TURNS 443 - DNS migration fallback
      *
      * @see [TxSocket]
      * @see [PeerConnection.IceServer]
@@ -314,6 +316,16 @@ internal class Peer(
                 .setPassword(PASSWORD)
                 .createIceServer()
         )
+
+        // 6. Secondary production TURNS endpoint retained during DNS migration.
+        if (providedTurn == DEFAULT_TURN) {
+            iceServers.add(
+                PeerConnection.IceServer.builder(SECONDARY_TURNS_443)
+                    .setUsername(USERNAME)
+                    .setPassword(PASSWORD)
+                    .createIceServer()
+            )
+        }
 
         Logger.d(message = "End collection of ice servers: ${iceServers.size} servers configured (UDP: $turnUdp, TCP: $turnTcp, TURNS: $turns443)")
         return iceServers

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/peer/IceServersTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/peer/IceServersTest.kt
@@ -56,11 +56,11 @@ class IceServersTest : BaseTest() {
     }
 
     @Test
-    fun `default production config exposes 5 ICE servers with the documented first four`() {
+    fun `default production config exposes 6 ICE servers with the documented first four`() {
         val peer = newPeer()
         val servers = peer.iceServer
 
-        assertEquals(5, servers.size, "Expected 5 ICE servers (STUN x2, TURN UDP, TURN TCP, TURNS 443)")
+        assertEquals(6, servers.size, "Expected 6 ICE servers including both production TURNS endpoints")
 
         // The existing four servers remain in their original order ahead of the
         // new TURNS 443 fallback.
@@ -71,12 +71,20 @@ class IceServersTest : BaseTest() {
     }
 
     @Test
-    fun `default production config appends production TURNS 443 as the last server`() {
+    fun `default production config places primary TURNS 443 fifth`() {
         val peer = newPeer()
-        val last = peer.iceServer.last()
+        val primary = peer.iceServer[4]
 
-        assertEquals(listOf(Config.DEFAULT_TURNS_443), last.urls)
+        assertEquals(listOf(Config.DEFAULT_TURNS_443), primary.urls)
         // TURN credentials are propagated to the derived TURNS entry.
+        assertEquals(Config.USERNAME, primary.username)
+        assertEquals(Config.PASSWORD, primary.password)
+    }
+
+    @Test
+    fun `default production config appends secondary TURNS endpoint last`() {
+        val last = newPeer().iceServer.last()
+        assertEquals(listOf(Config.SECONDARY_TURNS_443), last.urls)
         assertEquals(Config.USERNAME, last.username)
         assertEquals(Config.PASSWORD, last.password)
     }
@@ -119,7 +127,7 @@ class IceServersTest : BaseTest() {
     fun `TURNS 443 entry is always the last server regardless of input`() {
         // Default production
         val production = newPeer(turn = Config.DEFAULT_TURN).iceServer
-        assertEquals(Config.DEFAULT_TURNS_443, production.last().urls.single())
+        assertEquals(Config.SECONDARY_TURNS_443, production.last().urls.single())
 
         // Default development
         val development = newPeer(turn = Config.DEV_TURN).iceServer


### PR DESCRIPTION
Adds the secondary turns:turn2.telnyx.com:443 production endpoint after the primary turns:turn.telnyx.com:443 endpoint, matching the JavaScript SDK catalog. TURNS URLs intentionally omit the transport query. Updates production ordering and credential tests. Local Android tests could not run because this host has no Java runtime; CI will validate.