### PR TITLE
Android Structured Error & Warning Parity

### DIFF
--- a/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
+++ b/telnyx_common/src/main/java/com/telnyx/webrtc/common/TelnyxViewModel.kt
@@ -98,6 +98,7 @@ sealed class TelnyxPrecallDiagnosisState {
  * incoming calls. It exposes state flows for observing socket events, session state,
  * and loading state.
  */
+@Suppress("DEPRECATION")
 class TelnyxViewModel : ViewModel() {
 
     /**

--- a/telnyx_rtc/CHANGELOG.md
+++ b/telnyx_rtc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Enhancement
 - Upgrade `compileSdk` to 36 (Android 16) and `targetSdk` to 36 for all sample apps to meet Google Play deadline (31 August 2026). Update AGP from 8.6.1 to 8.7.3 (VSDK-469). Library modules (`telnyx_rtc`, `telnyx_common`) intentionally keep `targetSdkVersion 34` so SDK consumers are not forced onto the API 36 behavior band.
+- **Structured Error & Warning System**: Add `errorFlow` and `warningFlow` on `TelnyxClient` for structured SDK error and warning events. 24 error codes (40001-49001) and 26 warning codes (31001-36005) with descriptions, causes, solutions, and fatal flag. Matches JS SDK and Flutter SDK parity. Legacy `SocketError` enum and `SocketResponse.error()` deprecated but still functional.
 
 ## [3.7.1](https://github.com/team-telnyx/telnyx-webrtc-android/releases/tag/3.7.1) (2026-07-28)
 

--- a/telnyx_rtc/docs/error-handling.md
+++ b/telnyx_rtc/docs/error-handling.md
@@ -1,0 +1,134 @@
+# Error Handling Migration Guide
+
+## Overview
+
+The Android SDK now provides structured error and warning events via `TelnyxClient.errorFlow` and `TelnyxClient.warningFlow`. This brings parity with the JS SDK and Flutter SDK.
+
+## What's New
+
+### Error Flow
+
+```kotlin
+telnyxClient.errorFlow.collect { error ->
+    // error.code — numeric code (e.g. 46001)
+    // error.name — machine name (e.g. "LOGIN_FAILED")
+    // error.message — short message (e.g. "Login failed")
+    // error.description — full explanation
+    // error.causes — list of possible causes
+    // error.solutions — list of suggested fixes
+    // error.fatal — true if terminal, false if SDK handles recovery
+    // error.callId — call UUID if associated with a call
+    // error.sessionId — session identifier
+}
+```
+
+### Warning Flow
+
+```kotlin
+telnyxClient.warningFlow.collect { warning ->
+    // warning.code — numeric code (e.g. 31001)
+    // warning.name — machine name (e.g. "HIGH_RTT")
+    // warning.message — short message
+    // warning.description — full explanation
+    // warning.causes — list of possible causes
+    // warning.solutions — list of suggested fixes
+    // warning.callId — call UUID if associated with a call
+    // warning.sessionId — session identifier
+}
+```
+
+## Error Codes
+
+| Range | Category | Examples |
+|---|---|---|
+| 400xx | SDP negotiation | `SDP_CREATE_OFFER_FAILED` (40001) |
+| 420xx | Media / device | `MEDIA_MICROPHONE_PERMISSION_DENIED` (42001) |
+| 440xx | Call control | `HOLD_FAILED` (44001) |
+| 450xx | WebSocket / transport | `WEBSOCKET_CONNECTION_FAILED` (45001) |
+| 460xx | Authentication | `INVALID_CREDENTIALS` (46002) |
+| 470xx | ICE restart | `ICE_RESTART_FAILED` (47001) |
+| 480xx | Network | `NETWORK_OFFLINE` (48001) |
+| 485xx | Session | `SESSION_NOT_REATTACHED` (48501) |
+| 490xx | General | `UNEXPECTED_ERROR` (49001) |
+
+## Warning Codes
+
+| Range | Category | Examples |
+|---|---|---|
+| 310xx | Network quality | `HIGH_RTT` (31001) |
+| 320xx | Connection / data-flow | `LOW_BYTES_RECEIVED` (32001) |
+| 330xx | Call connection | `ICE_CONNECTIVITY_LOST` (33001) |
+| 340xx | Authentication | `TOKEN_EXPIRING_SOON` (34001) |
+| 350xx | Session / reconnection | `UNKNOWN_REATTACHED_SESSION` (35002) |
+| 360xx | Signaling health | `SIGNALING_RECOVERY_REQUIRED` (36003) |
+
+## Migration from Legacy API
+
+### Before (deprecated)
+
+```kotlin
+telnyxClient.socketResponseFlow.collect { response ->
+    if (response.status == SocketStatus.ERROR) {
+        val message = response.errorMessage
+        val code = response.errorCode
+        // No description, causes, or solutions
+    }
+}
+```
+
+### After (recommended)
+
+```kotlin
+// Structured errors
+telnyxClient.errorFlow.collect { error ->
+    if (error.fatal) {
+        // Show error UI, end call, or return to login
+    } else {
+        // SDK is handling recovery — show informational toast
+    }
+}
+
+// Structured warnings
+telnyxClient.warningFlow.collect { warning ->
+    // Show degradation indicator or log for diagnostics
+}
+```
+
+### Using Error Codes
+
+```kotlin
+import com.telnyx.webrtc.sdk.model.TelnyxErrorCodes
+
+telnyxClient.errorFlow.collect { error ->
+    when (error.code) {
+        TelnyxErrorCodes.INVALID_CREDENTIALS -> {
+            // Show login screen
+        }
+        TelnyxErrorCodes.NETWORK_OFFLINE -> {
+            // Show network warning
+        }
+        TelnyxErrorCodes.SDP_CREATE_OFFER_FAILED -> {
+            // Show call failed dialog
+        }
+        else -> {
+            // Generic error handling
+        }
+    }
+}
+```
+
+## Backward Compatibility
+
+- `SocketError` enum is deprecated but still functional
+- `SocketResponse.error(msg, errorCode)` is deprecated but still works
+- `socketResponseFlow` continues to emit all events including errors
+- Both old and new APIs can be used simultaneously during migration
+
+## Deprecated APIs
+
+| API | Replacement |
+|---|---|
+| `SocketError` enum | `TelnyxErrorCodes` constants |
+| `SocketResponse.error(msg, code)` | `TelnyxClient.errorFlow` |
+| `response.errorCode` | `error.code` + `error.name` |
+| `response.errorMessage` | `error.message` + `error.description` |

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/Call.kt
@@ -18,6 +18,7 @@ import com.telnyx.webrtc.sdk.model.AudioCodec
 import com.telnyx.webrtc.sdk.model.CallState
 import com.telnyx.webrtc.sdk.model.CallNetworkChangeReason
 import com.telnyx.webrtc.sdk.model.SocketMethod
+import com.telnyx.webrtc.sdk.model.TelnyxErrorCodes
 import com.telnyx.webrtc.sdk.peer.Peer
 import com.telnyx.webrtc.sdk.socket.TxSocket
 import com.telnyx.webrtc.sdk.stats.CallQualityMetrics
@@ -223,6 +224,7 @@ data class Call(
      * @see [Call]
      */
     fun endCall(callId: UUID) {
+        // TODO: emit TelnyxError(BYE_SEND_FAILED, callId) if socket.send fails — currently handled in TelnyxClient.endCall()
         client.endCall(callId)
     }
 
@@ -302,6 +304,11 @@ data class Call(
      */
     private fun sendHoldModifier(callId: UUID, holdAction: String) {
         val signalingCallId = client.signalingCallId(callId)
+        if (signalingCallId == callId && client.getActiveCalls().containsKey(callId).not()) {
+            // Call not found in active calls — can't send hold
+            client.emitTelnyxError(TelnyxErrorCodes.HOLD_FAILED, callId)
+            return
+        }
         val uuid: String = UUID.randomUUID().toString()
         val modifyMessageBody = SendingMessageBody(
             id = uuid,
@@ -593,6 +600,7 @@ data class Call(
         } else {
             if (sdpDescription == null) Logger.e(message = "Failed to get local SDP description for Call [${currentSignalingCallId()}]. Cannot send invite.")
             if (outgoingInviteUUID == null) Logger.e(message = "Missing outgoingInviteUUID for Call [${currentSignalingCallId()}]. Cannot send invite.")
+            client.emitTelnyxError(TelnyxErrorCodes.INVALID_CALL_PARAMETERS, currentSignalingCallId())
             updateCallState(CallState.ERROR)
         }
     }

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1149,6 +1149,7 @@ class TelnyxClient private constructor(
                             null
                         )
                     )
+                    emitTelnyxError(TelnyxErrorCodes.NETWORK_OFFLINE)
 
                     // Start the reconnection timer to track timeout
                     startReconnectionTimer()
@@ -1444,6 +1445,7 @@ class TelnyxClient private constructor(
             }
         } else {
             emitSocketResponse(SocketResponse.error("No Network Connection", null))
+            emitTelnyxError(TelnyxErrorCodes.NETWORK_OFFLINE)
         }
     }
 
@@ -1549,6 +1551,7 @@ class TelnyxClient private constructor(
             }
         } else {
             emitSocketResponse(SocketResponse.error("No Network Connection", null))
+            emitTelnyxError(TelnyxErrorCodes.NETWORK_OFFLINE)
             clearTransientDeclinePushMode()
         }
     }
@@ -1654,6 +1657,7 @@ class TelnyxClient private constructor(
             }
         } else {
             emitSocketResponse(SocketResponse.error("No Network Connection", null))
+            emitTelnyxError(TelnyxErrorCodes.NETWORK_OFFLINE)
             clearTransientDeclinePushMode()
         }
     }
@@ -2868,6 +2872,7 @@ class TelnyxClient private constructor(
                             SocketError.GATEWAY_FAILURE_ERROR.errorCode
                         )
                     )
+                    emitTelnyxError(TelnyxErrorCodes.GATEWAY_FAILED)
                     disconnectTransientDeclinePushConnection()
                 }
             }
@@ -3001,6 +3006,7 @@ class TelnyxClient private constructor(
                             null
                         )
                     )
+                    emitTelnyxError(TelnyxErrorCodes.RECONNECTION_EXHAUSTED)
 
                     // Reset reconnection state
                     reconnecting = false
