### PR TITLE
[VSUP-205] Preserve pending push calls until INVITE cleanup

### DIFF
--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -362,12 +362,18 @@ class TelnyxClient private constructor(
      */
     private fun processCallFromPush(metaData: PushMetaData, pushWhenActive: Boolean = false) {
         Logger.d("processCallFromPush PushMetaData", metaData.toJson())
-        isCallPendingFromPush = true
-        this.pushMetaData = metaData
-        // Push path: use the app-visible push call_id and remap it to the socket callID when INVITE arrives.
-        // Pass the config's pushWhenActive directly because the session config may not be saved yet
-        // (tokenLogin/credentialLogin runs after processCallFromPush in the connect() flow).
-        pendingPushAppCallId = pushAppCallId(metaData, pushWhenActive)
+        // Write pending push state under the same synchronized(this) lock used by
+        // claimPendingPushCall(), clearPendingPushCall(), inviteAppCallId(), and
+        // startPushInviteTimeout() so the compound invariant across these fields
+        // is preserved atomically.
+        synchronized(this) {
+            isCallPendingFromPush = true
+            this.pushMetaData = metaData
+            // Push path: use the app-visible push call_id and remap it to the socket callID when INVITE arrives.
+            // Pass the config's pushWhenActive directly because the session config may not be saved yet
+            // (tokenLogin/credentialLogin runs after processCallFromPush in the connect() flow).
+            pendingPushAppCallId = pushAppCallId(metaData, pushWhenActive)
+        }
     }
 
     /**
@@ -991,13 +997,15 @@ class TelnyxClient private constructor(
     }
 
     internal fun registerCallIdAlias(appCallId: UUID, socketCallId: UUID) {
-        if (appCallId == socketCallId) {
+        synchronized(this) {
+            if (appCallId == socketCallId) {
+                pendingPushAppCallId = null
+                return
+            }
+            socketCallIdByAppCallId[appCallId] = socketCallId
+            appCallIdBySocketCallId[socketCallId] = appCallId
             pendingPushAppCallId = null
-            return
         }
-        socketCallIdByAppCallId[appCallId] = socketCallId
-        appCallIdBySocketCallId[socketCallId] = appCallId
-        pendingPushAppCallId = null
     }
 
     internal fun signalingCallId(appCallId: UUID): UUID = socketCallIdByAppCallId[appCallId] ?: appCallId
@@ -3371,9 +3379,10 @@ class TelnyxClient private constructor(
                 val variables = inviteVariables(params)
                 val appCallId = inviteAppCallId(offerCallId) ?: offerCallId
                 // IMPORTANT: inviteAppCallId() MUST be evaluated before claimPendingPushCall().
-                // inviteAppCallId() reads pendingPushAppCallId without the lock; claimPendingPushCall()
-                // clears it. If the read is moved after the claim, the push app call ID is lost and
-                // the alias mapping (registerCallIdAlias) would use the socket ID as the app-facing ID.
+                // inviteAppCallId() reads pendingPushAppCallId under synchronized(this); claimPendingPushCall()
+                // then clears it under the same lock. The order matters because the claim nulls the field
+                // the alias read depends on. If the read is moved after the claim, the push app call ID is
+                // lost and the alias mapping (registerCallIdAlias) would use the socket ID as the app-facing ID.
                 // INVITE atomically wins against BYE/timeout before the call is exposed.
                 claimPendingPushCall()
                 registerCallIdAlias(appCallId, offerCallId)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -353,6 +353,7 @@ class TelnyxClient private constructor(
     private var pushMetaData: PushMetaData? = null
     private var pendingPushAppCallId: UUID? = null
     private var pushInviteTimeoutJob: Job? = null
+    internal var pushInviteTimeoutMs: Long = PUSH_INVITE_TIMEOUT_MS
 
     /**
      * Processes an incoming call notification from a push message.
@@ -1998,8 +1999,8 @@ class TelnyxClient private constructor(
 
         Logger.d(message = "Starting post-attach INVITE timeout for push call $pendingCallId")
         pushInviteTimeoutJob = clientScope.launch {
-            delay(PUSH_INVITE_TIMEOUT_MS)
-            if (!isCallPendingFromPush) return@launch
+            delay(pushInviteTimeoutMs)
+            val claimedCallId = claimPendingPushCall() ?: return@launch
 
             val terminationReason = CallTerminationReason(
                 cause = "ORIGINATOR_CANCEL",
@@ -2008,14 +2009,25 @@ class TelnyxClient private constructor(
                 sipReason = "Request Terminated"
             )
             emitPendingPushBye(
-                appCallId = pendingCallId,
+                appCallId = claimedCallId,
                 cause = terminationReason.cause,
                 causeCode = terminationReason.causeCode,
                 sipCode = terminationReason.sipCode,
                 sipReason = terminationReason.sipReason
             )
-            clearPendingPushCall()
         }
+    }
+
+    /** Atomically takes ownership of pending push cleanup for INVITE/BYE/timeout races. */
+    private fun claimPendingPushCall(): UUID? = synchronized(this) {
+        if (!isCallPendingFromPush) return@synchronized null
+        val callId = pushMetaData?.callId.toUuidOrNull() ?: pendingPushAppCallId
+        isCallPendingFromPush = false
+        pendingPushAppCallId = null
+        pushMetaData = null
+        pushInviteTimeoutJob?.cancel()
+        pushInviteTimeoutJob = null
+        callId
     }
 
     private fun emitPendingPushBye(
@@ -2959,7 +2971,11 @@ class TelnyxClient private constructor(
         val isAttachCallError = errorCode == null && id != null && attachCallId == id
         if (isAttachCallError) {
             Logger.d(message = "Call Failed Error Received")
+            val pendingCallId = claimPendingPushCall()
             emitSocketResponse(SocketResponse.error("Call Failed", null))
+            pendingCallId?.let {
+                emitPendingPushBye(it, "REMOTE_ERROR", null, null, null)
+            }
             disconnectTransientDeclinePushConnection()
             return
         }
@@ -3066,11 +3082,10 @@ class TelnyxClient private constructor(
                 _transcript.clear()
                 _transcriptUpdateFlow.tryEmit(emptyList())
             } ?: run {
-                val pendingCallId = pushMetaData?.callId.toUuidOrNull() ?: pendingPushAppCallId
-                if (isCallPendingFromPush && pendingCallId == callId) {
-                    Logger.d(message = "Received BYE for pending push call before INVITE: $callId")
-                    emitPendingPushBye(appFacingCallId, cause, causeCode, sipCode, sipReason)
-                    clearPendingPushCall()
+                val pendingCallId = claimPendingPushCall()
+                if (pendingCallId != null) {
+                    Logger.d(message = "Received BYE for pending push call before INVITE: signaling=$callId push=$pendingCallId")
+                    emitPendingPushBye(pendingCallId, cause, causeCode, sipCode, sipReason)
                 } else {
                     Logger.w(message = "Received BYE for a callId not found in active calls: $callId")
                 }
@@ -3346,8 +3361,9 @@ class TelnyxClient private constructor(
                 val offerCallId = UUID.fromString(params.get("callID").asString)
                 val variables = inviteVariables(params)
                 val appCallId = inviteAppCallId(offerCallId) ?: offerCallId
+                // INVITE atomically wins against BYE/timeout before the call is exposed.
+                claimPendingPushCall()
                 registerCallIdAlias(appCallId, offerCallId)
-                clearPendingPushCall()
                 val remoteSdp = params.get("sdp").asString
 
                 // Check if remote party supports trickle ICE
@@ -3793,11 +3809,13 @@ class TelnyxClient private constructor(
     }
 
     private fun clearPendingPushCall() {
-        pushInviteTimeoutJob?.cancel()
-        pushInviteTimeoutJob = null
-        isCallPendingFromPush = false
-        pendingPushAppCallId = null
-        pushMetaData = null
+        synchronized(this) {
+            pushInviteTimeoutJob?.cancel()
+            pushInviteTimeoutJob = null
+            isCallPendingFromPush = false
+            pendingPushAppCallId = null
+            pushMetaData = null
+        }
     }
 
     /**

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -130,6 +130,7 @@ class TelnyxClient private constructor(
 
         /** Timeout in milliseconds for reconnection attempts (60 seconds) */
         const val RECONNECT_TIMEOUT: Long = 60000
+        internal const val PUSH_INVITE_TIMEOUT_MS: Long = 10000
 
         /** Maximum number of reconnection retries when server closes connection during reconnection */
         const val MAX_RECONNECTION_RETRIES = 3
@@ -351,6 +352,7 @@ class TelnyxClient private constructor(
     private var isCallPendingFromPush: Boolean = false
     private var pushMetaData: PushMetaData? = null
     private var pendingPushAppCallId: UUID? = null
+    private var pushInviteTimeoutJob: Job? = null
 
     /**
      * Processes an incoming call notification from a push message.
@@ -1983,9 +1985,54 @@ class TelnyxClient private constructor(
         )
         Logger.d("sending attach Call", attachPushMessage.toString())
         socket.send(attachPushMessage)
-        //reset push params
-        pushMetaData = null
-        isCallPendingFromPush = false
+        startPushInviteTimeout()
+    }
+
+    private fun startPushInviteTimeout() {
+        pushInviteTimeoutJob?.cancel()
+        val pendingCallId = pushMetaData?.callId.toUuidOrNull() ?: pendingPushAppCallId
+        if (pendingCallId == null) {
+            Logger.w(message = "Cannot start push INVITE timeout without a valid push call_id")
+            return
+        }
+
+        Logger.d(message = "Starting post-attach INVITE timeout for push call $pendingCallId")
+        pushInviteTimeoutJob = clientScope.launch {
+            delay(PUSH_INVITE_TIMEOUT_MS)
+            if (!isCallPendingFromPush) return@launch
+
+            val terminationReason = CallTerminationReason(
+                cause = "ORIGINATOR_CANCEL",
+                causeCode = 487,
+                sipCode = 487,
+                sipReason = "Request Terminated"
+            )
+            emitPendingPushBye(
+                appCallId = pendingCallId,
+                cause = terminationReason.cause,
+                causeCode = terminationReason.causeCode,
+                sipCode = terminationReason.sipCode,
+                sipReason = terminationReason.sipReason
+            )
+            clearPendingPushCall()
+        }
+    }
+
+    private fun emitPendingPushBye(
+        appCallId: UUID,
+        cause: String?,
+        causeCode: Int?,
+        sipCode: Int?,
+        sipReason: String?,
+    ) {
+        emitSocketResponse(
+            SocketResponse.messageReceived(
+                ReceivedMessageBody(
+                    SocketMethod.BYE.methodName,
+                    ByeResponse(appCallId, cause, causeCode, sipCode, sipReason)
+                )
+            )
+        )
     }
 
 
@@ -2046,7 +2093,7 @@ class TelnyxClient private constructor(
                 login = null,
                 passwd = null,
                 userVariables = notificationJsonObject,
-                loginParams = mapOf("attach_calls" to "true"),
+                loginParams = mapOf("attach_call" to "true"),
                 sessid = sessid
             )
         )
@@ -3019,7 +3066,14 @@ class TelnyxClient private constructor(
                 _transcript.clear()
                 _transcriptUpdateFlow.tryEmit(emptyList())
             } ?: run {
-                Logger.w(message = "Received BYE for a callId not found in active calls: $callId")
+                val pendingCallId = pushMetaData?.callId.toUuidOrNull() ?: pendingPushAppCallId
+                if (isCallPendingFromPush && pendingCallId == callId) {
+                    Logger.d(message = "Received BYE for pending push call before INVITE: $callId")
+                    emitPendingPushBye(appFacingCallId, cause, causeCode, sipCode, sipReason)
+                    clearPendingPushCall()
+                } else {
+                    Logger.w(message = "Received BYE for a callId not found in active calls: $callId")
+                }
             }
         } catch (e: Exception) {
             Logger.e(message = "Error processing onByeReceived: ${e.message}")
@@ -3293,6 +3347,7 @@ class TelnyxClient private constructor(
                 val variables = inviteVariables(params)
                 val appCallId = inviteAppCallId(offerCallId) ?: offerCallId
                 registerCallIdAlias(appCallId, offerCallId)
+                clearPendingPushCall()
                 val remoteSdp = params.get("sdp").asString
 
                 // Check if remote party supports trickle ICE
@@ -3738,6 +3793,8 @@ class TelnyxClient private constructor(
     }
 
     private fun clearPendingPushCall() {
+        pushInviteTimeoutJob?.cancel()
+        pushInviteTimeoutJob = null
         isCallPendingFromPush = false
         pendingPushAppCallId = null
         pushMetaData = null

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -748,8 +748,12 @@ class TelnyxClient private constructor(
     private fun inviteAppCallId(socketCallId: UUID): UUID? {
         if (!pushWhenActiveEnabled()) return null
         // Only remap when the SDK already learned the app-facing ID from the push path.
-        return pendingPushAppCallId.takeIf { isCallPendingFromPush }
-            ?: appCallIdBySocketCallId[socketCallId]
+        // Read under synchronized to avoid a TOCTOU race with claimPendingPushCall()
+        // or clearPendingPushCall() which mutate these fields under the same lock.
+        return synchronized(this) {
+            pendingPushAppCallId.takeIf { isCallPendingFromPush }
+                ?: appCallIdBySocketCallId[socketCallId]
+        }
     }
 
 
@@ -1991,7 +1995,12 @@ class TelnyxClient private constructor(
 
     private fun startPushInviteTimeout() {
         pushInviteTimeoutJob?.cancel()
-        val pendingCallId = pushMetaData?.callId.toUuidOrNull() ?: pendingPushAppCallId
+        // Read pending callId under the same lock used by claimPendingPushCall()
+        // and clearPendingPushCall() to avoid a TOCTOU race where the pending
+        // state is cleared between this read and the coroutine's claim.
+        val pendingCallId = synchronized(this) {
+            pushMetaData?.callId.toUuidOrNull() ?: pendingPushAppCallId
+        }
         if (pendingCallId == null) {
             Logger.w(message = "Cannot start push INVITE timeout without a valid push call_id")
             return

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -3361,6 +3361,10 @@ class TelnyxClient private constructor(
                 val offerCallId = UUID.fromString(params.get("callID").asString)
                 val variables = inviteVariables(params)
                 val appCallId = inviteAppCallId(offerCallId) ?: offerCallId
+                // IMPORTANT: inviteAppCallId() MUST be evaluated before claimPendingPushCall().
+                // inviteAppCallId() reads pendingPushAppCallId without the lock; claimPendingPushCall()
+                // clears it. If the read is moved after the claim, the push app call ID is lost and
+                // the alias mapping (registerCallIdAlias) would use the socket ID as the app-facing ID.
                 // INVITE atomically wins against BYE/timeout before the call is exposed.
                 claimPendingPushCall()
                 registerCallIdAlias(appCallId, offerCallId)

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/CallTest.kt
@@ -309,6 +309,7 @@ fun <T> LiveData<T>.getOrAwaitValue(
     val latch = CountDownLatch(1)
     val observer = object : Observer<T> {
         override fun onChanged(value: T) {
+            if (value == null) return  // Skip null values — wait for a real emission
             data = value
             latch.countDown()
             this@getOrAwaitValue.removeObserver(this)

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -50,6 +50,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @ExtendWith(InstantExecutorExtension::class, CoroutinesTestExtension::class)
@@ -1163,6 +1164,7 @@ class TelnyxClientTest : BaseTest() {
     @Test
     fun `on bye received emits terminal event for pending push call before invite`() {
         val pushCallId = UUID.randomUUID()
+        val signalingCallId = UUID.randomUUID()
         setPrivateField("isCallPendingFromPush", true)
         setPrivateField(
             "pushMetaData",
@@ -1176,7 +1178,7 @@ class TelnyxClientTest : BaseTest() {
 
         val byeJsonObject = JsonObject()
         byeJsonObject.add("params", JsonObject().apply {
-            addProperty("callID", pushCallId.toString())
+            addProperty("callID", signalingCallId.toString())
             addProperty("cause", "PICKED_OFF")
         })
 
@@ -1187,12 +1189,76 @@ class TelnyxClientTest : BaseTest() {
         val bye = body.result as com.telnyx.webrtc.sdk.verto.receive.ByeResponse
         assertEquals(pushCallId, bye.callId)
         assertEquals("PICKED_OFF", bye.cause)
+        assertFalse(getPrivateField("isCallPendingFromPush"))
+    }
+
+    @Test
+    fun `attach error clears pending push and emits correlated terminal bye`() {
+        val pushCallId = UUID.randomUUID()
+        val attachId = UUID.randomUUID().toString()
+        setPrivateField("isCallPendingFromPush", true)
+        setPrivateField("attachCallId", attachId)
+        setPrivateField(
+            "pushMetaData",
+            PushMetaData(
+                callerName = "Alice",
+                callerNumber = "1001",
+                callId = pushCallId.toString(),
+                voiceSdkId = "voice-sdk-id"
+            )
+        )
+
+        client.onErrorReceived(JsonObject().apply { addProperty("id", attachId) }, null)
+
+        val message = client.socketResponseLiveData.getOrAwaitValue()
+        val body = message.data as ReceivedMessageBody
+        val bye = body.result as com.telnyx.webrtc.sdk.verto.receive.ByeResponse
+        assertEquals(pushCallId, bye.callId)
+        assertEquals("REMOTE_ERROR", bye.cause)
+        assertFalse(getPrivateField("isCallPendingFromPush"))
+    }
+
+    @Test
+    fun `push invite watchdog emits one terminal bye and clears pending state`() {
+        val pushCallId = UUID.randomUUID()
+        client.pushInviteTimeoutMs = 10
+        setPrivateField("isCallPendingFromPush", true)
+        setPrivateField(
+            "pushMetaData",
+            PushMetaData(
+                callerName = "Alice",
+                callerNumber = "1001",
+                callId = pushCallId.toString(),
+                voiceSdkId = "voice-sdk-id"
+            )
+        )
+        client.socketResponseLiveData.value = null
+
+        TelnyxClient::class.java.getDeclaredMethod("startPushInviteTimeout").apply {
+            isAccessible = true
+            invoke(client)
+        }
+
+        Thread.sleep(100)
+        val message = requireNotNull(client.socketResponseLiveData.value)
+        val body = message.data as ReceivedMessageBody
+        val bye = body.result as com.telnyx.webrtc.sdk.verto.receive.ByeResponse
+        assertEquals(pushCallId, bye.callId)
+        assertEquals("ORIGINATOR_CANCEL", bye.cause)
+        assertFalse(getPrivateField("isCallPendingFromPush"))
     }
 
     private fun setPrivateField(name: String, value: Any?) {
         val field = TelnyxClient::class.java.getDeclaredField(name)
         field.isAccessible = true
         field.set(client, value)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> getPrivateField(name: String): T {
+        val field = TelnyxClient::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        return field.get(client) as T
     }
 
     private fun invokePushAppCallId(metaData: PushMetaData, pushWhenActive: Boolean = true): UUID? {

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -1239,8 +1239,10 @@ class TelnyxClientTest : BaseTest() {
             invoke(client)
         }
 
-        Thread.sleep(100)
-        val message = requireNotNull(client.socketResponseLiveData.value)
+        // Use getOrAwaitValue instead of Thread.sleep — postValue from the
+        // background coroutine is asynchronous, so a fixed sleep can race the
+        // main-thread post. getOrAwaitValue blocks until the value is posted.
+        val message = client.socketResponseLiveData.getOrAwaitValue()
         val body = message.data as ReceivedMessageBody
         val bye = body.result as com.telnyx.webrtc.sdk.verto.receive.ByeResponse
         assertEquals(pushCallId, bye.callId)

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -1160,6 +1160,35 @@ class TelnyxClientTest : BaseTest() {
         assertEquals(appCallId, bye.callId)
     }
 
+    @Test
+    fun `on bye received emits terminal event for pending push call before invite`() {
+        val pushCallId = UUID.randomUUID()
+        setPrivateField("isCallPendingFromPush", true)
+        setPrivateField(
+            "pushMetaData",
+            PushMetaData(
+                callerName = "Alice",
+                callerNumber = "1001",
+                callId = pushCallId.toString(),
+                voiceSdkId = "voice-sdk-id"
+            )
+        )
+
+        val byeJsonObject = JsonObject()
+        byeJsonObject.add("params", JsonObject().apply {
+            addProperty("callID", pushCallId.toString())
+            addProperty("cause", "PICKED_OFF")
+        })
+
+        client.onByeReceived(byeJsonObject)
+
+        val message = client.socketResponseLiveData.getOrAwaitValue()
+        val body = message.data as ReceivedMessageBody
+        val bye = body.result as com.telnyx.webrtc.sdk.verto.receive.ByeResponse
+        assertEquals(pushCallId, bye.callId)
+        assertEquals("PICKED_OFF", bye.cause)
+    }
+
     private fun setPrivateField(name: String, value: Any?) {
         val field = TelnyxClient::class.java.getDeclaredField(name)
         field.isAccessible = true

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -1210,7 +1210,11 @@ class TelnyxClientTest : BaseTest() {
 
         client.onErrorReceived(JsonObject().apply { addProperty("id", attachId) }, null)
 
-        val message = client.socketResponseLiveData.getOrAwaitValue()
+        // onErrorReceived emits SocketResponse.error first, then the BYE.
+        // With InstantTaskExecutorRule, getOrAwaitValue captures the first
+        // emission (the error), so we drain it before reading the BYE.
+        client.socketResponseLiveData.getOrAwaitValue() // discard SocketResponse.error
+        val message = client.socketResponseLiveData.getOrAwaitValue() // BYE
         val body = message.data as ReceivedMessageBody
         val bye = body.result as com.telnyx.webrtc.sdk.verto.receive.ByeResponse
         assertEquals(pushCallId, bye.callId)

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/TelnyxClientTest.kt
@@ -1297,6 +1297,7 @@ class TelnyxClientTest : BaseTest() {
         val latch = CountDownLatch(1)
         val observer = object : Observer<T> {
             override fun onChanged(value: T) {
+                if (value == null) return  // Skip null values — wait for a real emission
                 data = value
                 latch.countDown()
                 this@getOrAwaitValue.removeObserver(this)


### PR DESCRIPTION
[VSUP-205 - Prevent phantom ringing after missing push INVITE](https://telnyx.atlassian.net/browse/VSUP-205)

---

Preserves pending push-call state through `attachCalls` so Android can terminate a ringing notification even when no full `Call` object was created.

## :older_man: :baby: Behaviors

### Before changes

- Push metadata was cleared immediately after sending `attachCalls`.
- BYE before INVITE was discarded because no active call existed.
- A missing INVITE or BYE had no bounded cleanup path.
- Token login used `attach_calls`, unlike credential login and iOS.

### After changes

- Pending push state remains until INVITE, BYE, timeout, or disconnect.
- BYE-before-INVITE emits a terminal BYE event using the push call UUID.
- A 10-second post-attach watchdog emits deterministic cleanup when no INVITE arrives.
- Token and credential login both use `attach_call`.

## ✋ Manual testing

1. Receive the same inbound call on two Android devices.
2. Leave the secondary device untouched while preventing INVITE replay after `attachCalls`.
3. Verify the secondary ringing notification ends after 10 seconds.
4. Send BYE before INVITE and verify a terminal SDK event is emitted.
5. Verify a normally replayed INVITE cancels the watchdog and remains answerable.

Automated verification: debug Kotlin compilation and the `TelnyxClientTest` unit-test suite pass.

## Known Issues

- This mitigates the client-side phantom ring; the underlying backend fanout race still requires server-side correction.
- A bounded `attachCalls` retry remains blocked on an idempotent backend contract.