@@ -3052,6 +3058,7 @@ class TelnyxClient private constructor(
             Logger.d(message = "Call Failed Error Received")
             val pendingCallId = claimPendingPushCall()
             emitSocketResponse(SocketResponse.error("Call Failed", null))
+            emitTelnyxError(TelnyxErrorCodes.SESSION_NOT_REATTACHED)
             pendingCallId?.let {
                 emitPendingPushBye(it, "REMOTE_ERROR", null, null, null)
             }
@@ -3067,6 +3074,26 @@ class TelnyxClient private constructor(
         Logger.d(message = "onErrorReceived $errorMessage, code: $errorCode")
         emitSocketResponse(SocketResponse.error(errorMessage, errorCode))
         disconnectTransientDeclinePushConnection()
+
+        // Emit structured error alongside the legacy SocketResponse.error() for
+        // backward compatibility. Map known error codes to structured TelnyxErrorCodes.
+        when (errorCode) {
+            SocketError.TOKEN_ERROR.errorCode ->
+                emitTelnyxError(TelnyxErrorCodes.AUTHENTICATION_REQUIRED)
+            SocketError.CREDENTIAL_ERROR.errorCode ->
+                emitTelnyxError(TelnyxErrorCodes.INVALID_CREDENTIALS)
+            SocketError.GATEWAY_TIMEOUT_ERROR.errorCode,
+            SocketError.GATEWAY_FAILURE_ERROR.errorCode ->
+                emitTelnyxError(TelnyxErrorCodes.WEBSOCKET_CONNECTION_FAILED)
+            else -> {
+                // Generic WebSocket error or catch-all for unknown error codes
+                if (!socket.isLoggedIn) {
+                    emitTelnyxError(TelnyxErrorCodes.LOGIN_FAILED)
+                } else {
+                    emitTelnyxError(TelnyxErrorCodes.WEBSOCKET_ERROR)
+                }
+            }
+        }
 
         // If we're not logged in yet and not already reconnecting, schedule a single
         // retry with a jittered delay. This handles the case where a non-JSON-object

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -1056,6 +1056,11 @@ class TelnyxClient private constructor(
      */
     internal fun addToCalls(call: Call) {
         calls[call.currentSignalingCallId()] = call
+
+        // Emit structured warning if multiple active calls are detected
+        if (calls.size > 1) {
+            this.emitTelnyxWarning(TelnyxWarningCodes.MULTIPLE_ACTIVE_CALLS_DETECTED, call.currentSignalingCallId())
+        }
     }
 
     internal fun registerCallIdAlias(appCallId: UUID, socketCallId: UUID) {
@@ -3008,6 +3013,12 @@ class TelnyxClient private constructor(
                     )
                     emitTelnyxError(TelnyxErrorCodes.RECONNECTION_EXHAUSTED)
 
+                    // Emit structured warning if auto-reconnect is disabled — manual
+                    // reconnection is required.
+                    if (!autoReconnectLogin) {
+                        this.emitTelnyxWarning(TelnyxWarningCodes.RECONNECTION_FAILED_WITH_NO_AUTO_RECONNECT)
+                    }
+
                     // Reset reconnection state
                     reconnecting = false
                     reconnectionRetryCounter.set(0)
@@ -3214,6 +3225,12 @@ class TelnyxClient private constructor(
         latencyTracker.markCallAnsweredByRemote(callUuid)
         
         val answeredCall = calls[callUuid]
+
+        // Emit structured warning if an answer is received while a call is already active
+        if (answeredCall != null && answeredCall.callStateFlow.value == CallState.ACTIVE) {
+            this.emitTelnyxWarning(TelnyxWarningCodes.ANSWER_WHILE_PEER_ACTIVE, callUuid)
+        }
+
         answeredCall?.apply {
             val customHeaders =
                 params.get("dialogParams")?.asJsonObject?.get("custom_headers")?.asJsonArray

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -210,6 +210,20 @@ class TelnyxClient private constructor(
     @Deprecated("Use socketResponseFlow instead. LiveData is deprecated in favor of Kotlin Flows.")
     var socketResponseLiveData: MutableLiveData<SocketResponse<ReceivedMessageBody>>
 
+    // Structured error flow — emits TelnyxError events with code, description, causes, solutions
+    private val _errorFlow = MutableSharedFlow<TelnyxError>(
+        replay = 0,
+        extraBufferCapacity = 32
+    )
+    val errorFlow: SharedFlow<TelnyxError> = _errorFlow.asSharedFlow()
+
+    // Structured warning flow — emits TelnyxWarning events
+    private val _warningFlow = MutableSharedFlow<TelnyxWarning>(
+        replay = 0,
+        extraBufferCapacity = 32
+    )
+    val warningFlow: SharedFlow<TelnyxWarning> = _warningFlow.asSharedFlow()
+
     // SharedFlow for ws messages responses (replaces LiveData)
     private val _wsMessagesResponseFlow = MutableSharedFlow<JsonObject>(
         replay = 1,
@@ -267,6 +281,54 @@ class TelnyxClient private constructor(
 
         // Emit to LiveData (deprecated, for backward compatibility)
         socketResponseLiveData.postValue(response)
+    }
+
+    /**
+     * Emits a structured SDK error event on [errorFlow].
+     * Looks up the error definition from [SdkErrorRegistry] and attaches call/session context.
+     *
+     * @param code The numeric error code from [TelnyxErrorCodes]
+     * @param callId Optional call identifier
+     * @param fatalOverride Override the registry's fatal flag (e.g. media recovery sets false)
+     */
+    internal fun emitTelnyxError(
+        code: Int,
+        callId: java.util.UUID? = null,
+        fatalOverride: Boolean? = null
+    ) {
+        val error = SdkErrorRegistry.create(code, callId, sessid.toString(), fatalOverride)
+        Logger.e(message = "[TelnyxError] ${error.name} (${error.code}): ${error.message} — fatal=${error.fatal}")
+        _errorFlow.tryEmit(error)
+    }
+
+    /**
+     * Emits a structured SDK error with fatal=false for media recovery scenarios.
+     * The SDK handles recovery; the error is informational, not terminal.
+     *
+     * @param code The numeric error code from [TelnyxErrorCodes]
+     * @param callId Optional call identifier
+     */
+    internal fun emitTelnyxMediaRecoveryError(
+        code: Int,
+        callId: java.util.UUID? = null
+    ) {
+        emitTelnyxError(code, callId, fatalOverride = false)
+    }
+
+    /**
+     * Emits a structured SDK warning event on [warningFlow].
+     * Looks up the warning definition from [SdkWarningRegistry] and attaches call/session context.
+     *
+     * @param code The numeric warning code from [TelnyxWarningCodes]
+     * @param callId Optional call identifier
+     */
+    internal fun emitTelnyxWarning(
+        code: Int,
+        callId: java.util.UUID? = null
+    ) {
+        val warning = SdkWarningRegistry.create(code, callId, sessid.toString())
+        Logger.w(message = "[TelnyxWarning] ${warning.name} (${warning.code}): ${warning.message}")
+        _warningFlow.tryEmit(warning)
     }
 
     // Keeps track of all the created calls by theirs UUIDs.

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/TelnyxClient.kt
@@ -54,7 +54,7 @@ import kotlin.concurrent.timerTask
  *
  * @param context the Context that the application is using
  */
-@Suppress("LargeClass")
+@Suppress("LargeClass", "DEPRECATION")
 class TelnyxClient private constructor(
     var context: Context,
     startsInDeclinePushMode: Boolean,

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SdkErrorRegistry.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SdkErrorRegistry.kt
@@ -1,0 +1,288 @@
+/*
+ * Copyright © 2026 Telnyx LLC. All rights reserved.
+ */
+
+package com.telnyx.webrtc.sdk.model
+
+import java.util.UUID
+
+/**
+ * SDK error code registry.
+ *
+ * All entries are surfaced via [TelnyxClient.errorFlow] with level 'error'.
+ * Per-entry runtime guarantee lives on [TelnyxError.fatal].
+ *
+ * Convention for new entries: the safe default is `false` (not terminal).
+ * Only set `true` when the SDK genuinely has no recovery path for the error
+ * (e.g. SDP failures, invalid credentials, session/call lost).
+ */
+object SdkErrorRegistry {
+
+    private val registry: Map<Int, TelnyxError> = mapOf(
+        // ── SDP errors (400xx) ──────────────────────────────────────────
+        TelnyxErrorCodes.SDP_CREATE_OFFER_FAILED to TelnyxError(
+            code = TelnyxErrorCodes.SDP_CREATE_OFFER_FAILED,
+            name = "SDP_CREATE_OFFER_FAILED",
+            message = "Failed to create call offer",
+            description = "The SDK was unable to generate a local SDP offer. This typically indicates a WebRTC API error or invalid media constraints.",
+            causes = listOf("WebRTC API error", "Missing or invalid media constraints"),
+            solutions = listOf("Check microphone permissions", "Verify ICE server configuration"),
+            fatal = true
+        ),
+        TelnyxErrorCodes.SDP_CREATE_ANSWER_FAILED to TelnyxError(
+            code = TelnyxErrorCodes.SDP_CREATE_ANSWER_FAILED,
+            name = "SDP_CREATE_ANSWER_FAILED",
+            message = "Failed to answer the call",
+            description = "The SDK was unable to generate a local SDP answer. The remote offer may be invalid or the peer connection state inconsistent.",
+            causes = listOf("WebRTC API error", "Invalid remote SDP offer"),
+            solutions = listOf("Retry the call", "Check WebRTC compatibility"),
+            fatal = true
+        ),
+        TelnyxErrorCodes.SDP_SET_LOCAL_DESCRIPTION_FAILED to TelnyxError(
+            code = TelnyxErrorCodes.SDP_SET_LOCAL_DESCRIPTION_FAILED,
+            name = "SDP_SET_LOCAL_DESCRIPTION_FAILED",
+            message = "Failed to apply local call settings",
+            description = "setLocalDescription() was rejected. The generated SDP may be malformed or the peer connection state may be inconsistent.",
+            causes = listOf("Malformed SDP", "Peer connection state inconsistency"),
+            solutions = listOf("Retry the call"),
+            fatal = true
+        ),
+        TelnyxErrorCodes.SDP_SET_REMOTE_DESCRIPTION_FAILED to TelnyxError(
+            code = TelnyxErrorCodes.SDP_SET_REMOTE_DESCRIPTION_FAILED,
+            name = "SDP_SET_REMOTE_DESCRIPTION_FAILED",
+            message = "Failed to apply remote call settings",
+            description = "setRemoteDescription() was rejected. The remote SDP may be malformed or contain unsupported codecs.",
+            causes = listOf("Malformed remote SDP", "Codec mismatch"),
+            solutions = listOf("Retry the call", "Check codec configuration"),
+            fatal = true
+        ),
+        TelnyxErrorCodes.SDP_SEND_FAILED to TelnyxError(
+            code = TelnyxErrorCodes.SDP_SEND_FAILED,
+            name = "SDP_SEND_FAILED",
+            message = "Failed to send call data to server",
+            description = "The Invite or Answer message could not be delivered via the signaling WebSocket. The connection may have been lost.",
+            causes = listOf("WebSocket connection lost", "Server error"),
+            solutions = listOf("Check network connectivity", "Retry the call"),
+            fatal = true
+        ),
+
+        // ── Media / device errors (420xx) ───────────────────────────────
+        TelnyxErrorCodes.MEDIA_MICROPHONE_PERMISSION_DENIED to TelnyxError(
+            code = TelnyxErrorCodes.MEDIA_MICROPHONE_PERMISSION_DENIED,
+            name = "MEDIA_MICROPHONE_PERMISSION_DENIED",
+            message = "Microphone access denied",
+            description = "The user or operating system denied microphone permission.",
+            causes = listOf("User denied permission", "OS-level microphone access disabled"),
+            solutions = listOf("Ask user to grant microphone permission in app settings"),
+            fatal = true
+        ),
+        TelnyxErrorCodes.MEDIA_DEVICE_NOT_FOUND to TelnyxError(
+            code = TelnyxErrorCodes.MEDIA_DEVICE_NOT_FOUND,
+            name = "MEDIA_DEVICE_NOT_FOUND",
+            message = "No microphone found",
+            description = "The requested audio input device is not available. No microphone is connected or the device was disconnected.",
+            causes = listOf("No microphone connected", "Device was disconnected", "Invalid deviceId"),
+            solutions = listOf("Check that a microphone is connected", "Select a valid audio input device"),
+            fatal = true
+        ),
+        TelnyxErrorCodes.MEDIA_GET_USER_MEDIA_FAILED to TelnyxError(
+            code = TelnyxErrorCodes.MEDIA_GET_USER_MEDIA_FAILED,
+            name = "MEDIA_GET_USER_MEDIA_FAILED",
+            message = "Failed to access microphone",
+            description = "Audio capture failed for an unexpected reason. The device may be in use by another application.",
+            causes = listOf("Device in use by another application", "Internal error"),
+            solutions = listOf("Close other applications using the microphone", "Retry"),
+            fatal = true
+        ),
+
+        // ── Call-control errors (440xx) ─────────────────────────────────
+        TelnyxErrorCodes.HOLD_FAILED to TelnyxError(
+            code = TelnyxErrorCodes.HOLD_FAILED,
+            name = "HOLD_FAILED",
+            message = "Failed to hold the call",
+            description = "The server rejected or did not respond to the hold request.",
+            causes = listOf("Server error", "WebSocket connection lost during hold"),
+            solutions = listOf("Retry the hold operation", "Check network connectivity"),
+            fatal = false
+        ),
+        TelnyxErrorCodes.INVALID_CALL_PARAMETERS to TelnyxError(
+            code = TelnyxErrorCodes.INVALID_CALL_PARAMETERS,
+            name = "INVALID_CALL_PARAMETERS",
+            message = "Invalid call parameters",
+            description = "The call could not be initiated because required parameters are missing or invalid.",
+            causes = listOf("Missing destination number", "Invalid call configuration"),
+            solutions = listOf("Provide a valid destination number", "Verify call parameters"),
+            fatal = false
+        ),
+        TelnyxErrorCodes.BYE_SEND_FAILED to TelnyxError(
+            code = TelnyxErrorCodes.BYE_SEND_FAILED,
+            name = "BYE_SEND_FAILED",
+            message = "Failed to end the call",
+            description = "The BYE message could not be delivered via the signaling WebSocket.",
+            causes = listOf("WebSocket connection lost", "Server error"),
+            solutions = listOf("Check network connectivity"),
+            fatal = false
+        ),
+        TelnyxErrorCodes.SUBSCRIBE_FAILED to TelnyxError(
+            code = TelnyxErrorCodes.SUBSCRIBE_FAILED,
+            name = "SUBSCRIBE_FAILED",
+            message = "Failed to subscribe to events",
+            description = "The server rejected the subscribe request.",
+            causes = listOf("Server error", "Invalid subscription parameters"),
+            solutions = listOf("Retry the operation"),
+            fatal = false
+        ),
+        TelnyxErrorCodes.PEER_CLOSED_DURING_INIT to TelnyxError(
+            code = TelnyxErrorCodes.PEER_CLOSED_DURING_INIT,
+            name = "PEER_CLOSED_DURING_INIT",
+            message = "Connection closed during call setup",
+            description = "The peer connection was closed while the call was being established.",
+            causes = listOf("Remote party disconnected", "Network failure during setup"),
+            solutions = listOf("Retry the call"),
+            fatal = true
+        ),
+
+        // ── WebSocket / transport errors (450xx) ────────────────────────
+        TelnyxErrorCodes.WEBSOCKET_CONNECTION_FAILED to TelnyxError(
+            code = TelnyxErrorCodes.WEBSOCKET_CONNECTION_FAILED,
+            name = "WEBSOCKET_CONNECTION_FAILED",
+            message = "Failed to connect to server",
+            description = "The WebSocket connection to the signaling server could not be established.",
+            causes = listOf("Network unreachable", "Server unavailable", "Firewall blocking WebSocket"),
+            solutions = listOf("Check network connectivity", "Verify server URL", "Check firewall settings"),
+            fatal = false
+        ),
+        TelnyxErrorCodes.WEBSOCKET_ERROR to TelnyxError(
+            code = TelnyxErrorCodes.WEBSOCKET_ERROR,
+            name = "WEBSOCKET_ERROR",
+            message = "WebSocket error",
+            description = "An error occurred on the WebSocket connection.",
+            causes = listOf("Network interruption", "Server-side error", "Protocol error"),
+            solutions = listOf("Check network connectivity", "SDK will attempt reconnection"),
+            fatal = false
+        ),
+        TelnyxErrorCodes.RECONNECTION_EXHAUSTED to TelnyxError(
+            code = TelnyxErrorCodes.RECONNECTION_EXHAUSTED,
+            name = "RECONNECTION_EXHAUSTED",
+            message = "Reconnection attempts exhausted",
+            description = "The SDK has exhausted all reconnection attempts and cannot restore the connection.",
+            causes = listOf("Persistent network failure", "Server unavailable"),
+            solutions = listOf("Check network connectivity", "Manually reconnect when network is available"),
+            fatal = true
+        ),
+        TelnyxErrorCodes.GATEWAY_FAILED to TelnyxError(
+            code = TelnyxErrorCodes.GATEWAY_FAILED,
+            name = "GATEWAY_FAILED",
+            message = "Gateway failure",
+            description = "The WebRTC gateway reported a failure state.",
+            causes = listOf("Gateway internal error", "Gateway unavailable"),
+            solutions = listOf("Retry connection", "Check server status"),
+            fatal = true
+        ),
+
+        // ── Authentication errors (460xx) ───────────────────────────────
+        TelnyxErrorCodes.LOGIN_FAILED to TelnyxError(
+            code = TelnyxErrorCodes.LOGIN_FAILED,
+            name = "LOGIN_FAILED",
+            message = "Login failed",
+            description = "The login attempt was rejected by the server.",
+            causes = listOf("Invalid credentials", "Server error"),
+            solutions = listOf("Verify credentials", "Check server status"),
+            fatal = false
+        ),
+        TelnyxErrorCodes.INVALID_CREDENTIALS to TelnyxError(
+            code = TelnyxErrorCodes.INVALID_CREDENTIALS,
+            name = "INVALID_CREDENTIALS",
+            message = "Invalid credentials",
+            description = "The SIP credentials provided are invalid or expired.",
+            causes = listOf("Wrong SIP username or password", "Expired credential", "Credential revoked"),
+            solutions = listOf("Verify SIP credentials", "Generate new credentials"),
+            fatal = true
+        ),
+        TelnyxErrorCodes.AUTHENTICATION_REQUIRED to TelnyxError(
+            code = TelnyxErrorCodes.AUTHENTICATION_REQUIRED,
+            name = "AUTHENTICATION_REQUIRED",
+            message = "Authentication required",
+            description = "The provided token is invalid, expired, or missing.",
+            causes = listOf("Expired token", "Invalid token", "Token not provided"),
+            solutions = listOf("Generate a new token", "Verify token configuration"),
+            fatal = true
+        ),
+
+        // ── ICE restart errors (470xx) ─────────────────────────────────
+        TelnyxErrorCodes.ICE_RESTART_FAILED to TelnyxError(
+            code = TelnyxErrorCodes.ICE_RESTART_FAILED,
+            name = "ICE_RESTART_FAILED",
+            message = "ICE restart failed",
+            description = "The ICE restart attempt failed to re-establish media connectivity.",
+            causes = listOf("Network change", "ICE server unavailable"),
+            solutions = listOf("Retry the call"),
+            fatal = true
+        ),
+
+        // ── Network errors (480xx) ─────────────────────────────────────
+        TelnyxErrorCodes.NETWORK_OFFLINE to TelnyxError(
+            code = TelnyxErrorCodes.NETWORK_OFFLINE,
+            name = "NETWORK_OFFLINE",
+            message = "Network is offline",
+            description = "The device has no network connectivity.",
+            causes = listOf("No network connection", "Airplane mode"),
+            solutions = listOf("Check network connectivity", "Disable airplane mode"),
+            fatal = false
+        ),
+
+        // ── Session errors (485xx) ────────────────────────────────────
+        TelnyxErrorCodes.SESSION_NOT_REATTACHED to TelnyxError(
+            code = TelnyxErrorCodes.SESSION_NOT_REATTACHED,
+            name = "SESSION_NOT_REATTACHED",
+            message = "Session was not reattached",
+            description = "The SDK could not reattach to the previous session after reconnection.",
+            causes = listOf("Session expired on server", "Stale voice_sdk_id"),
+            solutions = listOf("Start a new session"),
+            fatal = true
+        ),
+
+        // ── General / catch-all errors (490xx) ─────────────────────────
+        TelnyxErrorCodes.UNEXPECTED_ERROR to TelnyxError(
+            code = TelnyxErrorCodes.UNEXPECTED_ERROR,
+            name = "UNEXPECTED_ERROR",
+            message = "Unexpected error",
+            description = "An unexpected error occurred in the SDK.",
+            causes = listOf("Internal SDK error", "Unexpected server response"),
+            solutions = listOf("Retry the operation", "Contact support if persistent"),
+            fatal = false
+        )
+    )
+
+    /**
+     * Look up an error definition by code.
+     *
+     * @param code The numeric error code
+     * @return The [TelnyxError] definition, or null if not found
+     */
+    fun lookup(code: Int): TelnyxError? = registry[code]
+
+    /**
+     * Create a TelnyxError event from a registry definition, optionally
+     * overriding the fatal flag and attaching call/session context.
+     *
+     * @param code The numeric error code
+     * @param callId Optional call identifier
+     * @param sessionId Optional session identifier
+     * @param fatalOverride Override the registry's fatal flag (e.g. media recovery sets false)
+     * @return A [TelnyxError] with context attached, or a generic UNEXPECTED_ERROR if code not found
+     */
+    fun create(
+        code: Int,
+        callId: UUID? = null,
+        sessionId: String? = null,
+        fatalOverride: Boolean? = null
+    ): TelnyxError {
+        val base = registry[code] ?: registry[TelnyxErrorCodes.UNEXPECTED_ERROR]!!
+        return base.copy(
+            callId = callId,
+            sessionId = sessionId,
+            fatal = fatalOverride ?: base.fatal
+        )
+    }
+}

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SdkWarningRegistry.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SdkWarningRegistry.kt
@@ -1,0 +1,281 @@
+/*
+ * Copyright © 2026 Telnyx LLC. All rights reserved.
+ */
+
+package com.telnyx.webrtc.sdk.model
+
+import java.util.UUID
+
+/**
+ * SDK warning code registry.
+ *
+ * Warnings represent degraded conditions that may cause unstable
+ * connections or bad call experience.
+ *
+ * Code ranges:
+ * - 310xx — Network quality warnings
+ * - 320xx — Connection / data-flow warnings
+ * - 330xx — Call connection warnings
+ * - 340xx — Authentication warnings
+ * - 350xx — Session / reconnection warnings
+ * - 360xx — Signaling health warnings
+ */
+object SdkWarningRegistry {
+
+    private val registry: Map<Int, TelnyxWarning> = mapOf(
+        // ── Network quality warnings (310xx) ───────────────────────────
+        TelnyxWarningCodes.HIGH_RTT to TelnyxWarning(
+            code = TelnyxWarningCodes.HIGH_RTT,
+            name = "HIGH_RTT",
+            message = "High network latency detected",
+            description = "Round-trip time (RTT) exceeded the threshold for multiple consecutive samples. High latency causes perceptible audio delays.",
+            causes = listOf("Poor network connection", "Geographic distance to media server", "Network congestion"),
+            solutions = listOf("Check network connectivity", "Consider using a closer media server")
+        ),
+        TelnyxWarningCodes.HIGH_JITTER to TelnyxWarning(
+            code = TelnyxWarningCodes.HIGH_JITTER,
+            name = "HIGH_JITTER",
+            message = "High jitter detected",
+            description = "Packet inter-arrival time variation exceeded the threshold. High jitter causes choppy audio.",
+            causes = listOf("Network congestion", "Route changes", "Insufficient bandwidth"),
+            solutions = listOf("Check network stability", "Reduce network load")
+        ),
+        TelnyxWarningCodes.HIGH_PACKET_LOSS to TelnyxWarning(
+            code = TelnyxWarningCodes.HIGH_PACKET_LOSS,
+            name = "HIGH_PACKET_LOSS",
+            message = "High packet loss detected",
+            description = "Packet loss exceeded the threshold for multiple consecutive samples. High loss causes audio gaps and artifacts.",
+            causes = listOf("Network congestion", "Unstable connection", "Firewall dropping RTP"),
+            solutions = listOf("Check network connectivity", "Verify firewall allows RTP traffic")
+        ),
+        TelnyxWarningCodes.LOW_MOS to TelnyxWarning(
+            code = TelnyxWarningCodes.LOW_MOS,
+            name = "LOW_MOS",
+            message = "Low call quality detected",
+            description = "Mean Opinion Score (MOS) fell below the acceptable threshold.",
+            causes = listOf("High latency", "High jitter", "High packet loss", "Low bandwidth"),
+            solutions = listOf("Check network conditions", "Reduce concurrent network usage")
+        ),
+        TelnyxWarningCodes.LOW_LOCAL_AUDIO to TelnyxWarning(
+            code = TelnyxWarningCodes.LOW_LOCAL_AUDIO,
+            name = "LOW_LOCAL_AUDIO",
+            message = "Low outbound audio level",
+            description = "Outbound audio level is below the threshold. The microphone may be muted or too quiet.",
+            causes = listOf("Microphone muted", "Microphone gain too low", "Microphone hardware issue"),
+            solutions = listOf("Check microphone is not muted", "Increase microphone gain", "Check microphone hardware")
+        ),
+        TelnyxWarningCodes.LOW_INBOUND_AUDIO to TelnyxWarning(
+            code = TelnyxWarningCodes.LOW_INBOUND_AUDIO,
+            name = "LOW_INBOUND_AUDIO",
+            message = "Low inbound audio level",
+            description = "Inbound audio level is below the threshold. The remote party may be muted or too quiet.",
+            causes = listOf("Remote party muted", "Remote microphone issue", "Media path issue"),
+            solutions = listOf("Ask remote party to check microphone", "Verify media connectivity")
+        ),
+
+        // ── Connection / data-flow warnings (320xx) ────────────────────
+        TelnyxWarningCodes.LOW_BYTES_RECEIVED to TelnyxWarning(
+            code = TelnyxWarningCodes.LOW_BYTES_RECEIVED,
+            name = "LOW_BYTES_RECEIVED",
+            message = "Low data received",
+            description = "Bytes received from the remote party are below expected levels.",
+            causes = listOf("Remote party not sending audio", "Media path blocked", "NAT/firewall issue"),
+            solutions = listOf("Verify remote party is sending audio", "Check firewall settings")
+        ),
+        TelnyxWarningCodes.LOW_BYTES_SENT to TelnyxWarning(
+            code = TelnyxWarningCodes.LOW_BYTES_SENT,
+            name = "LOW_BYTES_SENT",
+            message = "Low data sent",
+            description = "Bytes sent to the remote party are below expected levels.",
+            causes = listOf("Microphone not capturing", "Encoder issue", "Media path blocked"),
+            solutions = listOf("Check microphone permissions", "Verify encoder is active")
+        ),
+        TelnyxWarningCodes.RECORDING_UNAVAILABLE to TelnyxWarning(
+            code = TelnyxWarningCodes.RECORDING_UNAVAILABLE,
+            name = "RECORDING_UNAVAILABLE",
+            message = "Recording unavailable",
+            description = "Call recording is not available for this call.",
+            causes = listOf("Recording not enabled on connection", "Server does not support recording"),
+            solutions = listOf("Enable recording on the connection in Portal")
+        ),
+        TelnyxWarningCodes.RECORDING_BUFFER_OVERFLOW to TelnyxWarning(
+            code = TelnyxWarningCodes.RECORDING_BUFFER_OVERFLOW,
+            name = "RECORDING_BUFFER_OVERFLOW",
+            message = "Recording buffer overflow",
+            description = "The recording buffer overflowed, potentially causing data loss.",
+            causes = listOf("Insufficient memory", "Slow disk I/O", "Recording buffer too small"),
+            solutions = listOf("Free device memory", "Check available storage")
+        ),
+
+        // ── Call connection warnings (330xx) ───────────────────────────
+        TelnyxWarningCodes.ICE_CONNECTIVITY_LOST to TelnyxWarning(
+            code = TelnyxWarningCodes.ICE_CONNECTIVITY_LOST,
+            name = "ICE_CONNECTIVITY_LOST",
+            message = "ICE connectivity lost",
+            description = "ICE connectivity was lost. The media path may be disrupted.",
+            causes = listOf("Network change", "ICE candidate pair failure", "NAT timeout"),
+            solutions = listOf("SDK will attempt ICE restart", "Check network stability")
+        ),
+        TelnyxWarningCodes.ICE_GATHERING_TIMEOUT to TelnyxWarning(
+            code = TelnyxWarningCodes.ICE_GATHERING_TIMEOUT,
+            name = "ICE_GATHERING_TIMEOUT",
+            message = "ICE gathering timeout",
+            description = "ICE candidate gathering timed out before all candidates were collected.",
+            causes = listOf("STUN/TURN server unreachable", "Network firewall blocking STUN/TURN", "DNS resolution failure"),
+            solutions = listOf("Verify STUN/TURN server availability", "Check firewall settings")
+        ),
+        TelnyxWarningCodes.ICE_GATHERING_EMPTY to TelnyxWarning(
+            code = TelnyxWarningCodes.ICE_GATHERING_EMPTY,
+            name = "ICE_GATHERING_EMPTY",
+            message = "No ICE candidates gathered",
+            description = "No ICE candidates were gathered, including host candidates.",
+            causes = listOf("No network interfaces available", "Network disabled", "WebRTC initialization failure"),
+            solutions = listOf("Check network connectivity", "Restart the call")
+        ),
+        TelnyxWarningCodes.PEER_CONNECTION_FAILED to TelnyxWarning(
+            code = TelnyxWarningCodes.PEER_CONNECTION_FAILED,
+            name = "PEER_CONNECTION_FAILED",
+            message = "Peer connection failed",
+            description = "The WebRTC peer connection failed.",
+            causes = listOf("ICE failure", "DTLS handshake failure", "Remote party disconnected"),
+            solutions = listOf("Retry the call", "Check network connectivity")
+        ),
+        TelnyxWarningCodes.ONLY_HOST_ICE_CANDIDATES to TelnyxWarning(
+            code = TelnyxWarningCodes.ONLY_HOST_ICE_CANDIDATES,
+            name = "ONLY_HOST_ICE_CANDIDATES",
+            message = "Only host ICE candidates available",
+            description = "Only host (local) ICE candidates were gathered. No STUN or TURN candidates are available, which may fail behind NAT.",
+            causes = listOf("STUN/TURN server unreachable", "Firewall blocking STUN/TURN", "No STUN/TURN configured"),
+            solutions = listOf("Verify STUN/TURN server availability", "Check firewall settings", "Verify ICE server configuration")
+        ),
+        TelnyxWarningCodes.ANSWER_WHILE_PEER_ACTIVE to TelnyxWarning(
+            code = TelnyxWarningCodes.ANSWER_WHILE_PEER_ACTIVE,
+            name = "ANSWER_WHILE_PEER_ACTIVE",
+            message = "Answer received while call active",
+            description = "An incoming call answer was received while a call is already active.",
+            causes = listOf("Simultaneous answer from multiple devices", "Race condition in multi-device flow"),
+            solutions = listOf("End the active call before answering a new one")
+        ),
+        TelnyxWarningCodes.DUPLICATE_INBOUND_ANSWER to TelnyxWarning(
+            code = TelnyxWarningCodes.DUPLICATE_INBOUND_ANSWER,
+            name = "DUPLICATE_INBOUND_ANSWER",
+            message = "Duplicate inbound answer",
+            description = "A duplicate answer was received for an already-answered call.",
+            causes = listOf("Server retransmission", "Race condition"),
+            solutions = listOf("No action needed — SDK ignores the duplicate")
+        ),
+        TelnyxWarningCodes.ICE_CANDIDATE_PAIR_CHANGED to TelnyxWarning(
+            code = TelnyxWarningCodes.ICE_CANDIDATE_PAIR_CHANGED,
+            name = "ICE_CANDIDATE_PAIR_CHANGED",
+            message = "ICE candidate pair changed",
+            description = "The active ICE candidate pair changed, which may briefly affect audio quality.",
+            causes = listOf("Network path change", "Better candidate found", "Current pair degraded"),
+            solutions = listOf("No action needed — SDK handles automatically")
+        ),
+        TelnyxWarningCodes.AUDIO_INPUT_DEVICE_CHANGE_SKIPPED to TelnyxWarning(
+            code = TelnyxWarningCodes.AUDIO_INPUT_DEVICE_CHANGE_SKIPPED,
+            name = "AUDIO_INPUT_DEVICE_CHANGE_SKIPPED",
+            message = "Audio device change skipped",
+            description = "An audio input device change was detected but could not be applied during an active call.",
+            causes = listOf("Device changed mid-call", "Bluetooth reconnection"),
+            solutions = listOf("Restart the call to use the new device")
+        ),
+        TelnyxWarningCodes.MULTIPLE_ACTIVE_CALLS_DETECTED to TelnyxWarning(
+            code = TelnyxWarningCodes.MULTIPLE_ACTIVE_CALLS_DETECTED,
+            name = "MULTIPLE_ACTIVE_CALLS_DETECTED",
+            message = "Multiple active calls detected",
+            description = "Multiple active calls were detected simultaneously, which may cause unexpected behavior.",
+            causes = listOf("Simultaneous incoming calls", "Push delivery race condition"),
+            solutions = listOf("End one call before starting another")
+        ),
+        TelnyxWarningCodes.SHARED_REMOTE_ELEMENT_OVERWRITE to TelnyxWarning(
+            code = TelnyxWarningCodes.SHARED_REMOTE_ELEMENT_OVERWRITE,
+            name = "SHARED_REMOTE_ELEMENT_OVERWRITE",
+            message = "Remote element overwritten",
+            description = "A shared remote media element was overwritten by a new call.",
+            causes = listOf("New call reused existing media element", "Improper cleanup"),
+            solutions = listOf("Ensure each call has its own media element")
+        ),
+
+        // ── Authentication warnings (340xx) ──────────────────────────────
+        TelnyxWarningCodes.TOKEN_EXPIRING_SOON to TelnyxWarning(
+            code = TelnyxWarningCodes.TOKEN_EXPIRING_SOON,
+            name = "TOKEN_EXPIRING_SOON",
+            message = "Token expiring soon",
+            description = "The JWT token will expire soon. Reconnect with a fresh token to avoid disconnection.",
+            causes = listOf("Token nearing expiration time"),
+            solutions = listOf("Generate a new token", "Reconnect before the token expires")
+        ),
+
+        // ── Session / reconnection warnings (350xx) ────────────────────
+        TelnyxWarningCodes.UNKNOWN_REATTACHED_SESSION to TelnyxWarning(
+            code = TelnyxWarningCodes.UNKNOWN_REATTACHED_SESSION,
+            name = "UNKNOWN_REATTACHED_SESSION",
+            message = "Unknown reattached session",
+            description = "The SDK reattached to a session but the server does not recognize it.",
+            causes = listOf("Session expired on server", "Stale voice_sdk_id", "Server restart"),
+            solutions = listOf("Start a new session")
+        ),
+
+        // ── Signaling health warnings (360xx) ─────────────────────────
+        TelnyxWarningCodes.SIGNALING_RECOVERY_REQUIRED to TelnyxWarning(
+            code = TelnyxWarningCodes.SIGNALING_RECOVERY_REQUIRED,
+            name = "SIGNALING_RECOVERY_REQUIRED",
+            message = "Signaling recovery required",
+            description = "The signaling channel requires recovery. The SDK will attempt to reconnect.",
+            causes = listOf("WebSocket connection dropped", "Gateway state changed"),
+            solutions = listOf("SDK will reconnect automatically", "Check network if reconnection fails")
+        ),
+        TelnyxWarningCodes.MEDIA_RECOVERY_REQUIRED to TelnyxWarning(
+            code = TelnyxWarningCodes.MEDIA_RECOVERY_REQUIRED,
+            name = "MEDIA_RECOVERY_REQUIRED",
+            message = "Media recovery required",
+            description = "The media path requires recovery. The SDK will attempt ICE restart.",
+            causes = listOf("ICE connectivity lost", "Network change"),
+            solutions = listOf("SDK will attempt ICE restart", "Check network stability")
+        ),
+        TelnyxWarningCodes.RECONNECTION_FAILED_WITH_NO_AUTO_RECONNECT to TelnyxWarning(
+            code = TelnyxWarningCodes.RECONNECTION_FAILED_WITH_NO_AUTO_RECONNECT,
+            name = "RECONNECTION_FAILED_WITH_NO_AUTO_RECONNECT",
+            message = "Reconnection failed",
+            description = "Reconnection failed and auto-reconnect is disabled. Manual reconnection is required.",
+            causes = listOf("Network unavailable", "Server unreachable", "Auto-reconnect disabled in config"),
+            solutions = listOf("Check network connectivity", "Manually call connect() when network is available")
+        )
+    )
+
+    /**
+     * Look up a warning definition by code.
+     *
+     * @param code The numeric warning code
+     * @return The [TelnyxWarning] definition, or null if not found
+     */
+    fun lookup(code: Int): TelnyxWarning? = registry[code]
+
+    /**
+     * Create a TelnyxWarning event from a registry definition, optionally
+     * attaching call/session context.
+     *
+     * @param code The numeric warning code
+     * @param callId Optional call identifier
+     * @param sessionId Optional session identifier
+     * @return A [TelnyxWarning] with context attached
+     */
+    fun create(
+        code: Int,
+        callId: UUID? = null,
+        sessionId: String? = null
+    ): TelnyxWarning {
+        val base = registry[code] ?: return TelnyxWarning(
+            code = code,
+            name = "UNKNOWN_WARNING",
+            message = "Unknown warning",
+            description = "An unknown warning was emitted.",
+            causes = emptyList(),
+            solutions = emptyList(),
+            callId = callId,
+            sessionId = sessionId
+        )
+        return base.copy(callId = callId, sessionId = sessionId)
+    }
+}

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SocketError.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/SocketError.kt
@@ -15,7 +15,11 @@ package com.telnyx.webrtc.sdk.model
  * @property CODEC_ERROR there was an issue with the SDP handshake, likely due to codec issues.
  * @property GATEWAY_TIMEOUT_ERROR Gateway registration timed out.
  * @property GATEWAY_FAILURE_ERROR Gateway registration failed after multiple retries.
+ *
+ * @deprecated Use [TelnyxErrorCodes] and [TelnyxError] via [TelnyxClient.errorFlow] instead.
+ * This enum is retained for backward compatibility and will be removed in a future release.
  */
+@Deprecated("Use TelnyxErrorCodes and TelnyxError via TelnyxClient.errorFlow instead. This enum will be removed in a future release.")
 enum class SocketError(var errorCode: Int) {
     TOKEN_ERROR(-32000),
     CREDENTIAL_ERROR(-32001),

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/TelnyxError.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/TelnyxError.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2026 Telnyx LLC. All rights reserved.
+ */
+
+package com.telnyx.webrtc.sdk.model
+
+import java.util.UUID
+
+/**
+ * Structured SDK error event.
+ *
+ * Surfaced via [TelnyxClient.errorFlow] and [TelnyxClient.fatalErrorFlow].
+ * Per-entry runtime guarantee lives on [fatal]: `true` = terminal, `false` = SDK
+ * handles or safe to ignore.
+ *
+ * @param code Numeric error code (e.g. 40001)
+ * @param name Machine-readable name in UPPER_SNAKE_CASE
+ * @param message Short human-readable message for UI alerts
+ * @param description Full explanation of the error
+ * @param causes Possible root causes
+ * @param solutions Suggested remediation steps
+ * @param fatal Whether the situation is terminal — the operation/call/session is dead
+ * @param callId Call identifier when the error is associated with a call
+ * @param sessionId Current SDK session identifier
+ */
+data class TelnyxError(
+    val code: Int,
+    val name: String,
+    val message: String,
+    val description: String,
+    val causes: List<String>,
+    val solutions: List<String>,
+    val fatal: Boolean,
+    val callId: UUID? = null,
+    val sessionId: String? = null
+)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/TelnyxErrorCodes.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/TelnyxErrorCodes.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2026 Telnyx LLC. All rights reserved.
+ */
+
+package com.telnyx.webrtc.sdk.model
+
+/**
+ * Named constants for SDK error codes.
+ *
+ * SDK consumers should use these instead of hard-coding numeric literals
+ * in comparisons against error events.
+ *
+ * Code ranges:
+ * - 400xx — SDP negotiation errors
+ * - 420xx — Media / device errors
+ * - 440xx — Call-control errors (hold, bye, subscribe, call params)
+ * - 450xx — WebSocket / transport errors
+ * - 460xx — Authentication errors
+ * - 470xx — ICE restart errors
+ * - 480xx — Network errors
+ * - 485xx — Session errors
+ * - 490xx — General / catch-all errors
+ */
+object TelnyxErrorCodes {
+    // ── SDP errors (400xx) ──────────────────────────────────────────────
+    const val SDP_CREATE_OFFER_FAILED = 40001
+    const val SDP_CREATE_ANSWER_FAILED = 40002
+    const val SDP_SET_LOCAL_DESCRIPTION_FAILED = 40003
+    const val SDP_SET_REMOTE_DESCRIPTION_FAILED = 40004
+    const val SDP_SEND_FAILED = 40005
+
+    // ── Media / device errors (420xx) ───────────────────────────────────
+    const val MEDIA_MICROPHONE_PERMISSION_DENIED = 42001
+    const val MEDIA_DEVICE_NOT_FOUND = 42002
+    const val MEDIA_GET_USER_MEDIA_FAILED = 42003
+
+    // ── Call-control errors (440xx) ─────────────────────────────────────
+    const val HOLD_FAILED = 44001
+    const val INVALID_CALL_PARAMETERS = 44002
+    const val BYE_SEND_FAILED = 44003
+    const val SUBSCRIBE_FAILED = 44004
+    const val PEER_CLOSED_DURING_INIT = 44005
+
+    // ── WebSocket / transport errors (450xx) ──────────────────────────
+    const val WEBSOCKET_CONNECTION_FAILED = 45001
+    const val WEBSOCKET_ERROR = 45002
+    const val RECONNECTION_EXHAUSTED = 45003
+    const val GATEWAY_FAILED = 45004
+
+    // ── Authentication errors (460xx) ───────────────────────────────────
+    const val LOGIN_FAILED = 46001
+    const val INVALID_CREDENTIALS = 46002
+    const val AUTHENTICATION_REQUIRED = 46003
+
+    // ── ICE restart errors (470xx) ─────────────────────────────────────
+    const val ICE_RESTART_FAILED = 47001
+
+    // ── Network errors (480xx) ──────────────────────────────────────────
+    const val NETWORK_OFFLINE = 48001
+
+    // ── Session errors (485xx) ───────────────────────────────────────────
+    const val SESSION_NOT_REATTACHED = 48501
+
+    // ── General / catch-all errors (490xx) ──────────────────────────────
+    const val UNEXPECTED_ERROR = 49001
+}

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/TelnyxWarning.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/TelnyxWarning.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2026 Telnyx LLC. All rights reserved.
+ */
+
+package com.telnyx.webrtc.sdk.model
+
+import java.util.UUID
+
+/**
+ * Structured SDK warning event.
+ *
+ * Warnings represent degraded conditions that may cause unstable
+ * connections or bad call experience. Surfaced via [TelnyxClient.warningFlow].
+ *
+ * @param code Numeric warning code (e.g. 31001)
+ * @param name Machine-readable name in UPPER_SNAKE_CASE
+ * @param message Short human-readable message for UI alerts
+ * @param description Full explanation of the warning
+ * @param causes Possible root causes
+ * @param solutions Suggested remediation steps
+ * @param callId Call identifier when the warning is associated with a call
+ * @param sessionId Current SDK session identifier
+ */
+data class TelnyxWarning(
+    val code: Int,
+    val name: String,
+    val message: String,
+    val description: String,
+    val causes: List<String>,
+    val solutions: List<String>,
+    val callId: UUID? = null,
+    val sessionId: String? = null
+)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/TelnyxWarningCodes.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/model/TelnyxWarningCodes.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2026 Telnyx LLC. All rights reserved.
+ */
+
+package com.telnyx.webrtc.sdk.model
+
+/**
+ * Named constants for SDK warning codes.
+ *
+ * Code ranges:
+ * - 310xx — Network quality warnings
+ * - 320xx — Connection / data-flow warnings
+ * - 330xx — Call connection warnings
+ * - 340xx — Authentication warnings
+ * - 350xx — Session / reconnection warnings
+ * - 360xx — Signaling health warnings
+ */
+object TelnyxWarningCodes {
+    // ── Network quality warnings (310xx) ──────────────────────────────
+    const val HIGH_RTT = 31001
+    const val HIGH_JITTER = 31002
+    const val HIGH_PACKET_LOSS = 31003
+    const val LOW_MOS = 31004
+    const val LOW_LOCAL_AUDIO = 31005
+    const val LOW_INBOUND_AUDIO = 31006
+
+    // ── Connection / data-flow warnings (320xx) ───────────────────────
+    const val LOW_BYTES_RECEIVED = 32001
+    const val LOW_BYTES_SENT = 32002
+    const val RECORDING_UNAVAILABLE = 32003
+    const val RECORDING_BUFFER_OVERFLOW = 32004
+
+    // ── Call connection warnings (330xx) ──────────────────────────────
+    const val ICE_CONNECTIVITY_LOST = 33001
+    const val ICE_GATHERING_TIMEOUT = 33002
+    const val ICE_GATHERING_EMPTY = 33003
+    const val PEER_CONNECTION_FAILED = 33004
+    const val ONLY_HOST_ICE_CANDIDATES = 33005
+    const val ANSWER_WHILE_PEER_ACTIVE = 33006
+    const val DUPLICATE_INBOUND_ANSWER = 33007
+    const val ICE_CANDIDATE_PAIR_CHANGED = 33008
+    const val AUDIO_INPUT_DEVICE_CHANGE_SKIPPED = 33009
+    const val MULTIPLE_ACTIVE_CALLS_DETECTED = 33010
+    const val SHARED_REMOTE_ELEMENT_OVERWRITE = 33011
+
+    // ── Authentication warnings (340xx) ───────────────────────────────
+    const val TOKEN_EXPIRING_SOON = 34001
+
+    // ── Session / reconnection warnings (350xx) ─────────────────────
+    const val UNKNOWN_REATTACHED_SESSION = 35002
+
+    // ── Signaling health warnings (360xx) ────────────────────────────
+    const val SIGNALING_RECOVERY_REQUIRED = 36003
+    const val MEDIA_RECOVERY_REQUIRED = 36004
+    const val RECONNECTION_FAILED_WITH_NO_AUTO_RECONNECT = 36005
+}

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
@@ -47,6 +47,7 @@ import com.telnyx.webrtc.lib.RtpTransceiver
 import com.telnyx.webrtc.lib.MediaStreamTrack
 import com.telnyx.webrtc.lib.RtpCapabilities
 import com.telnyx.webrtc.sdk.model.AudioCodec
+import com.telnyx.webrtc.sdk.model.TelnyxErrorCodes
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import java.util.*
@@ -693,6 +694,11 @@ internal class Peer(
             Logger.e(tag = "Peer:Audio", message = "Failed to create local audio track.")
             // Track getUserMedia failure
             client.debugDataCollector.onMicrophoneAccessError(callId, "Failed to create local audio track")
+            // Emit structured error — MEDIA_GET_USER_MEDIA_FAILED is the catch-all for
+            // audio capture failure. With more granular detection we could also emit:
+            //   - TelnyxErrorCodes.MEDIA_MICROPHONE_PERMISSION_DENIED (42001)
+            //   - TelnyxErrorCodes.MEDIA_DEVICE_NOT_FOUND (42002)
+            client.emitTelnyxError(TelnyxErrorCodes.MEDIA_GET_USER_MEDIA_FAILED, callId)
             return
         }
 
@@ -753,6 +759,7 @@ internal class Peer(
                                     tag = "Call",
                                     message = "setLocalDescription onSetFailure $p0"
                                 )
+                                client.emitTelnyxError(TelnyxErrorCodes.SDP_SET_LOCAL_DESCRIPTION_FAILED, callId)
                             }
 
                             override fun onSetSuccess() {
@@ -778,6 +785,7 @@ internal class Peer(
 
                 override fun onCreateFailure(p0: String?) {
                     Logger.e(tag = "Call", message = "createOffer onCreateFailure $p0")
+                    client.emitTelnyxError(TelnyxErrorCodes.SDP_CREATE_OFFER_FAILED, callId)
                     sdpObserver.onCreateFailure(p0)
                 }
             },
@@ -858,6 +866,7 @@ internal class Peer(
                                     tag = "Answer",
                                     message = "setLocalDescription onSetFailure $p0"
                                 )
+                                client.emitTelnyxError(TelnyxErrorCodes.SDP_SET_LOCAL_DESCRIPTION_FAILED, callId)
                             }
 
                             override fun onSetSuccess() {
@@ -885,6 +894,7 @@ internal class Peer(
 
                 override fun onCreateFailure(p0: String?) {
                     Logger.e(tag = "Answer", message = "createAnswer onCreateFailure $p0")
+                    client.emitTelnyxError(TelnyxErrorCodes.SDP_CREATE_ANSWER_FAILED, callId)
                     sdpObserver.onCreateFailure(p0)
                 }
             },
@@ -938,6 +948,7 @@ internal class Peer(
                         tag = "RemoteSessionReceived",
                         message = "Set Remote Description Failed: $p0"
                     )
+                    client.emitTelnyxError(TelnyxErrorCodes.SDP_SET_REMOTE_DESCRIPTION_FAILED, callId)
                 }
 
                 override fun onSetSuccess() {
@@ -1641,6 +1652,10 @@ internal class Peer(
         // Ensure WebRTC is initialized using companion's method
         initPeerConnectionFactory(context)
         peerConnection = buildPeerConnection()
+        if (peerConnection == null) {
+            Logger.e(tag = "Peer", message = "PeerConnection is null after buildPeerConnection — peer closed during init")
+            client.emitTelnyxError(TelnyxErrorCodes.PEER_CLOSED_DURING_INIT, callId)
+        }
         CallTimingBenchmark.mark("peer_connection_created")
         // Track peer connection created milestone
         client.latencyTracker.markCallMilestone(callId, LatencyTracker.MILESTONE_PEER_CREATED)

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/peer/Peer.kt
@@ -48,6 +48,7 @@ import com.telnyx.webrtc.lib.MediaStreamTrack
 import com.telnyx.webrtc.lib.RtpCapabilities
 import com.telnyx.webrtc.sdk.model.AudioCodec
 import com.telnyx.webrtc.sdk.model.TelnyxErrorCodes
+import com.telnyx.webrtc.sdk.model.TelnyxWarningCodes
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import java.util.*
@@ -388,6 +389,9 @@ internal class Peer(
     private var localAudioTrack: AudioTrack? = null
     private var previousIceConnectionState: PeerConnection.IceConnectionState? = null
 
+    // Track gathered ICE candidate types for ONLY_HOST_ICE_CANDIDATES / ICE_GATHERING_EMPTY warnings
+    private val gatheredCandidateTypes = mutableSetOf<String>()
+
     /**
      * Gets the supported audio codec capabilities from the shared factory.
      * This method is kept for backward compatibility with existing code.
@@ -470,6 +474,13 @@ internal class Peer(
             // Handle ICE connection state transitions
             handleIceConnectionStateTransition(previousIceConnectionState, newState)
 
+            // Emit structured warning when ICE connectivity is lost (DISCONNECTED or FAILED)
+            if (newState == PeerConnection.IceConnectionState.DISCONNECTED ||
+                newState == PeerConnection.IceConnectionState.FAILED
+            ) {
+                client.emitTelnyxWarning(TelnyxWarningCodes.ICE_CONNECTIVITY_LOST, callId)
+            }
+
             // Update previous state
             previousIceConnectionState = newState
         }
@@ -499,7 +510,22 @@ internal class Peer(
             if (p0 == PeerConnection.IceGatheringState.COMPLETE && client.getUseTrickleIce()) {
                 sendEndOfCandidates()
                 Logger.d(tag = "Observer", message = "End-of-candidates sent via trickle ICE")
+
+                // Emit structured warnings based on gathered candidates
+                if (gatheredCandidateTypes.isEmpty()) {
+                    // ICE_GATHERING_EMPTY: no candidates were gathered at all
+                    client.emitTelnyxWarning(TelnyxWarningCodes.ICE_GATHERING_EMPTY, callId)
+                } else if (gatheredCandidateTypes.all { it == "host" }) {
+                    // ONLY_HOST_ICE_CANDIDATES: only host candidates found (no srflx/relay)
+                    client.emitTelnyxWarning(TelnyxWarningCodes.ONLY_HOST_ICE_CANDIDATES, callId)
+                }
             }
+
+            // TODO: ICE_GATHERING_TIMEOUT (33002) — no explicit ICE gathering timeout handler
+            // exists. The end-of-candidates timer (startEndOfCandidatesTimer) fires after
+            // END_OF_CANDIDATES_TIMEOUT but sends end-of-candidates rather than timing out
+            // gathering. When a dedicated gathering timeout is added, emit:
+            // client.emitTelnyxWarning(TelnyxWarningCodes.ICE_GATHERING_TIMEOUT, callId)
 
             peerConnectionObserver?.onIceGatheringChange(p0)
             // Notify debug data collector
@@ -557,6 +583,7 @@ internal class Peer(
                     // Notify debug data collector about ICE candidate
                     val candidateType = extractCandidateType(it.sdp)
                     val protocol = extractProtocol(it.sdp)
+                    gatheredCandidateTypes.add(candidateType)
                     client.debugDataCollector.onIceCandidateAdded(callId, candidateType, protocol)
                     
                     // Track first server-reflexive or relay candidate
@@ -615,6 +642,11 @@ internal class Peer(
             Logger.d(tag = "Observer", message = "Peer Connection State Change: $newState")
             peerConnectionObserver?.onConnectionChange(newState)
 
+            // Emit structured warning when peer connection fails
+            if (newState == PeerConnection.PeerConnectionState.FAILED) {
+                client.emitTelnyxWarning(TelnyxWarningCodes.PEER_CONNECTION_FAILED, callId)
+            }
+
             // Mark benchmark milestone for peer connection state changes
             newState?.let {
                 CallTimingBenchmark.mark("peer_state_${it.name}")
@@ -628,6 +660,11 @@ internal class Peer(
             }
         }
     }
+
+    // TODO: ICE_CANDIDATE_PAIR_CHANGED (33008) — PeerConnection.Observer does not expose
+    // an onIceCandidatePairChanged callback in this WebRTC build. When getStats() detects
+    // a selectedCandidatePairChanges transition, or a callback becomes available, emit:
+    // client.emitTelnyxWarning(TelnyxWarningCodes.ICE_CANDIDATE_PAIR_CHANGED, callId)
 
     /**
      * Builds the PeerConnection with the provided IceServers from the getIceServers method

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/socket/TxSocket.kt
@@ -32,6 +32,7 @@ import kotlin.math.sqrt
  * @param host_address the host address for the websocket to connect to
  * @param port the port that the websocket connection should use
  */
+@Suppress("DEPRECATION")
 class TxSocket(
     internal var host_address: String,
     internal var port: Int

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/WebRTCReporter.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/stats/WebRTCReporter.kt
@@ -21,6 +21,7 @@ import com.telnyx.webrtc.lib.PeerConnection
 import com.telnyx.webrtc.lib.RTCStats
 import com.telnyx.webrtc.sdk.utilities.LatencyTracker
 import com.telnyx.webrtc.sdk.utilities.Logger
+import com.telnyx.webrtc.sdk.model.TelnyxWarningCodes
 import timber.log.Timber
 import java.util.*
 
@@ -578,6 +579,53 @@ internal class WebRTCReporter(
                             outboundAudioLevel = outboundAudioLevel,
                             iceCandidates = iceCandidates
                         )
+
+                        // Emit structured quality warnings based on thresholds.
+                        // WebRTCReporter has access to TelnyxClient via peer.client.
+                        val rttMs = metrics.rtt * MS_IN_SECONDS
+                        val jitterMs = metrics.jitter * MS_IN_SECONDS
+                        val packetsReceived = (inboundAudioMap["packetsReceived"] as? Number)?.toLong() ?: 0L
+                        val packetsLost = (inboundAudioMap["packetsLost"] as? Number)?.toLong() ?: 0L
+                        val packetLossPct = if (packetsReceived + packetsLost > 0) {
+                            (packetsLost.toDouble() / (packetsReceived + packetsLost)) * 100.0
+                        } else 0.0
+                        val inboundBytes = (inboundAudioMap["bytesReceived"] as? Number)?.toLong() ?: 0L
+                        val outboundBytes = (outboundAudioMap["bytesSent"] as? Number)?.toLong() ?: 0L
+
+                        // HIGH_RTT — RTT above 300ms is considered high
+                        if (rttMs > 300.0 && rttMs.isFinite()) {
+                            peer.client.emitTelnyxWarning(TelnyxWarningCodes.HIGH_RTT, peerId)
+                        }
+
+                        // HIGH_JITTER — jitter above 30ms is considered high
+                        if (jitterMs > 30.0 && jitterMs.isFinite()) {
+                            peer.client.emitTelnyxWarning(TelnyxWarningCodes.HIGH_JITTER, peerId)
+                        }
+
+                        // HIGH_PACKET_LOSS — packet loss above 5% is considered high
+                        if (packetLossPct > 5.0) {
+                            peer.client.emitTelnyxWarning(TelnyxWarningCodes.HIGH_PACKET_LOSS, peerId)
+                        }
+
+                        // LOW_LOCAL_AUDIO — outbound audio level below 0.01 is considered low
+                        if (outboundAudioLevel > 0f && outboundAudioLevel < 0.01f) {
+                            peer.client.emitTelnyxWarning(TelnyxWarningCodes.LOW_LOCAL_AUDIO, peerId)
+                        }
+
+                        // LOW_INBOUND_AUDIO — inbound audio level below 0.01 is considered low
+                        if (inboundAudioLevel > 0f && inboundAudioLevel < 0.01f) {
+                            peer.client.emitTelnyxWarning(TelnyxWarningCodes.LOW_INBOUND_AUDIO, peerId)
+                        }
+
+                        // LOW_BYTES_RECEIVED — inbound bytes below threshold (100 bytes) during active call
+                        if (inboundBytes in 1L..100L) {
+                            peer.client.emitTelnyxWarning(TelnyxWarningCodes.LOW_BYTES_RECEIVED, peerId)
+                        }
+
+                        // LOW_BYTES_SENT — outbound bytes below threshold (100 bytes) during active call
+                        if (outboundBytes in 1L..100L) {
+                            peer.client.emitTelnyxWarning(TelnyxWarningCodes.LOW_BYTES_SENT, peerId)
+                        }
 
                         if (callDebug) {
                             // Emit metrics through callback

--- a/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/receive/SocketResponse.kt
+++ b/telnyx_rtc/src/main/java/com/telnyx/webrtc/sdk/verto/receive/SocketResponse.kt
@@ -5,6 +5,7 @@
 package com.telnyx.webrtc.sdk.verto.receive
 
 import com.telnyx.webrtc.sdk.model.SocketStatus
+import com.telnyx.webrtc.sdk.model.TelnyxError
 
 data class SocketResponse<out T>(
     var status: SocketStatus,
@@ -40,8 +41,17 @@ data class SocketResponse<out T>(
             )
         }
 
+        @Deprecated("Use error(TelnyxError) instead. This overload will be removed in a future release.")
         fun <T> error(msg: String, errorCode: Int? = null): SocketResponse<T> {
             return SocketResponse(SocketStatus.ERROR, null, msg, errorCode)
+        }
+
+        /**
+         * Creates an error SocketResponse from a structured TelnyxError.
+         * Use this alongside [TelnyxClient.errorFlow] for structured error handling.
+         */
+        fun <T> error(telnyxError: TelnyxError): SocketResponse<T> {
+            return SocketResponse(SocketStatus.ERROR, null, telnyxError.message, telnyxError.code)
         }
         fun <T> disconnect(): SocketResponse<T> {
             return SocketResponse(SocketStatus.DISCONNECT, null, null, null)

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/model/SdkErrorRegistryTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/model/SdkErrorRegistryTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2026 Telnyx LLC. All rights reserved.
+ */
+
+package com.telnyx.webrtc.sdk.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SdkErrorRegistryTest {
+
+    @Test
+    fun `all 24 error codes are registered`() {
+        val expectedCodes = listOf(
+            TelnyxErrorCodes.SDP_CREATE_OFFER_FAILED,
+            TelnyxErrorCodes.SDP_CREATE_ANSWER_FAILED,
+            TelnyxErrorCodes.SDP_SET_LOCAL_DESCRIPTION_FAILED,
+            TelnyxErrorCodes.SDP_SET_REMOTE_DESCRIPTION_FAILED,
+            TelnyxErrorCodes.SDP_SEND_FAILED,
+            TelnyxErrorCodes.MEDIA_MICROPHONE_PERMISSION_DENIED,
+            TelnyxErrorCodes.MEDIA_DEVICE_NOT_FOUND,
+            TelnyxErrorCodes.MEDIA_GET_USER_MEDIA_FAILED,
+            TelnyxErrorCodes.HOLD_FAILED,
+            TelnyxErrorCodes.INVALID_CALL_PARAMETERS,
+            TelnyxErrorCodes.BYE_SEND_FAILED,
+            TelnyxErrorCodes.SUBSCRIBE_FAILED,
+            TelnyxErrorCodes.PEER_CLOSED_DURING_INIT,
+            TelnyxErrorCodes.WEBSOCKET_CONNECTION_FAILED,
+            TelnyxErrorCodes.WEBSOCKET_ERROR,
+            TelnyxErrorCodes.RECONNECTION_EXHAUSTED,
+            TelnyxErrorCodes.GATEWAY_FAILED,
+            TelnyxErrorCodes.LOGIN_FAILED,
+            TelnyxErrorCodes.INVALID_CREDENTIALS,
+            TelnyxErrorCodes.AUTHENTICATION_REQUIRED,
+            TelnyxErrorCodes.ICE_RESTART_FAILED,
+            TelnyxErrorCodes.NETWORK_OFFLINE,
+            TelnyxErrorCodes.SESSION_NOT_REATTACHED,
+            TelnyxErrorCodes.UNEXPECTED_ERROR
+        )
+        assertEquals(24, expectedCodes.size)
+        expectedCodes.forEach { code ->
+            assertNotNull("Error code $code not registered", SdkErrorRegistry.lookup(code))
+        }
+    }
+
+    @Test
+    fun `lookup returns null for unknown code`() {
+        assertNull(SdkErrorRegistry.lookup(99999))
+    }
+
+    @Test
+    fun `create returns error with correct code and name`() {
+        val error = SdkErrorRegistry.create(TelnyxErrorCodes.LOGIN_FAILED)
+        assertEquals(TelnyxErrorCodes.LOGIN_FAILED, error.code)
+        assertEquals("LOGIN_FAILED", error.name)
+        assertEquals("Login failed", error.message)
+        assertFalse(error.fatal)
+    }
+
+    @Test
+    fun `create returns fatal error for SDP failures`() {
+        val error = SdkErrorRegistry.create(TelnyxErrorCodes.SDP_CREATE_OFFER_FAILED)
+        assertTrue(error.fatal)
+    }
+
+    @Test
+    fun `create with fatalOverride overrides registry fatal flag`() {
+        val error = SdkErrorRegistry.create(
+            TelnyxErrorCodes.SDP_CREATE_OFFER_FAILED,
+            fatalOverride = false
+        )
+        assertFalse("fatalOverride should override registry fatal=true", error.fatal)
+    }
+
+    @Test
+    fun `create with unknown code returns UNEXPECTED_ERROR`() {
+        val error = SdkErrorRegistry.create(99999)
+        assertEquals(TelnyxErrorCodes.UNEXPECTED_ERROR, error.code)
+    }
+
+    @Test
+    fun `create attaches callId and sessionId`() {
+        val callId = java.util.UUID.randomUUID()
+        val sessionId = "test-session"
+        val error = SdkErrorRegistry.create(
+            TelnyxErrorCodes.NETWORK_OFFLINE,
+            callId = callId,
+            sessionId = sessionId
+        )
+        assertEquals(callId, error.callId)
+        assertEquals(sessionId, error.sessionId)
+    }
+
+    @Test
+    fun `all errors have non-empty causes and solutions`() {
+        val allCodes = listOf(
+            TelnyxErrorCodes.SDP_CREATE_OFFER_FAILED,
+            TelnyxErrorCodes.SDP_CREATE_ANSWER_FAILED,
+            TelnyxErrorCodes.SDP_SET_LOCAL_DESCRIPTION_FAILED,
+            TelnyxErrorCodes.SDP_SET_REMOTE_DESCRIPTION_FAILED,
+            TelnyxErrorCodes.SDP_SEND_FAILED,
+            TelnyxErrorCodes.MEDIA_MICROPHONE_PERMISSION_DENIED,
+            TelnyxErrorCodes.MEDIA_DEVICE_NOT_FOUND,
+            TelnyxErrorCodes.MEDIA_GET_USER_MEDIA_FAILED,
+            TelnyxErrorCodes.HOLD_FAILED,
+            TelnyxErrorCodes.INVALID_CALL_PARAMETERS,
+            TelnyxErrorCodes.BYE_SEND_FAILED,
+            TelnyxErrorCodes.SUBSCRIBE_FAILED,
+            TelnyxErrorCodes.PEER_CLOSED_DURING_INIT,
+            TelnyxErrorCodes.WEBSOCKET_CONNECTION_FAILED,
+            TelnyxErrorCodes.WEBSOCKET_ERROR,
+            TelnyxErrorCodes.RECONNECTION_EXHAUSTED,
+            TelnyxErrorCodes.GATEWAY_FAILED,
+            TelnyxErrorCodes.LOGIN_FAILED,
+            TelnyxErrorCodes.INVALID_CREDENTIALS,
+            TelnyxErrorCodes.AUTHENTICATION_REQUIRED,
+            TelnyxErrorCodes.ICE_RESTART_FAILED,
+            TelnyxErrorCodes.NETWORK_OFFLINE,
+            TelnyxErrorCodes.SESSION_NOT_REATTACHED,
+            TelnyxErrorCodes.UNEXPECTED_ERROR
+        )
+        allCodes.forEach { code ->
+            val error = SdkErrorRegistry.lookup(code)!!
+            assertTrue("Error $code (${error.name}) has empty causes", error.causes.isNotEmpty())
+            assertTrue("Error $code (${error.name}) has empty solutions", error.solutions.isNotEmpty())
+            assertTrue("Error $code (${error.name}) has empty description", error.description.isNotEmpty())
+        }
+    }
+}

--- a/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/model/SdkWarningRegistryTest.kt
+++ b/telnyx_rtc/src/test/java/com/telnyx/webrtc/sdk/model/SdkWarningRegistryTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2026 Telnyx LLC. All rights reserved.
+ */
+
+package com.telnyx.webrtc.sdk.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SdkWarningRegistryTest {
+
+    @Test
+    fun `all 26 warning codes are registered`() {
+        val expectedCodes = listOf(
+            TelnyxWarningCodes.HIGH_RTT,
+            TelnyxWarningCodes.HIGH_JITTER,
+            TelnyxWarningCodes.HIGH_PACKET_LOSS,
+            TelnyxWarningCodes.LOW_MOS,
+            TelnyxWarningCodes.LOW_LOCAL_AUDIO,
+            TelnyxWarningCodes.LOW_INBOUND_AUDIO,
+            TelnyxWarningCodes.LOW_BYTES_RECEIVED,
+            TelnyxWarningCodes.LOW_BYTES_SENT,
+            TelnyxWarningCodes.RECORDING_UNAVAILABLE,
+            TelnyxWarningCodes.RECORDING_BUFFER_OVERFLOW,
+            TelnyxWarningCodes.ICE_CONNECTIVITY_LOST,
+            TelnyxWarningCodes.ICE_GATHERING_TIMEOUT,
+            TelnyxWarningCodes.ICE_GATHERING_EMPTY,
+            TelnyxWarningCodes.PEER_CONNECTION_FAILED,
+            TelnyxWarningCodes.ONLY_HOST_ICE_CANDIDATES,
+            TelnyxWarningCodes.ANSWER_WHILE_PEER_ACTIVE,
+            TelnyxWarningCodes.DUPLICATE_INBOUND_ANSWER,
+            TelnyxWarningCodes.ICE_CANDIDATE_PAIR_CHANGED,
+            TelnyxWarningCodes.AUDIO_INPUT_DEVICE_CHANGE_SKIPPED,
+            TelnyxWarningCodes.MULTIPLE_ACTIVE_CALLS_DETECTED,
+            TelnyxWarningCodes.SHARED_REMOTE_ELEMENT_OVERWRITE,
+            TelnyxWarningCodes.TOKEN_EXPIRING_SOON,
+            TelnyxWarningCodes.UNKNOWN_REATTACHED_SESSION,
+            TelnyxWarningCodes.SIGNALING_RECOVERY_REQUIRED,
+            TelnyxWarningCodes.MEDIA_RECOVERY_REQUIRED,
+            TelnyxWarningCodes.RECONNECTION_FAILED_WITH_NO_AUTO_RECONNECT
+        )
+        assertEquals(26, expectedCodes.size)
+        expectedCodes.forEach { code ->
+            assertNotNull("Warning code $code not registered", SdkWarningRegistry.lookup(code))
+        }
+    }
+
+    @Test
+    fun `lookup returns null for unknown code`() {
+        assertNull(SdkWarningRegistry.lookup(99999))
+    }
+
+    @Test
+    fun `create returns warning with correct code and name`() {
+        val warning = SdkWarningRegistry.create(TelnyxWarningCodes.HIGH_RTT)
+        assertEquals(TelnyxWarningCodes.HIGH_RTT, warning.code)
+        assertEquals("HIGH_RTT", warning.name)
+        assertEquals("High network latency detected", warning.message)
+    }
+
+    @Test
+    fun `create with unknown code returns UNKNOWN_WARNING`() {
+        val warning = SdkWarningRegistry.create(99999)
+        assertEquals(99999, warning.code)
+        assertEquals("UNKNOWN_WARNING", warning.name)
+    }
+
+    @Test
+    fun `create attaches callId and sessionId`() {
+        val callId = java.util.UUID.randomUUID()
+        val sessionId = "test-session"
+        val warning = SdkWarningRegistry.create(
+            TelnyxWarningCodes.ICE_CONNECTIVITY_LOST,
+            callId = callId,
+            sessionId = sessionId
+        )
+        assertEquals(callId, warning.callId)
+        assertEquals(sessionId, warning.sessionId)
+    }
+
+    @Test
+    fun `all warnings have non-empty causes and solutions`() {
+        val allCodes = listOf(
+            TelnyxWarningCodes.HIGH_RTT,
+            TelnyxWarningCodes.HIGH_JITTER,
+            TelnyxWarningCodes.HIGH_PACKET_LOSS,
+            TelnyxWarningCodes.LOW_MOS,
+            TelnyxWarningCodes.LOW_LOCAL_AUDIO,
+            TelnyxWarningCodes.LOW_INBOUND_AUDIO,
+            TelnyxWarningCodes.LOW_BYTES_RECEIVED,
+            TelnyxWarningCodes.LOW_BYTES_SENT,
+            TelnyxWarningCodes.RECORDING_UNAVAILABLE,
+            TelnyxWarningCodes.RECORDING_BUFFER_OVERFLOW,
+            TelnyxWarningCodes.ICE_CONNECTIVITY_LOST,
+            TelnyxWarningCodes.ICE_GATHERING_TIMEOUT,
+            TelnyxWarningCodes.ICE_GATHERING_EMPTY,
+            TelnyxWarningCodes.PEER_CONNECTION_FAILED,
+            TelnyxWarningCodes.ONLY_HOST_ICE_CANDIDATES,
+            TelnyxWarningCodes.ANSWER_WHILE_PEER_ACTIVE,
+            TelnyxWarningCodes.DUPLICATE_INBOUND_ANSWER,
+            TelnyxWarningCodes.ICE_CANDIDATE_PAIR_CHANGED,
+            TelnyxWarningCodes.AUDIO_INPUT_DEVICE_CHANGE_SKIPPED,
+            TelnyxWarningCodes.MULTIPLE_ACTIVE_CALLS_DETECTED,
+            TelnyxWarningCodes.SHARED_REMOTE_ELEMENT_OVERWRITE,
+            TelnyxWarningCodes.TOKEN_EXPIRING_SOON,
+            TelnyxWarningCodes.UNKNOWN_REATTACHED_SESSION,
+            TelnyxWarningCodes.SIGNALING_RECOVERY_REQUIRED,
+            TelnyxWarningCodes.MEDIA_RECOVERY_REQUIRED,
+            TelnyxWarningCodes.RECONNECTION_FAILED_WITH_NO_AUTO_RECONNECT
+        )
+        allCodes.forEach { code ->
+            val warning = SdkWarningRegistry.lookup(code)!!
+            assertTrue("Warning $code (${warning.name}) has empty causes", warning.causes.isNotEmpty())
+            assertTrue("Warning $code (${warning.name}) has empty solutions", warning.solutions.isNotEmpty())
+            assertTrue("Warning $code (${warning.name}) has empty description", warning.description.isNotEmpty())
+        }
+    }
+}


### PR DESCRIPTION
## Android Structured Error & Warning Parity

Implements structured error and warning system matching the JS SDK pattern ([webrtc/constants](https://github.com/team-telnyx/webrtc/tree/main/packages/js/src/Modules/Verto/util/constants)) and Flutter SDK ([PR #312](https://github.com/team-telnyx/flutter-voice-sdk/pull/312)).

Linear project: [Android Structured Error & Warning Parity](https://linear.app/telnyx/project/android-structured-error-and-warning-parity-0ec4c8db0dda/overview)

---

## Phases

### ✅ Phase 1: Core data model (6 new files)
- `TelnyxErrorCodes.kt` — 24 error code constants (40001-49001)
- `TelnyxWarningCodes.kt` — 26 warning code constants (31001-36005)
- `TelnyxError.kt` — data class: code, name, message, description, causes, solutions, fatal, callId, sessionId
- `TelnyxWarning.kt` — data class: code, name, message, description, causes, solutions, callId, sessionId
- `SdkErrorRegistry.kt` — all 24 error definitions with lookup() and create()
- `SdkWarningRegistry.kt` — all 26 warning definitions with lookup() and create()

### ✅ Phase 2: Emission infrastructure
- `errorFlow: SharedFlow<TelnyxError>` on TelnyxClient
- `warningFlow: SharedFlow<TelnyxWarning>` on TelnyxClient
- `emitTelnyxError(code, callId, fatalOverride)` — registry lookup + emit + log
- `emitTelnyxMediaRecoveryError(code, callId)` — same with fatal=false
- `emitTelnyxWarning(code, callId)` — registry lookup + emit + log

### ✅ Phase 3: Error emission sites (19 active + 2 TODO)
- **Peer.kt** — 7 sites: SDP failures (40001-40004), media failure (42003), peer closed (44005)
- **TelnyxClient.kt** — 10 sites: network offline, gateway failed, reconnection exhausted, auth errors, websocket errors, session not reattached
- **Call.kt** — 2 sites + 2 TODOs: hold failed, invalid call params; BYE_SEND_FAILED and SUBSCRIBE_FAILED pending TelnyxClient integration

### 🚧 Phase 4: Warning emission sites (in progress)
- ICE warnings: ICE_CONNECTIVITY_LOST, ICE_GATHERING_TIMEOUT, ICE_GATHERING_EMPTY, PEER_CONNECTION_FAILED, ONLY_HOST_ICE_CANDIDATES
- Connection warnings: ANSWER_WHILE_PEER_ACTIVE, MULTIPLE_ACTIVE_CALLS_DETECTED, RECONNECTION_FAILED_WITH_NO_AUTO_RECONNECT
- Quality warnings: HIGH_RTT, HIGH_JITTER, HIGH_PACKET_LOSS, LOW_LOCAL_AUDIO, LOW_INBOUND_AUDIO, LOW_BYTES_RECEIVED, LOW_BYTES_SENT

### 📋 Phase 5-7 (pending)
- Phase 5: Deprecate `SocketError` enum, add backward compat layer
- Phase 6: Unit tests for registries and emission
- Phase 7: CHANGELOG, migration guide, sample app integration

## Design decisions

- **Backward compatible**: existing `SocketResponse.error()` and `socketResponseFlow` continue to work unchanged. New `errorFlow`/`warningFlow` are additive.
- **Registry pattern**: single source of truth for error/warning definitions, matching JS SDK's `_SDK_ERRORS` and `SDK_WARNINGS` maps
- **Fatal flag**: each error definition has `fatal: Boolean` — `true` = terminal, `false` = SDK handles recovery. Emit sites can override via `fatalOverride` (e.g. media recovery sets `false`)
- **Internal visibility**: emit methods are `internal` — not part of public API, used by Peer/Call which are in the same module
